### PR TITLE
Add 700n.b for other spatial notations to "coverage".

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -84,11 +84,11 @@
 		<data source="021[-b]1.a" name="http://purl.org/dc/terms/isFormatOf">
 			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
 		</data>
-		<!-- temporarily set new subject id outcommented as a workaround, s. https://github.com/hbz/lobid/issues/155 
-			<data name="~rdf:subject" source="021[-b]1.a"> <regexp match="(.*)" format="$[ns-lobid-resource]${1}"/> 
-			</data> <combine name="http://purl.org/dc/terms/hasFormat" value="$[ns-lobid-resource]${subjectid}"> 
-			<data source="021[-b]1.a" name=""/> <data source="@id" name="subjectid"/> </combine> set subject 
-			uri of resource anew <combine name="~rdf:subject" value="$[ns-lobid-resource]${subject}"> <data 
+		<!-- temporarily set new subject id outcommented as a workaround, s. https://github.com/hbz/lobid/issues/155
+			<data name="~rdf:subject" source="021[-b]1.a"> <regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
+			</data> <combine name="http://purl.org/dc/terms/hasFormat" value="$[ns-lobid-resource]${subjectid}">
+			<data source="021[-b]1.a" name=""/> <data source="@id" name="subjectid"/> </combine> set subject
+			uri of resource anew <combine name="~rdf:subject" value="$[ns-lobid-resource]${subject}"> <data
 			source="@id" name="subject"/> <data source="021[-b]1.a"/> </combine> -->
 		<!-- ####################### -->
 		<!-- ####### Child, link to parent and vice versa, e.g. HT000009600 -->
@@ -98,32 +98,32 @@
 		<data source="010-1.a|@idTitleSeries" name="@isPartOfHbzId">
 			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
 		</data>
-		<!-- temporarily set new subject uri outcommented as a workaround, s. https://github.com/hbz/lobid/issues/155 
-			<data name="~rdf:subject" source="010-1.a|529z1.9|@idTitleSeries"> <regexp match="(.*)" format="$[ns-lobid-resource]${1}"/> 
-			</data> <combine name="http://purl.org/dc/terms/hasPart" value="$[ns-lobid-resource]${subjectid}"> 
-			<data source="010-1.a|@idTitleSeries"/> <data source="@id" name="subjectid"/> </combine> is 
-			supplement to <combine name="http://rdaregistry.info/Elements/u/P60259" value="$[ns-lobid-resource]${subjectid}"> 
-			<data source="529z1.9"/> <data source="@id" name="subjectid"/> </combine> set subject uri of 
-			resource anew <combine name="~rdf:subject" value="$[ns-lobid-resource]${subject}"> <data source="@id" 
+		<!-- temporarily set new subject uri outcommented as a workaround, s. https://github.com/hbz/lobid/issues/155
+			<data name="~rdf:subject" source="010-1.a|529z1.9|@idTitleSeries"> <regexp match="(.*)" format="$[ns-lobid-resource]${1}"/>
+			</data> <combine name="http://purl.org/dc/terms/hasPart" value="$[ns-lobid-resource]${subjectid}">
+			<data source="010-1.a|@idTitleSeries"/> <data source="@id" name="subjectid"/> </combine> is
+			supplement to <combine name="http://rdaregistry.info/Elements/u/P60259" value="$[ns-lobid-resource]${subjectid}">
+			<data source="529z1.9"/> <data source="@id" name="subjectid"/> </combine> set subject uri of
+			resource anew <combine name="~rdf:subject" value="$[ns-lobid-resource]${subject}"> <data source="@id"
 			name="subject"/> <data source="010-1.a|529z1.9|@idTitleSeries"/> </combine> -->
 		<!-- ####################### -->
 		<!-- ####### provenance not used for now, see https://github.com/lobid/lodmill/issues/541 -->
 		<!-- ####################### -->
