### PR TITLE
Update lobid-rdf-to-json dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>com.github.hbz</groupId>
 				<artifactId>lobid-rdf-to-json</artifactId>
-				<version>38f8ef9ff100adcaa8b3d67be15a1718cb7fab07</version>
+				<version>69e05f5a3f3c1733c0d2c9983da99d74c938ca46</version>
 				<exclusions>
 					<exclusion>
 						<groupId>ch.qos.logback</groupId>

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -7455,7 +7455,6 @@ _:Bb2 <http://purl.org/lobid/lv#numbering> "19"^^<http://www.w3.org/2001/XMLSche
 _:Bb2 <http://purl.org/lobid/lv#numbering> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT004984061#!> .
 _:Bb2 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT006514951#!> .
-_:Bb2 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017500108#!> .
 _:Bb2 <http://schema.org/location> "Augsburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Baden-Baden"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7608,6 +7607,7 @@ _:Bb3 <http://purl.org/lobid/lv#numbering> "3,5,1"^^<http://www.w3.org/2001/XMLS
 _:Bb3 <http://purl.org/lobid/lv#numbering> "F2001/F2003]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT006514951#!> .
 _:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT013370531#!> .
+_:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017500108#!> .
 _:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/TT001197763#!> .
 _:Bb3 <http://schema.org/location> "Assen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/jsonld/BT000110055
+++ b/src/test/resources/jsonld/BT000110055
@@ -5,10 +5,10 @@
     "label" : "Nordrhein-Westfälische Bibliographie"
   } ],
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Kall",
       "type" : [ "SubjectHeading", "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"

--- a/src/test/resources/jsonld/CT003012479
+++ b/src/test/resources/jsonld/CT003012479
@@ -210,13 +210,13 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-CT003012479",
     "label" : "Culturegraph Ressource"
   } ],
-  "secondaryPublication" : [ {
+  "secondaryPublication" : {
     "description" : "Digitalisierte Ausg.",
     "location" : "DÃ¼sseldorf",
     "publishedBy" : "UniversitÃ¤ts- und Landesbibliothek",
     "startDate" : "2015",
     "type" : [ "Publication" ]
-  } ],
+  },
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125",
     "label" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"

--- a/src/test/resources/jsonld/HT009993506
+++ b/src/test/resources/jsonld/HT009993506
@@ -1,20 +1,20 @@
 {
   "@context" : "http://lobid.org/download/context-staging.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Hinrichs, Fritz",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Sankt Sebastianus-Schützenbruderschaft <Reusrath>",
       "type" : [ "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"

--- a/src/test/resources/jsonld/HT015894164
+++ b/src/test/resources/jsonld/HT015894164
@@ -1,10 +1,10 @@
 {
   "@context" : "http://lobid.org/download/context-staging.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Organisation de coopération et de développement économiques",
       "type" : [ "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"

--- a/src/test/resources/jsonld/HT017411546
+++ b/src/test/resources/jsonld/HT017411546
@@ -92,10 +92,10 @@
     "id" : "http://ld.zdb-services.de/resource/2685248-2",
     "label" : "http://ld.zdb-services.de/resource"
   } ],
-  "secondaryPublication" : [ {
+  "secondaryPublication" : {
     "description" : [ "Digitalisierte Ausg.", "Münster : Universitäts- und Landesbibliothek, 2012. (Digitale Sammlungen der Universitäts- und Landesbibliothek Münster)" ],
     "startDate" : "2012"
-  } ],
+  },
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
     "label" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092"

--- a/src/test/resources/jsonld/HT018290299
+++ b/src/test/resources/jsonld/HT018290299
@@ -49,19 +49,19 @@
   "hbzId" : "HT018290299",
   "id" : "http://lobid.org/resources/HT018290299#!",
   "inSeries" : [ {
+    "numbering" : "19",
+    "series" : [ {
+      "id" : "http://lobid.org/resources/HT006514951#!",
+      "label" : "lobid Ressource"
+    } ],
+    "type" : [ "SeriesRelation" ]
+  }, {
     "numbering" : [ "2", "19" ],
     "series" : [ {
       "id" : "http://lobid.org/resources/HT006514951#!",
       "label" : "lobid Ressource"
     }, {
       "id" : "http://lobid.org/resources/HT017500108#!",
-      "label" : "lobid Ressource"
-    } ],
-    "type" : [ "SeriesRelation" ]
-  }, {
-    "numbering" : "19",
-    "series" : [ {
-      "id" : "http://lobid.org/resources/HT006514951#!",
       "label" : "lobid Ressource"
     } ],
     "type" : [ "SeriesRelation" ]

--- a/src/test/resources/jsonld/HT018617137
+++ b/src/test/resources/jsonld/HT018617137
@@ -5,10 +5,10 @@
     "label" : "Nordrhein-Westfälische Bibliographie"
   } ],
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Helm, Eva Maria",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/cre",
       "label" : "Autor/in"

--- a/src/test/resources/jsonld/HT018700720
+++ b/src/test/resources/jsonld/HT018700720
@@ -23,10 +23,10 @@
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Ottovay, Kathrin",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"

--- a/src/test/resources/jsonld/TT002234042
+++ b/src/test/resources/jsonld/TT002234042
@@ -1,10 +1,10 @@
 {
   "@context" : "http://lobid.org/download/context-staging.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Lierschied",
       "type" : [ "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"

--- a/src/test/resources/jsonld/TT002234459
+++ b/src/test/resources/jsonld/TT002234459
@@ -1,40 +1,40 @@
 {
   "@context" : "http://lobid.org/download/context-staging.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Kranz, Heinrich",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Müller, Guntram",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Rhein-Lahn-Kreis",
       "type" : [ "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Wirtschaftsförderungs-Gesellschaft Rhein-Lahn",
       "type" : [ "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"

--- a/src/test/resources/jsonld/TT050409948
+++ b/src/test/resources/jsonld/TT050409948
@@ -1,20 +1,20 @@
 {
   "@context" : "http://lobid.org/download/context-staging.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Irlenbusch, Lars",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Siekmann, Holger",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/cre",
       "label" : "Autor/in"


### PR DESCRIPTION
Helps to resolve hbz/lobid-rdf-to-json#74.

Makes also bnode agents single entries.
Same for secondaryPublication.
