### PR TITLE
Use jitpack to handle lobid-rdf-to-json library

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -4,8 +4,3 @@ git clone https://github.com/hbz/metafacture-core.git
 cd metafacture-core
 git pull
 mvn clean install -DskipTests=true
-cd ..
-git clone https://github.com/hbz/lobid-rdf-to-json.git
-cd lobid-rdf-to-json
-git pull
-mvn clean install -DskipTests=true

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,17 @@
 		<target.jdk>1.8</target.jdk>
 		<junit.version>4.8.2</junit.version>
 	</properties>
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>
-			<groupId>de.hbz.lobid</groupId>
-			<artifactId>lobid-rdf-to-json</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<groupId>com.github.hbz</groupId>
+				<artifactId>lobid-rdf-to-json</artifactId>
+				<version>0fbaa4018e4cacdfd9159c96457cf5fa010722e1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.culturegraph</groupId>


### PR DESCRIPTION
- add jitpack repository to pom
- add lobid-rdf-to-json dependency to pom
- remove git building lobid-rdf-to-json from script

Resolves hbz/lobid-rdf-to-json#32.