-		<!-- <data source="@idzdb" name="@idzdbProvenance"> <regexp match="(.*)" format="$[ns-lobid-resource]${1}/about"/> 
-			</data> <data source="@idzdbProvenance" name="~rdf:subject"/> <data source="@idzdb" name="http://xmlns.com/foaf/0.1/primaryTopic"> 
-			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/> </data> <combine name=" :subject" 
-			value="$[ns-lobid-resource]${id}/about"> <if> <none> <data source="@idzdbProvenance"/> </none> 
-			</if> <data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine> 
-			<combine name="~rdf:subject" value="$[ns-lobid-resource]${id}/about"> <data source="@idzdb"/> 
-			<data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine> <data 
-			source="@idzdbProvenance" name="http://vocab.deri.ie/void#inDataset"> <regexp match=".*" format="http://lobid.org/dataset/resource"/> 
-			</data> <combine name="http://vocab.deri.ie/void#inDataset" value="http://lobid.org/dataset/resource"> 
-			<if> <none> <data source="@idzdbProvenance"/> </none> </if> <data source="@id"/> </combine> 
-			<combine name="http://vocab.deri.ie/void#inDataset" value="http://lobid.org/dataset/resource"> 
-			<data source="@idzdb"/> <data source="@id"/> </combine> <combine name="http://xmlns.com/foaf/0.1/primaryTopic" 
-			value="$[ns-lobid-resource]${id}"> <if> <none> <data source="@idzdbProvenance"/> </none> </if> 
-			<data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine> <combine 
-			name="http://xmlns.com/foaf/0.1/primaryTopic" value="$[ns-lobid-resource]${id}"> <data source="@idzdb"/> 
+		<!-- <data source="@idzdb" name="@idzdbProvenance"> <regexp match="(.*)" format="$[ns-lobid-resource]${1}/about"/>
+			</data> <data source="@idzdbProvenance" name="~rdf:subject"/> <data source="@idzdb" name="http://xmlns.com/foaf/0.1/primaryTopic">
+			<regexp match="(.*)" format="$[ns-lobid-resource]${1}"/> </data> <combine name=" :subject"
+			value="$[ns-lobid-resource]${id}/about"> <if> <none> <data source="@idzdbProvenance"/> </none>
+			</if> <data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine>
+			<combine name="~rdf:subject" value="$[ns-lobid-resource]${id}/about"> <data source="@idzdb"/>
+			<data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine> <data
+			source="@idzdbProvenance" name="http://vocab.deri.ie/void#inDataset"> <regexp match=".*" format="http://lobid.org/dataset/resource"/>
+			</data> <combine name="http://vocab.deri.ie/void#inDataset" value="http://lobid.org/dataset/resource">
+			<if> <none> <data source="@idzdbProvenance"/> </none> </if> <data source="@id"/> </combine>
+			<combine name="http://vocab.deri.ie/void#inDataset" value="http://lobid.org/dataset/resource">
+			<data source="@idzdb"/> <data source="@id"/> </combine> <combine name="http://xmlns.com/foaf/0.1/primaryTopic"
+			value="$[ns-lobid-resource]${id}"> <if> <none> <data source="@idzdbProvenance"/> </none> </if>
+			<data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine> <combine
+			name="http://xmlns.com/foaf/0.1/primaryTopic" value="$[ns-lobid-resource]${id}"> <data source="@idzdb"/>
 			<data source="@id" name="id"> <regexp match="(.*)" format="${1}"/> </data> </combine> -->
 
 		<!-- ####################### -->
@@ -173,7 +173,7 @@
 		<!-- ####################### -->
 		<!-- ########## carrier and type -->
 		<!-- ####################### -->
-		<!-- type is book (and also manifestation) if 050 begins with 'a' and 051 or 052 is missing 
+		<!-- type is book (and also manifestation) if 050 begins with 'a' and 051 or 052 is missing
 			or 051 and 052 does not fulfill a certain pattern -->
 		<combine name="@rdftype" value="$[ns-bibo]Book">
 			<if>
@@ -753,10 +753,10 @@
 			<data source="088 ?.c" name="signature"/>
 		</combine>
 		<!-- provenance -->
-		<!-- <combine name="~rdf:subject" value="${itemId}/about"> <data source="@itemId" name="itemId"> 
-			<regexp match="(.*)" format="${1}"/> </data> </combine> <data source="@itemId" name="http://vocab.deri.ie/void#inDataset"> 
-			<regexp match=".*" format="http://lobid.org/dataset/resource"/> </data> <combine name="http://xmlns.com/foaf/0.1/primaryTopic" 
-			value="${itemId}"> <data source="@itemId" name="itemId"> <regexp match="(.*)" format="${1}"/> 
+		<!-- <combine name="~rdf:subject" value="${itemId}/about"> <data source="@itemId" name="itemId">
+			<regexp match="(.*)" format="${1}"/> </data> </combine> <data source="@itemId" name="http://vocab.deri.ie/void#inDataset">
+			<regexp match=".*" format="http://lobid.org/dataset/resource"/> </data> <combine name="http://xmlns.com/foaf/0.1/primaryTopic"
+			value="${itemId}"> <data source="@itemId" name="itemId"> <regexp match="(.*)" format="${1}"/>
 			</data> </combine> -->
 		<!-- set subject uri of resource anew -->
 		<!-- set subject uri of resource anew -->
@@ -923,7 +923,7 @@
 			<data source="[29]??[-abcfep][12].d" name="d"/>
 			<data source="[29]??[-abcfep][12].c" name="c"/>
 		</combine>
-		<!-- lv:nameOfContributingCorporateBody is only a temporarily workaround. It also subsumes 
+		<!-- lv:nameOfContributingCorporateBody is only a temporarily workaround. It also subsumes
 			creators! -->
 		<data source="8[012][02468][-mn]-.k" name="$[ns-lobid-vocab]nameOfContributingCorporateBody"/>
 		<!-- all names, also variants ("Verweisungsformen") -->
@@ -1341,8 +1341,8 @@
 			<data source="@subjectTopic"/>
 			<data source="@subjectMain"/>
 		</choose>
-		<!-- Schlagwortketten (aka "subject chains", with permutation number) - It's necessary to 
-			repeat the combines to fire correctly when dealing with multiple e.g. "902". Use macros to 
+		<!-- Schlagwortketten (aka "subject chains", with permutation number) - It's necessary to
+			repeat the combines to fire correctly when dealing with multiple e.g. "902". Use macros to
 			avoid duplication. Use gnd subjects literals, use even if link present/> -->
 		<call-macro name="subject-chain-name" field_1="902" field_2="903"/>
 		<call-macro name="subject-chain-perm" field="902"/>
@@ -1510,7 +1510,7 @@
 				<regexp match="^([a-zA-Z].*)" format="${1}"/>
 			</data>
 		</combine>
-		<!--first three chars of "Resolving System" or "Volltext" or "EZB" or "Archivierte Online 
+		<!--first three chars of "Resolving System" or "Volltext" or "EZB" or "Archivierte Online
 			Ressource " or "Online-Ausgabe" <=> @fulltextOnlineUri -->
 		<combine name="@fulltextOnlineUri" value="${uri}" sameEntity="true">
 			<data source="655[-eu][ -1].[x3]">
@@ -1666,7 +1666,7 @@
 		<!-- ignore '99' in e.g. '700n|a 99|b Bonn', but take 'b' to lookup ID's ,see HT018131501 -->
 		<combine name="@nwbib700_99" value="${a}" sameEntity="true">
 			<data source="700n[-1].a">
-				<regexp match="^99\b|^97\b|^96\b"/>
+				<regexp match="^99\b|^97\b|^96\b|^74\b|^72\b|^54\b|^52\b|^37\b|^36\b|^35\b|^28\b|^24\b|^14\b|^12\b|^10\b"/>
 			</data>
 			<data source="700n[-1].b" name="a"/>
 		</combine>

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -2411,6 +2411,7 @@
 <http://lobid.org/resources/HT004381366/about> <http://purl.org/dc/terms/created> "19921203"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366/about> <http://purl.org/dc/terms/modified> "20010605"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366> <http://iflastandards.info/ns/isbd/elements/P1053> "117 S. : zahlr. Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://lobid.org/resources/HT004381366> <http://purl.org/dc/elements/1.1/coverage> "M\u00FCnsterland"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366> <http://purl.org/dc/elements/1.1/publisher> "Der Regierungspr\u00E4sident"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366> <http://purl.org/dc/terms/creator> <http://d-nb.info/gnd/2019209-5> .
 <http://lobid.org/resources/HT004381366> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT003160768> .
@@ -5086,6 +5087,7 @@ _:Bb0 <http://purl.org/lobid/lv#numbering> "119"^^<http://www.w3.org/2001/XMLSch
 _:Bb0 <http://purl.org/lobid/lv#numbering> "17"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb0 <http://purl.org/lobid/lv#numbering> "18"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb0 <http://purl.org/lobid/lv#numbering> "1805,04,17"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb0 <http://purl.org/lobid/lv#numbering> "19"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb0 <http://purl.org/lobid/lv#numbering> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb0 <http://purl.org/lobid/lv#numbering> "22392"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb0 <http://purl.org/lobid/lv#numbering> "25/26"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5099,13 +5101,13 @@ _:Bb0 <http://purl.org/lobid/lv#numbering> "Tezemu"^^<http://www.w3.org/2001/XML
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT001252640> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT002091108> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT004984061> .
+_:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT006514951> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT013370531> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT013911051> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT014679525> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT015550020> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT016777884> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017290519> .
-_:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017500108> .
 _:Bb0 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/TT001197763> .
 _:Bb0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Rheine, Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1060772442, http://d-nb.info/gnd/2175350-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5141,8 +5143,8 @@ _:Bb0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/
 _:Bb0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb1 .
 _:Bb0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#MultiVolumeWorkRelation> .
 _:Bb0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#SeriesRelation> .
-_:Bb1 <http://purl.org/lobid/lv#numbering> "19"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb1 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT006514951> .
+_:Bb1 <http://purl.org/lobid/lv#numbering> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb1 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017500108> .
 _:Bb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Vogelschutz, Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/11850066X, Geschichte 1963-1967, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118640038"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/jsonld/HT004381366
+++ b/src/test/resources/jsonld/HT004381366
@@ -4,6 +4,7 @@
     "id" : "http://lobid.org/resources/NWBib"
   } ],
   "contributorOrder" : [ "http://d-nb.info/gnd/2019209-5" ],
+  "coverage" : [ "Münsterland" ],
   "creator" : [ {
     "id" : "http://d-nb.info/gnd/2019209-5",
     "preferredName" : "Regierungsbezirk Münster, Westfalen"


### PR DESCRIPTION
Fixes #44. The atom editor obvioulsy made some automatic adjustments. I guess they don't hurt. The relevant change happened in [line 1669](https://github.com/hbz/lobid-resources/compare/44-add700nbToCoverage?expand=1#diff-9cd7dc3a9e57c8e575367094c6f3306bL1669).

(I also forgot to refer to the issue in the commit. Will try to remember it next time.)