### PR TITLE
Change namespace to rdaregistry.info, delete workManifested, update .…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /data/
 /bin/
 log/
+src/test/resources/input/nt/
 src/test/resources/test.tar.bz2
 src/test/resources/xml/
 stats.*.csv

--- a/src/main/resources/context.json
+++ b/src/main/resources/context.json
@@ -1,0 +1,616 @@
+{
+  "@context" : {
+    "extent" : {
+      "@id" : "http://iflastandards.info/ns/isbd/elements/P1053"
+    },
+    "endDate" : {
+      "@id" : "http://schema.org/endDate",
+      "@container" : "@set"
+    },
+    "altLabel" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
+      "@container" : "@set"
+    },
+    "Image" : {
+      "@id" : "http://purl.org/ontology/bibo/Image",
+      "@container" : "@set"
+    },
+    "type" : "@type",
+    "ReferenceSource" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/ReferenceSource",
+      "@container" : "@set"
+    },
+    "lccn" : {
+      "@id" : "http://purl.org/ontology/bibo/lccn",
+      "@container" : "@set"
+    },
+    "PlaceOrGeographicName" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName",
+      "@container" : "@set"
+    },
+    "Item" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/vocab/frbr/core#Item",
+      "@container" : "@set"
+    },
+    "Print" : {
+      "@type" : "@id",
+      "@id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+      "@container" : "@set"
+    },
+    "contribution" : {
+      "@type" : "@id",
+      "@id" : "http://bibframe.org/vocab/contribution",
+      "@container" : "@list"
+    },
+    "rpbSubject" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#rpbSubject",
+      "@container" : "@set"
+    },
+    "exemplarOf" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/vocab/frbr/core#exemplarOf"
+    },
+    "Book" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Book",
+      "@container" : "@set"
+    },
+    "exemplar" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/vocab/frbr/core#exemplar",
+      "@container" : "@set"
+    },
+    "Work" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#Work",
+      "@container" : "@set"
+    },
+    "id" : "@id",
+    "issued" : {
+      "@id" : "http://purl.org/dc/terms/issued"
+    },
+    "spatial" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/spatial",
+      "@container" : "@set"
+    },
+    "hbzId" : {
+      "@id" : "http://purl.org/lobid/lv#hbzID"
+    },
+    "similar" : {
+      "@type" : "@id",
+      "@id" : "http://umbel.org/umbel#isLike",
+      "@container" : "@set"
+    },
+    "hasPart" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/hasPart",
+      "@container" : "@set"
+    },
+    "Publication" : {
+      "@type" : "@id",
+      "@id" : "http://schema.org/Publication"
+    },
+    "eissn" : {
+      "@id" : "http://purl.org/ontology/bibo/eissn",
+      "@container" : "@set"
+    },
+    "isPartOf" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/isPartOf",
+      "@container" : "@set"
+    },
+    "nwbibspatial" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#nwbibspatial",
+      "@container" : "@set"
+    },
+    "MultiVolumeBook" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook",
+      "@container" : "@set"
+    },
+    "Newspaper" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Newspaper",
+      "@container" : "@set"
+    },
+    "Game" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/library/Game",
+      "@container" : "@set"
+    },
+    "issn" : {
+      "@id" : "http://purl.org/ontology/bibo/issn",
+      "@container" : "@set"
+    },
+    "bibliographicCitation" : {
+      "@id" : "http://purl.org/dc/terms/bibliographicCitation"
+    },
+    "Person" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#Person",
+      "@container" : "@set"
+    },
+    "startDate" : {
+      "@id" : "http://schema.org/startDate",
+      "@container" : "@set"
+    },
+    "doi" : {
+      "@id" : "http://purl.org/ontology/bibo/doi",
+      "@container" : "@set"
+    },
+    "role" : {
+      "@type" : "@id",
+      "@id" : "http://id.loc.gov/ontologies/bibframe/role",
+      "@container" : "@set"
+    },
+    "contributorOrder" : {
+      "@id" : "http://purl.org/lobid/lv#contributorOrder",
+      "@container" : "@set"
+    },
+    "longitudeAndLatitude" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60345",
+      "@container" : "@set"
+    },
+    "dateOfDeath" : {
+      "@id" : "http://d-nb.info/standards/elementset/gnd#dateOfDeath",
+      "@container" : "@set"
+    },
+    "Article" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Article",
+      "@container" : "@set"
+    },
+    "creatorName" : {
+      "@id" : "http://purl.org/dc/elements/1.1/creator",
+      "@container" : "@set"
+    },
+    "alternativeTitle" : {
+      "@id" : "http://purl.org/dc/terms/alternative",
+      "@container" : "@set"
+    },
+    "Festschrift" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#Festschrift",
+      "@container" : "@set"
+    },
+    "fulltextOnline" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#fulltextOnline",
+      "@container" : "@set"
+    },
+    "ConferenceOrEvent" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#ConferenceOrEvent",
+      "@container" : "@set"
+    },
+    "volumeIn" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#volumeIn",
+      "@container" : "@set"
+    },
+    "inSeries" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#inSeries",
+      "@container" : "@set"
+    },
+    "zdbId" : {
+      "@id" : "http://purl.org/lobid/lv#zdbID"
+    },
+    "hasSupplement" : {
+      "@type" : "@id",
+      "@id" : "http://rdaregistry.info/Elements/u/P60281",
+      "@container" : "@set"
+    },
+    "wikipedia" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/mo/wikipedia",
+      "@container" : "@set"
+    },
+    "PublishedScore" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/mo/PublishedScore",
+      "@container" : "@set"
+    },
+    "hasFormat" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/hasFormat",
+      "@container" : "@set"
+    },
+    "creator" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/creator",
+      "@container" : "@set"
+    },
+    "corporateBodyForTitle" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60327",
+      "@container" : "@set"
+    },
+    "Schoolbook" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#Schoolbook",
+      "@container" : "@set"
+    },
+    "MultiVolumeWorkRelation" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation",
+      "@container" : "@set"
+    },
+    "dateOfBirth" : {
+      "@id" : "http://d-nb.info/standards/elementset/gnd#dateOfBirth",
+      "@container" : "@set"
+    },
+    "abstract" : {
+      "@id" : "http://purl.org/dc/terms/abstract",
+      "@container" : "@set"
+    },
+    "otherTitleInformation" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60493",
+      "@container" : "@set"
+    },
+    "urn" : {
+      "@id" : "http://purl.org/lobid/lv#urn",
+      "@container" : "@set"
+    },
+    "subjectLocation" : {
+      "@id" : "http://purl.org/lobid/lv#subjectLocation",
+      "@container" : "@set"
+    },
+    "callNumber" : {
+      "@id" : "http://purl.org/ontology/daia/label"
+    },
+    "placeOfPublication" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60163",
+      "@container" : "@set"
+    },
+    "series" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#series",
+      "@container" : "@set"
+    },
+    "thesisInformation" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60489",
+      "@container" : "@set"
+    },
+    "describedby" : {
+      "@type" : "@id",
+      "@id" : "http://www.w3.org/2007/05/powder-s#describedby"
+    },
+    "Family" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#Family",
+      "@container" : "@set"
+    },
+    "ismn" : {
+      "@id" : "http://purl.org/ontology/mo/ismn",
+      "@container" : "@set"
+    },
+    "Bibliography" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#Bibliography",
+      "@container" : "@set"
+    },
+    "publishedBy" : {
+      "@id" : "http://schema.org/publishedBy",
+      "@container" : "@set"
+    },
+    "isFormatOf" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/isFormatOf"
+    },
+    "agent" : {
+      "@type" : "@id",
+      "@id" : "http://bibframe.org/vocab/agent"
+    },
+    "inDataset" : {
+      "@type" : "@id",
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#inDataset",
+      "@container" : "@set"
+    },
+    "ArchivalResource" : {
+      "@type" : "@id",
+      "@id" : "http://data.archiveshub.ac.uk/def/ArchivalResource",
+      "@container" : "@set"
+    },
+    "Miscellaneous" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#Miscellaneous",
+      "@container" : "@set"
+    },
+    "subject" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/subject",
+      "@container" : "@list"
+    },
+    "titleKeyword" : {
+      "@id" : "http://purl.org/lobid/lv#titleKeyword",
+      "@container" : "@set"
+    },
+    "language" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/language",
+      "@container" : "@set"
+    },
+    "Journal" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Journal",
+      "@container" : "@set"
+    },
+    "Creator" : {
+      "@type" : "@id",
+      "@id" : "http://id.loc.gov/vocabulary/relators/cre",
+      "@container" : "@set"
+    },
+    "source" : {
+      "@id" : "http://purl.org/dc/terms/source",
+      "@container" : "@set"
+    },
+    "shortTitle" : {
+      "@id" : "http://purl.org/ontology/bibo/shortTitle",
+      "@container" : "@set"
+    },
+    "subjectChain" : {
+      "@id" : "http://purl.org/lobid/lv#subjectChain",
+      "@container" : "@set"
+    },
+    "frequency" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60538",
+      "@container" : "@set"
+    },
+    "Proceedings" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Proceedings",
+      "@container" : "@set"
+    },
+    "contributingCorporateBodyLabel" : {
+      "@id" : "http://purl.org/lobid/lv#nameOfContributingCorporateBody",
+      "@container" : "@set"
+    },
+    "publication" : {
+      "@id" : "http://schema.org/publication",
+      "@container" : "@set"
+    },
+    "containedIn" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#containedIn",
+      "@container" : "@set"
+    },
+    "DifferentiatedPerson" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson",
+      "@container" : "@set"
+    },
+    "isPrimaryTopicOf" : {
+      "@type" : "@id",
+      "@id" : "http://xmlns.com/foaf/0.1/isPrimaryTopicOf"
+    },
+    "contributorLabel" : {
+      "@id" : "http://purl.org/lobid/lv#contributorLabel",
+      "@container" : "@set"
+    },
+    "CorporateBody" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#CorporateBody",
+      "@container" : "@set"
+    },
+    "publicationStatement" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60333",
+      "@container" : "@set"
+    },
+    "numbering" : {
+      "@id" : "http://purl.org/lobid/lv#numbering",
+      "@container" : "@set"
+    },
+    "subjectOrder" : {
+      "@id" : "http://purl.org/lobid/lv#subjectOrder",
+      "@container" : "@list"
+    },
+    "Legislation" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#Legislation",
+      "@container" : "@set"
+    },
+    "statementOfResponsibility" : {
+      "@id" : "http://rdaregistry.info/Elements/u/P60339"
+    },
+    "Thesis" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Thesis",
+      "@container" : "@set"
+    },
+    "ArchivedWebPage" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#ArchivedWebPage",
+      "@container" : "@set"
+    },
+    "volume" : {
+      "@id" : "http://purl.org/ontology/bibo/volume",
+      "@container" : "@set"
+    },
+    "BibliographicResource" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/BibliographicResource",
+      "@container" : "@set"
+    },
+    "primaryTopic" : {
+      "@type" : "@id",
+      "@id" : "http://xmlns.com/foaf/0.1/primaryTopic",
+      "@container" : "@set"
+    },
+    "publisher" : {
+      "@id" : "http://purl.org/dc/elements/1.1/publisher",
+      "@container" : "@set"
+    },
+    "Collection" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Collection",
+      "@container" : "@set"
+    },
+    "SeriesRelation" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#SeriesRelation",
+      "@container" : "@set"
+    },
+    "tableOfContents" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/tableOfContents",
+      "@container" : "@set"
+    },
+    "oclcnum" : {
+      "@id" : "http://purl.org/ontology/bibo/oclcnum",
+      "@container" : "@set"
+    },
+    "SubjectHeading" : {
+      "@type" : "@id",
+      "@id" : "http://d-nb.info/standards/elementset/gnd#SubjectHeading",
+      "@container" : "@set"
+    },
+    "multiVolumeWork" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#multiVolumeWork",
+      "@container" : "@set"
+    },
+    "note" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#note",
+      "@container" : "@set"
+    },
+    "hasVersion" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/hasVersion",
+      "@container" : "@set"
+    },
+    "secondaryPublication" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#secondaryPublication"
+    },
+    "isbn" : {
+      "@id" : "http://purl.org/ontology/bibo/isbn",
+      "@container" : "@set"
+    },
+    "xsd" : {
+      "@id" : "http://www.w3.org/2001/XMLSchema#",
+      "@container" : "@set"
+    },
+    "description" : {
+      "@id" : "http://purl.org/dc/terms/description",
+      "@container" : "@set"
+    },
+    "edition" : {
+      "@id" : "http://purl.org/ontology/bibo/edition",
+      "@container" : "@set"
+    },
+    "Standard" : {
+      "@id" : "http://purl.org/ontology/bibo/Standard",
+      "@container" : "@set"
+    },
+    "medium" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/dc/terms/medium",
+      "@container" : "@set"
+    },
+    "title" : {
+      "@id" : "http://purl.org/dc/terms/title"
+    },
+    "seeAlso" : {
+      "@type" : "@id",
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+      "@container" : "@set"
+    },
+    "dateCreated" : {
+      "@id" : "http://purl.org/dc/terms/created",
+      "@container" : "@set"
+    },
+    "Biography" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#Biography",
+      "@container" : "@set"
+    },
+    "subjectLabel" : {
+      "@id" : "http://purl.org/lobid/lv#subjectLabel",
+      "@container" : "@set"
+    },
+    "subjectName" : {
+      "@id" : "http://purl.org/dc/elements/1.1/subject",
+      "@container" : "@set"
+    },
+    "coverage" : {
+      "@id" : "http://purl.org/dc/elements/1.1/coverage",
+      "@container" : "@set"
+    },
+    "owner" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/vocab/frbr/core#owner"
+    },
+    "OfficialPublication" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#OfficialPublication",
+      "@container" : "@set"
+    },
+    "Periodical" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Periodical",
+      "@container" : "@set"
+    },
+    "Report" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Report",
+      "@container" : "@set"
+    },
+    "prefLabel" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#prefLabel",
+      "@container" : "@set"
+    },
+    "webPageArchived" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#webPageArchived",
+      "@container" : "@set"
+    },
+    "dateModified" : {
+      "@id" : "http://purl.org/dc/terms/modified",
+      "@container" : "@set"
+    },
+    "nwbibsubject" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#nwbibsubject",
+      "@container" : "@set"
+    },
+    "label" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#label",
+      "@container" : "@set"
+    },
+    "EditedVolume" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/lobid/lv#EditedVolume",
+      "@container" : "@set"
+    },
+    "Series" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/bibo/Series",
+      "@container" : "@set"
+    },
+    "location" : {
+      "@id" : "http://schema.org/location",
+      "@container" : "@set"
+    },
+    "Contribution" : {
+      "@type" : "@id",
+      "@id" : "http://bibframe.org/vocab/Contribution",
+      "@container" : "@set"
+    },
+    "collectedBy" : {
+      "@type" : "@id",
+      "@id" : "http://purl.org/ontology/holding#collectedBy",
+      "@container" : "@set"
+    },
+    "sameAs" : {
+      "@type" : "@id",
+      "@id" : "http://www.w3.org/2002/07/owl#sameAs",
+      "@container" : "@set"
+    }
+  }
+}

--- a/src/main/resources/labels.json
+++ b/src/main/resources/labels.json
@@ -11936,14 +11936,6 @@
         "multilangLabel": { }
     },
     {
-        "uri": "http://rdvocab.info/RDARelationshipsWEMI/workManifested",
-        "label": "Werkebene",
-        "name": "workManifested",
-        "referenceType": "@id",
-        "container": "@set",
-        "multilangLabel": { }
-    },
-    {
         "uri": "http://umbel.org/umbel#isLike",
         "label": "Ähnlich zu",
         "name": "similar",
@@ -12285,7 +12277,7 @@
         "multilangLabel": { }
     },
     {
-        "uri": "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+        "uri": "http://rdaregistry.info/termList/RDAproductionMethod/1010",
         "name": "Print",
         "label": "Print",
         "referenceType": "@id",
@@ -20175,11 +20167,11 @@
       "label":"lobid Organisation"
    },
    {
-      "uri":"http://rdvocab.info/termList/RDACarrierType/1010",
+      "uri":"http://rdaregistry.info/termList/RDACarrierType/1010",
       "label":"Datenträger"
    },
    {
-      "uri":"http://rdvocab.info/termList/RDACarrierType/1018",
+      "uri":"http://rdaregistry.info/termList/RDACarrierType/1018",
       "label":"Online-Ressource"
    },
    {

--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -279,10 +279,10 @@
 		</combine>
 		<!-- print -->
 		<data source="050." name="@medium">
-			<regexp match="^[abcd]" format="http://rdvocab.info/termList/RDAproductionMethod/#1010"/>
+			<regexp match="^[abcd]" format="http://rdaregistry.info/termList/RDAproductionMethod/1010"/>
 		</data>
 		<data source="050." name="@medium">
-			<regexp match="^.......a" format="http://rdvocab.info/termList/RDAproductionMethod/#1010"/>
+			<regexp match="^.......a" format="http://rdaregistry.info/termList/RDAproductionMethod/1010"/>
 		</data>
 		<!-- multimedia -->
 		<data source="050." name="@medium">
@@ -304,7 +304,7 @@
 			<regexp match=".*" format="$[ns-bibo]AudioVisualDocument"/>
 		</data>
 		<data source="@matVideo" name="@medium">
-			<regexp match=".*" format="http://rdvocab.info/termList/RDACarrierType/1050"/>
+			<regexp match=".*" format="http://rdaregistry.info/termList/RDACarrierType/1050"/>
 		</data>
 		<data source="334-[12].a" name="@medium">
 			<regexp match="^Bildton" format="$[ns-bibo]AudioVisualDocument"/>
@@ -318,13 +318,13 @@
 		</data>
 		<!-- microform -->
 		<data source="050." name="@medium">
-			<regexp match="^...[abc]" format="http://rdvocab.info/termList/RDACarrierType/1020"/>
+			<regexp match="^...[abc]" format="http://rdaregistry.info/termList/RDACarrierType/1020"/>
 		</data>
 		<data source="334-[12].a" name="@medium">
-			<regexp match="^Mikrofor" format="http://rdvocab.info/termList/RDACarrierType/1020"/>
+			<regexp match="^Mikrofor" format="http://rdaregistry.info/termList/RDACarrierType/1020"/>
 		</data>
 		<data source="057." name="@medium">
-			<regexp match=".*" format="http://rdvocab.info/termList/RDACarrierType/1020"/>
+			<regexp match=".*" format="http://rdaregistry.info/termList/RDACarrierType/1020"/>
 		</data>
 		<!-- Dini Kim , TODO dcterms:medium "rdacarrier:1044" (unmediated) -->
 		<!-- map -->
@@ -347,7 +347,7 @@
 			<regexp match="^....a" format="http://purl.org/library/BrailleBook"/>
 		</data>
 		<data source="050." name="@medium">
-			<regexp match="^....a" format="http://rdvocab.info/termList/RDAproductionMethod/1010"/>
+			<regexp match="^....a" format="http://rdaregistry.info/termList/RDAproductionMethod/1010"/>
 		</data>
 		<!-- game -->
 		<data source="050." name="@rdftype">
@@ -355,11 +355,11 @@
 		</data>
 		<!-- manuscript -->
 		<data source="050." name="@medium">
-			<regexp match="^.a" format="http://rdvocab.info/termList/prodManuscript/1002"/>
+			<regexp match="^.a" format="http://rdaregistry.info/termList/prodManuscript/1002"/>
 		</data>
 		<!-- Computer carriers -->
 		<data source="050." name="@medium">
-			<regexp match="^........[abcdefgz]" format="http://rdvocab.info/termList/RDACarrierType/1010"/>
+			<regexp match="^........[abcdefgz]" format="http://rdaregistry.info/termList/RDACarrierType/1010"/>
 		</data>
 		<combine name="~rdf:subject" value="${a}" flushWith="@typeOnly">
 			<data source="@typeOnly"/>
@@ -490,25 +490,25 @@
 		</data>
 		<!-- online -->
 		<data source="050." name="@1018">
-			<regexp match="^........g" format="http://rdvocab.info/termList/RDACarrierType/1018"/>
+			<regexp match="^........g" format="http://rdaregistry.info/termList/RDACarrierType/1018"/>
 		</data>
 		<data source="058." name="@1018">
-			<regexp match="^.r" format="http://rdvocab.info/termList/RDACarrierType/1018"/>
+			<regexp match="^.r" format="http://rdaregistry.info/termList/RDACarrierType/1018"/>
 		</data>
 		<data source="652a[-1].a" name="@1018">
-			<regexp match="^[AaOo][rn]" format="http://rdvocab.info/termList/RDACarrierType/1018"/>
+			<regexp match="^[AaOo][rn]" format="http://rdaregistry.info/termList/RDACarrierType/1018"/>
 		</data>
 		<data source="@1018" name="@medium"/>
 		<!-- computer carrier (disks etc) -->
 		<data source="058." name="@medium">
-			<regexp match="^.[^r]" format="http://rdvocab.info/termList/RDACarrierType/1010"/>
+			<regexp match="^.[^r]" format="http://rdaregistry.info/termList/RDACarrierType/1010"/>
 		</data>
 		<!-- electronic -->
 		<data source="@fulltextOnline" name="@medium">
-			<regexp match=".*" format="http://rdvocab.info/termList/RDACarrierType/1010"/>
+			<regexp match=".*" format="http://rdaregistry.info/termList/RDACarrierType/1010"/>
 		</data>
 		<data source="652a[-1].a" name="@medium">
-			<regexp match=".*" format="http://rdvocab.info/termList/RDACarrierType/1010"/>
+			<regexp match=".*" format="http://rdaregistry.info/termList/RDACarrierType/1010"/>
 		</data>
 		<data source="@medium" name="http://purl.org/dc/terms/medium"/>
 		<!-- set default medium -->

--- a/src/test/resources/hbz01.es.json
+++ b/src/test/resources/hbz01.es.json
@@ -90,7 +90,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -3479,7 +3479,7 @@
 <http://lobid.org/resources/BT000002852#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/BT000002852#!> <http://iflastandards.info/ns/isbd/elements/P1053> "46 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/elements/1.1/coverage> "Freudenberg <Siegen-Wittgenstein>"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/title> "Stadt Freudenberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/4018466-3"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3511,7 +3511,7 @@
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/BT000100437#!> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/title> "Deutschland, 2: Nordrhein-Westfalen, Niedersachsen-S\u00FCd"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/lobid/lv#hbzID> "BT000003404"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3548,7 +3548,7 @@
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/elements/1.1/coverage> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/bibliographicCitation> "Rheine gestern, heute, morgen. - 11 (1983), S. 26-38 : Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT003759287#!> .
-<http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/title> "Die Vogelwelt der Stadt Rheine."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT003759287#!> .
@@ -3572,7 +3572,7 @@
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/bibliographicCitation> "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT007751353#!> .
-<http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/title> "Das Portrait einer Region: Kreis Coesfeld."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT007751353#!> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/10880724X"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3593,7 +3593,7 @@
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/bibliographicCitation> "Kiebitz. - 6 (1986), S. 29-36, S. 63-67"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT006990419#!> .
-<http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/title> "Bestandsaufnahme der Amphibien im Raum Coesfeld-Billerbeck"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT006990419#!> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118033948"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3618,7 +3618,7 @@
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/bibliographicCitation> "Vom Kohlenpott zu Deutschlands \"starkem St\u00FCck\".; von J\u00FCrgen Reulecke; 1990; S. 49-76 ; graph. Darst., 1 Tab."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/von> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/title> "Von der Dorfschule zum Schulsystem"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/von> .
@@ -3642,7 +3642,7 @@
 <http://lobid.org/resources/BT000110055#!> <http://bibframe.org/vocab/contribution> _:Bb4 .
 <http://lobid.org/resources/BT000110055#!> <http://iflastandards.info/ns/isbd/elements/P1053> "28 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/elements/1.1/coverage> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/title> "Kall im Naturpark Nordeifel"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#contributorOrder> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3670,7 +3670,7 @@
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/abstract> "Erinnerungen an d. 1. FC K\u00F6ln u. Borussia M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/bibliographicCitation> "Nach dem Spiel ist vor dem Spiel : die wunderbare Welt des Fu\u00DFballs / Wolfgang Frank (Hg.); Orig.-Ausg.; 1996; S. 101-[108]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT007138775#!> .
-<http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/title> "Alle B\u00F6cke bei\u00DFen oder in Feindschaft fest"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT007138775#!> .
@@ -3701,7 +3701,7 @@
 <http://lobid.org/resources/BT000128754> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/BT000168595#!> <http://iflastandards.info/ns/isbd/elements/P1053> "42 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/title> "Frauen, Kultur, Politik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/5265186-1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3741,8 +3741,8 @@
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/isFormatOf> <http://lobid.org/resources/HT016511663#!> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT017290519#!> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/source> <http://lobid.org/resources/HT016511663#!> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/title> "Elise, Gr\u00C3\u00A4finn von Hillburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/119055716 | http://d-nb.info/gnd/123633206 | http://d-nb.info/gnd/116620153 | http://d-nb.info/gnd/141927135 | http://d-nb.info/gnd/142027901 | http://d-nb.info/gnd/14216075X | http://d-nb.info/gnd/118512536 | http://d-nb.info/gnd/1041277814 | http://d-nb.info/gnd/141834919 | http://d-nb.info/gnd/141889810 | http://d-nb.info/gnd/142061166 | http://d-nb.info/gnd/141891173 | http://d-nb.info/gnd/16068028-1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3765,7 +3765,7 @@
 <http://lobid.org/resources/CT003012479> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000009600#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/title> "Der Angestellte Hamburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/37043-5"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3835,7 +3835,7 @@
 <http://lobid.org/resources/HT000009600> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT000290078#!> <http://iflastandards.info/ns/isbd/elements/P1053> "X, 99 S. : GRAPH. DARST."^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT000290078#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT000290078#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/dc/terms/title> "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER- ZEHN- BIS FUENFZEHNJAEHRIGE"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/174737203"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/lobid/lv#hbzID> "HT000290078"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3857,7 +3857,7 @@
 <http://lobid.org/resources/HT001245500#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001252640#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215#!> <http://bibframe.org/vocab/contribution> _:Bb3 .
-<http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/title> "JOURNAL"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/177572388 | http://d-nb.info/gnd/37460-X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/lobid/lv#hbzID> "HT001310215"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3881,7 +3881,7 @@
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001381485#!> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/pol> .
-<http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/subject> _:Bb7 .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=3362189&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/title> "Gro\u00DFw\u00F6rterbuch Polnisch-Deutsch, 2: O - \u017B"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3933,7 +3933,7 @@
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/rus> .
-<http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/title> "Annual bulletin of transport statistics for Europe and North America"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2023669-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3962,7 +3962,7 @@
 <http://lobid.org/resources/HT003160768#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/elements/1.1/coverage> "M\u00FCnster <Westfalen, Bezirk>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/title> "Gebietsentwicklungsplan"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2019209-5"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -3998,7 +3998,7 @@
 <http://lobid.org/resources/HT003536695#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[8] Bl., 306 S., [1] gef. Bl. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/hasVersion> <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/lat> .
-<http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/title> "Fundamenta physices"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/119026074"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/lobid/lv#fulltextOnline> <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> .
@@ -4126,7 +4126,7 @@
 <http://lobid.org/resources/HT006266886#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Videokassette (VHS, 93 Min.) : farb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/ita> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/title> "Il giardino dei Finzi-Contini"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118677942 | http://d-nb.info/gnd/118657496 | http://d-nb.info/gnd/143102893 | http://d-nb.info/gnd/141618302 | http://d-nb.info/gnd/141649429 | http://d-nb.info/gnd/120454874"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/lobid/lv#hbzID> "HT006266886"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4147,7 +4147,7 @@
 <http://lobid.org/resources/HT006698544#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT006698544#!> <http://iflastandards.info/ns/isbd/elements/P1053> "XIV, 464 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/hasVersion> <http://resolver.sub.uni-goettingen.de/purl?PPN236434969> .
-<http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/title> "Texas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/116583053"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4184,7 +4184,7 @@
 <http://lobid.org/resources/HT009719670#!> <http://bibframe.org/vocab/contribution> _:Bb4 .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/medium> <http://iflastandards.info/ns/isbd/terms/mediatype/T1008> .
-<http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/title> "Le cin\u00E9ma de la vie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/172026644 | http://d-nb.info/gnd/133991210 | http://d-nb.info/gnd/11860225X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/lobid/lv#hbzID> "HT009719670"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4205,7 +4205,7 @@
 <http://lobid.org/resources/HT009993506#!> <http://bibframe.org/vocab/contribution> _:Bb5 .
 <http://lobid.org/resources/HT009993506#!> <http://iflastandards.info/ns/isbd/elements/P1053> "56 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/title> "500 Jahre Bruderschaften Reusrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/lobid/lv#contributorOrder> "Hinrichs, Fritz | Sankt Sebastianus-Sch\u00FCtzenbruderschaft Reusrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/lobid/lv#hbzID> "HT009993506"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4224,7 +4224,7 @@
 <http://lobid.org/resources/HT009993506> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT010662586#!> <http://iflastandards.info/ns/isbd/elements/P1053> "23 p."^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/title> "The Common man in the great Civil War"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118839055"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/lobid/lv#hbzID> "HT010662586"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4242,8 +4242,8 @@
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/hasVersion> <http://search.ebscohost.com/> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/subject> _:Bb1 .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/title> "Physics of plasmas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/lobid/lv#fulltextOnline> <http://search.ebscohost.com/> .
@@ -4311,7 +4311,7 @@
 <http://lobid.org/resources/HT010726584> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012237361#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/title> "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz / L / 4 / 6"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/36467-8"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/lobid/lv#hbzID> "HT012237361"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4333,7 +4333,7 @@
 <http://lobid.org/resources/HT012895751#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT012895751#!> <http://iflastandards.info/ns/isbd/elements/P1053> "76 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/title> "Mainz-Kinzig-Kreis"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2037247-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4359,7 +4359,7 @@
 <http://lobid.org/resources/HT012926727#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT012926727#!> <http://iflastandards.info/ns/isbd/elements/P1053> "XIV, 514 S. : graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1533597&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/title> "Handbuch der Elektrizit\u00E4tswirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4450,8 +4450,8 @@
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/hasVersion> <http://gso.gbv.de/DB=5.85/PPNSET?PPN=%2024428153X> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?2013112> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/subject> _:Bb1 .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/title> "EC tax review"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/lobid/lv#fulltextOnline> <http://gso.gbv.de/DB=5.85/PPNSET?PPN=%2024428153X> .
@@ -4500,7 +4500,7 @@
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld <Kreis>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/subject> _:Bb9 .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/title> "Geschichte hier"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/11079267X | http://d-nb.info/gnd/109490312 | http://d-nb.info/gnd/128755-2"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4550,7 +4550,7 @@
 <http://lobid.org/resources/HT013077595> <http://purl.org/dc/terms/modified> "20011113"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/subject> _:Bb1 .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/title> "D\u00E9cid\u00E9"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/lobid/lv#hbzID> "HT013304490"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4590,7 +4590,7 @@
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/bibliographicCitation> "Kontinuit\u00E4t und Diskontinuit\u00E4t / hrsg. von Thomas Gr\u00FCnewald ... - Berlin [u.a.], 2003. - (Reallexikon der germanischen Altertumskunde : Erg\u00E4nzungsb\u00E4nde ; 35). - S. [266]-344 : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013538692#!> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/title> "Ubier, Chatten, Bataver"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT013538692#!> .
@@ -4624,7 +4624,7 @@
 <http://lobid.org/resources/HT013798403#!> <http://iflastandards.info/ns/isbd/elements/P1053> "56 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT004520034#!> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/title> "Do fixed-term contracts increase the long-term employment opportunities of the unemployment?"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/13017923X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/lobid/lv#hbzID> "HT013798403"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4679,7 +4679,7 @@
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/bibliographicCitation> "Heimatbl\u00E4tter. - 82 (2002), S. 149-152 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT006991655#!> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/title> "Zur Kapellenrestaurierung in Schwarzenraben 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT006991655#!> .
@@ -4707,7 +4707,7 @@
 <http://lobid.org/resources/HT014015351#!> <http://bibframe.org/vocab/contribution> _:Bb4 .
 <http://lobid.org/resources/HT014015351#!> <http://iflastandards.info/ns/isbd/elements/P1053> "324 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/title> "Spuren, Lekt\u00FCren"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/129016713 | http://d-nb.info/gnd/136788548"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4766,7 +4766,7 @@
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/bibliographicCitation> "Karl der Gro\u00DFe und Europa / hrsg. von der Schweizerischen Botschaft in der Bundesrepublik Deutschland ... - Frankfurt am Main [u.a.], 2004. - S. 67-86 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT014168843#!> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/title> "Karl der Gro\u00DFe und sein Bild"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT014168843#!> .
@@ -4809,7 +4809,7 @@
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/elements/1.1/coverage> "Bad Honnef"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/elements/1.1/coverage> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/title> "Titus Reinarz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/133595935 | http://d-nb.info/gnd/159865794"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4865,7 +4865,7 @@
 <http://lobid.org/resources/HT014681992#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[ca. 50 Bl.] : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/elements/1.1/coverage> "Neuss-Selikum"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/title> "Herzlich Willkommen zum Appeltaatefest 2005"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/6509781-6 | http://d-nb.info/gnd/5176874-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4895,8 +4895,8 @@
 <http://lobid.org/resources/HT014997977#!> <http://iflastandards.info/ns/isbd/elements/P1053> "15, [14] S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/subject> _:Bb7 .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/title> "Leitfaden f\u00FCr die Behandlung von Ausbauasphalt und Stra\u00DFenaufbruch mit teer-/pechtypischen Bestandteilen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/3062366-2 | http://d-nb.info/gnd/10048424-4 | http://d-nb.info/gnd/2092393-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4921,7 +4921,7 @@
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/isPartOf> <http://ld.zdb-services.de/resource/208524-0> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001373475#!> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/nld> .
-<http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/title> "Tijdschrift voor geschiedenis, 119"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/lobid/lv#hbzID> "HT015082724"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4947,7 +4947,7 @@
 <http://lobid.org/resources/HT015183529#!> <http://iflastandards.info/ns/isbd/elements/P1053> "LV, 225 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT004984061#!> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/title> "The great Gatsby"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118533592 | http://d-nb.info/gnd/119468476"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/lobid/lv#hbzID> "HT015183529"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4970,7 +4970,7 @@
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/bibliographicCitation> "Medien und Terrorismus; Christian Schicha ... (Hg.); 2002; S. 80 - 93"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013384949#!> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/title> "Die Terrorkrise als Medienereignis?"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT013384949#!> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/122021878 | http://d-nb.info/gnd/186186193 | http://d-nb.info/gnd/11075851X"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4991,7 +4991,7 @@
 <http://lobid.org/resources/HT015440386#!> <http://iflastandards.info/ns/isbd/elements/P1053> "181, VIII S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002091108#!> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/title> "Jago"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/111614597"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5042,7 +5042,7 @@
 <http://lobid.org/resources/HT015455455#!> <http://iflastandards.info/ns/isbd/elements/P1053> "291 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=2957975&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/subject> _:Bb9 .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/title> "Austro-Daimler und Steyr"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/124897274"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5085,7 +5085,7 @@
 <http://lobid.org/resources/HT015865114#!> <http://bibframe.org/vocab/contribution> _:Bb5 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013370531#!> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/title> "Von der Teilung zur Einheit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/105667129"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5124,7 +5124,7 @@
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002786685#!> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT015845132#!> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/title> "Die letzten Lebensjahre, 1963 - 1967, 2: September 1965 - April 1967"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/11850066X | http://d-nb.info/gnd/109702662"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5164,8 +5164,8 @@
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.1787/9789264273085-fr> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/isPartOf> _:Bb2 .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
-<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/title> "Examens en mati\u00E8re de coop\u00E9ration pour le d\u00E9veloppement : Danemark 1999"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/lobid/lv#contributorOrder> "Organisation de coop\u00E9ration et de d\u00E9veloppement \u00E9conomiques"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/lobid/lv#fulltextOnline> <http://dx.doi.org/10.1787/9789264273085-fr> .
@@ -5214,7 +5214,7 @@
 <http://lobid.org/resources/HT016135351#!> <http://iflastandards.info/ns/isbd/elements/P1053> "32 gez. S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/elements/1.1/coverage> "Harsewinkel-Marienfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/title> "Lutter-Wasserm\u00FChle Roberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/186931808"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5244,7 +5244,7 @@
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/alternative> "Linux for dummies <dt.>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=3474380&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027722&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/title> "Linux f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5293,7 +5293,7 @@
 <http://lobid.org/resources/HT016511663#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/elements/1.1/coverage> "Nordkirchen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/title> "Verzeichnis der Geb\u00E4ude und ihrer Eigent\u00FCmer auf dem Gebiet der Altgemeinde Nordkirchen 1805, 1900, 1955 und 2000"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/lobid/lv#hbzID> "HT016545462"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5314,7 +5314,7 @@
 <http://lobid.org/resources/HT016593925#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://bibframe.org/vocab/contribution> _:Bb4 .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/title> "Bericht der Beschwerdekommission"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/16090142-X | http://d-nb.info/gnd/4065786-3"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5365,8 +5365,8 @@
 <http://lobid.org/resources/HT016618741#!> <http://iflastandards.info/ns/isbd/elements/P1053> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/hasVersion> <http://deposit.ddb.de/cgi-bin/dokserv?idn=1^010809261> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/title> "Ver\u00E4nderungen in der Zellmorphologie und Zellzyklusverteilung unter dem Einfluss einer Paclitaxel (Taxol\u00AE) induzierten Wachstumsinhibition im Nierenzellkarzinom"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/143001299"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/lobid/lv#fulltextOnline> <http://deposit.ddb.de/cgi-bin/dokserv?idn=1^010809261> .
@@ -5393,7 +5393,7 @@
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/bibliographicCitation> "Westfalen; 88. 2010 (2012), S. 175-179"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001374559#!> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/title> "Situationsbericht Fachbereich Praktische Denkmalpflege"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT001374559#!> .
@@ -5420,8 +5420,8 @@
 <http://lobid.org/resources/HT017411546#!> <http://bibframe.org/vocab/contribution> _:Bb10 .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/subject> _:Bb11 .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/title> "Westf\u00E4lische Bibliographie zur Geschichte, Landeskunde und Volkskunde"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2140069-6"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5471,8 +5471,8 @@
 <http://lobid.org/resources/HT017437638#!> <http://bibframe.org/vocab/contribution> _:Bb3 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/hasVersion> <http://beck-online.beck.de/Default.aspx?vpath=bibdata%5Ckomm%5Cpewkokagbefrvo_1%5Ccont%5Cpewkokagbefrvo.htm&pos=0&hlwords=pewestorf%C3%90adrian%C3%90+adrian+%C3%90+pewestorf+#xhlhit> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/title> "Kurzarbeitergeld-BefristungsVO"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/133658104"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5527,7 +5527,7 @@
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/bibliographicCitation> "Nachrichten aus der Netter Geschichte; 2 (2011), S. 18-35 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT016593925#!> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/title> "Der Name Dorhoff in Urkunden im Wandel der Zeiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT016593925#!> .
@@ -5555,8 +5555,8 @@
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.4126/38m-004826540> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/title> "Immunohistochemical localization of complement regulatory proteins in the human retina"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1028627270"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5587,7 +5587,7 @@
 <http://lobid.org/resources/HT017529028#!> <http://iflastandards.info/ns/isbd/elements/P1053> "XXXVII, 265 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT012848847#!> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/title> "Edith-Stein-Gesamtausgabe, 18: Kreuzeswissenschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118617230 | http://d-nb.info/gnd/12226861X | http://d-nb.info/gnd/120534983"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5646,7 +5646,7 @@
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/bibliographicCitation> "Der Gie\u00DFerjunge; 34 (2014),1, S. 14-15"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT007072426#!> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/title> "D\u00FCsseldorf und das bergische Territorium"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT007072426#!> .
@@ -5697,7 +5697,7 @@
 <http://lobid.org/resources/HT018131501> <http://purl.org/dc/terms/created> "20140115"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/title> "Gesundheit und Pflege - aus der Hochschule in die Praxis"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/lobid/lv#hbzID> "HT018187026"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/ontology/bibo/issn> "21955131"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5720,7 +5720,7 @@
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4584991&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT016777884#!> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764417&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/title> "Irmgard Keun: Zeit und Zitat"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5772,7 +5772,7 @@
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT006514951#!> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT017500108#!> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6261756&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/title> "\"Uns verschleppten sie nach K\u00C3\u00B6ln ...\""^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5854,7 +5854,7 @@
 <http://lobid.org/resources/HT018295975#!> <http://iflastandards.info/ns/isbd/elements/P1053> "596 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4685554&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852707&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/title> "Th\u00FCringische und rheinische Forschungen"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5899,7 +5899,7 @@
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/bibliographicCitation> "Grabbe-Jahrbuch ...; 32. 2013 (2014), S. 80-95"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002156174#!> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/title> "Theatraler Exzess und \u0090\u0090\u0090,gespielte\u2018 Sinnlosigkeit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT002156174#!> .
@@ -5929,7 +5929,7 @@
 <http://lobid.org/resources/HT018454638#!> <http://iflastandards.info/ns/isbd/elements/P1053> "122 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/elements/1.1/coverage> "Bergisch Gladbach- Herkenrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/title> "Gottes Haus - Tor des Himmels"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/172845785 | http://d-nb.info/gnd/1060772442 | http://d-nb.info/gnd/2175350-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5965,8 +5965,8 @@
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/hasVersion> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/title> "\"Arisierung\" und \"Wiedergutmachung\" in deutschen St\u00C3\u00A4dten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/128495626 | http://d-nb.info/gnd/122511158"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6027,8 +6027,8 @@
 <http://lobid.org/resources/HT018585406#!> <http://bibframe.org/vocab/contribution> _:Bb4 .
 <http://lobid.org/resources/HT018585406#!> <http://iflastandards.info/ns/isbd/elements/P1053> "45 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/subject> _:Bb7 .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/title> "Endbericht Workshop Der Oberrhein als Europ\u00E4ische Metropolregion"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/121842118 | http://d-nb.info/gnd/16080300-7 | http://d-nb.info/gnd/5079636-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6066,7 +6066,7 @@
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=5203696&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT014679525#!> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/subject> _:Bb14 .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/title> "Wie die Pop Art nach Deutschland kam"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1050748387 | http://d-nb.info/gnd/1069643262 | http://d-nb.info/gnd/10040152-1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6197,8 +6197,8 @@
 <http://lobid.org/resources/HT018617137#!> <http://iflastandards.info/ns/isbd/elements/P1053> "55 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/title> "Nachhaltige Forschung an Fachhochschulen in NRW"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/lobid/lv#contributorOrder> "Helm, Eva Maria"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/lobid/lv#fulltextOnline> <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128> .
@@ -6226,8 +6226,8 @@
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT015550020#!> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/subject> _:Bb13 .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/title> "Die Hochaltrigen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/136371671 | http://d-nb.info/gnd/129961604 | Ottovay, Kathrin | http://d-nb.info/gnd/115325859 | http://d-nb.info/gnd/2006655-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6259,7 +6259,7 @@
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?2655603> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013878511#!> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/title> "Eine Marke sucht ihren Platz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT013878511#!> .
@@ -6285,7 +6285,7 @@
 <http://lobid.org/resources/HT018770176#!> <http://iflastandards.info/ns/isbd/elements/P1053> "276 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001252640#!> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/tableOfContents> <http://d-nb.info/1076583180/04> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/title> "Strafzumessungstatsachen zwischen Verbrechenslehre und Straftheorie"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6316,7 +6316,7 @@
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/elements/1.1/coverage> "Bergisch Gladbach- Bensberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/isPartOf> _:Bb2 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/subject> _:Bb7 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/tableOfContents> <http://d-nb.info/1074113608/04> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/title> "7. Schloss Bensberg Classics"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6342,7 +6342,7 @@
 <http://lobid.org/resources/HT018779822#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/HT018779822#!> <http://iflastandards.info/ns/isbd/elements/P1053> "264 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/title> "Humor in contemporary junior literature"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/143846655"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/lobid/lv#hbzID> "HT018779822"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6362,7 +6362,7 @@
 <http://lobid.org/resources/HT018786244#!> <http://iflastandards.info/ns/isbd/elements/P1053> "353 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT004394800#!> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6774059&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/tableOfContents> <http://www.folkwang-uni.de/fileadmin/medien/Downloads/Bibliothek/Inhaltsverzeichnisse/HT018786244.pdf> .
@@ -6395,9 +6395,9 @@
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/hasVersion> <https://repository.publisso.de/resource/frl:6399387> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/subject> _:Bb9 .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/title> "PUBLISSO - Das ZB MED Open-Access-Publikationsportal"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1072011352 | http://d-nb.info/gnd/1080327355 | http://d-nb.info/gnd/1049793021 | http://d-nb.info/gnd/1088345387"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6422,8 +6422,8 @@
 <http://lobid.org/resources/HT018895767#!> <http://iflastandards.info/ns/isbd/elements/P1053> "7 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT017447882#!> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/title> "\"Schulkrieg\" in Rheinland-Pfalz?"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1019562781"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6459,9 +6459,9 @@
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT018907246#!> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/title> "Digital object identifiers (DOIs) for research data and publications in the field of life sciences, 1: DOI registration with ZB MED"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1080327010 | http://d-nb.info/gnd/1080327355 | http://d-nb.info/gnd/105204266X | http://d-nb.info/gnd/1080064435 | http://d-nb.info/gnd/1072011352 | http://d-nb.info/gnd/1088345387"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/lobid/lv#hbzID> "HT018907266"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6483,7 +6483,7 @@
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/elements/1.1/coverage> "Dinslaken"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/elements/1.1/coverage> "Duisburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/title> "Der Ferd das Buch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1093886471"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6513,8 +6513,8 @@
 <http://lobid.org/resources/HT018939763#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Online-Ressource (265 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/por> .
-<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/subject> _:Bb5 .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/title> "Din\u00E2micas Afro-Latinas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1068655429 | http://d-nb.info/gnd/185493769"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6553,7 +6553,7 @@
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT018998832#!> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/lat> .
-<http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/title> "Historische || Ertzehlung || vnd || Leychpredigten || Etlicher Hocherleuchter Keyser/|| K\u00F6nige vnd Churf[ue]rsten/ Sampt jhrem || Christlichen Leben/ Wandel vnd T[oe]dt=||lichem Abgang.|| De\u00DFgleichen derselben Contrafacturen vnnd Bild=||nissen/ auch Epitaphijs oder Grabschrifften ... || in Druck verordnet/|| Durch || M. THOMAM STYBARVM,|| der Freyen Herrschafft vom Wolffstein Super-||intendenten zu Pyrbawm.||, 1"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/130303402"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/lobid/lv#hbzID> "HT018998891"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6580,8 +6580,8 @@
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/hasVersion> <http://langsci-press.org//catalog/book/91> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT018839495#!> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/title> "Roots of language"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/185844154"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/lobid/lv#fulltextOnline> <http://edocs.fu-berlin.de/docs/receive/FUDOCS_document_000000023900> .
@@ -6628,8 +6628,7 @@
 <http://lobid.org/resources/TT001210514#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://purl.org/library/BrailleBook> .
-<http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
-<http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/title> "Mein Kampf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118551655"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/lobid/lv#hbzID> "TT001210514"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6651,7 +6650,7 @@
 <http://lobid.org/resources/TT001230001#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[8] Bl., 414, [1] S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/TT001197763#!> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/lat> .
-<http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1020> .
+<http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1020> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/title> "Reliqua librorum Friderici II. ... de arte venandi cum avibus"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118535765 | http://d-nb.info/gnd/118577018 | http://d-nb.info/gnd/118637649"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/lobid/lv#hbzID> "TT001230001"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6676,7 +6675,7 @@
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002808565#!> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/subject> _:Bb7 .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/title> "Geographisch-landeskundlicher Atlas von Westfalen, 3,5,1: Bev\u00F6lkerungsdichte der Gemeinden 1871 - 1987 und Ver\u00E4nderung 1818 - 1987"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/137082479 | http://d-nb.info/gnd/2056181-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6717,8 +6716,8 @@
 <http://lobid.org/resources/TT001726537#!> <http://bibframe.org/vocab/contribution> _:Bb2 .
 <http://lobid.org/resources/TT001726537#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[2] Bl., 116 S. : Ill. (Kupfert.)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
-<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
-<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/prodManuscript/1002> .
+<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/prodManuscript/1002> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/title> "Critique Du Jesuite Secularis\u00E9"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/115541802"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/lobid/lv#hbzID> "TT001726537"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6741,8 +6740,8 @@
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/hasVersion> <http://www.edoweb-rlp.de/resource/edoweb:1638076> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/hasVersion> <https://www.edoweb-rlp.de/resource/edoweb:1638076> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/subject> _:Bb4 .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/title> "2. Nachtragshaushaltssatzung und 1. Nachtragshaushaltsplan 2001"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/lobid/lv#contributorOrder> "Lierschied"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6771,8 +6770,8 @@
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/subject> _:Bb13 .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/title> "Jakobswege : der Lahn-Camino"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#contributorOrder> "Kranz, Heinrich | M\u00FCller, Guntram | Rhein-Lahn-Kreis | Wirtschaftsf\u00F6rderungs-Gesellschaft Rhein-Lahn"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6806,8 +6805,8 @@
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6267588&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/hasVersion> <https://www.edoweb-rlp.de/resource/edoweb:49> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/subject> _:Bb2 .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/title> "Rheinland-Pfalz - Staatskanzlei"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2029758-0"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6835,8 +6834,8 @@
 <http://lobid.org/resources/TT003059252#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
-<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/title> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2005535-3 | http://d-nb.info/gnd/2005535-3"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/lobid/lv#hbzID> "TT003059252"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6857,8 +6856,8 @@
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/title> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2005535-3 | http://d-nb.info/gnd/2005535-3"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/lobid/lv#hbzID> "TT003059252_contAndCrea"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6878,7 +6877,7 @@
 <http://lobid.org/resources/TT003280170#!> <http://iflastandards.info/ns/isbd/elements/P1053> "171 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001245500#!> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/title> "Festschrift zum 60. Geburtstag von Professor Dr. Ing. habil. Franz P\u00F6pel am 4. Oktober 1961"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/lobid/lv#hbzID> "TT003280170"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/lobid/lv#inSeries> _:Bb0 .
@@ -6895,8 +6894,8 @@
 <http://lobid.org/resources/TT050409948#!> <http://bibframe.org/vocab/contribution> _:Bb6 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.1007/978-3-642-20784-6> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/title> "Operationsberichte Unfallchirurgie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#contributorOrder> "Irlenbusch, Lars | Siekmann, Holger"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6979,13 +6978,12 @@
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/ontology"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/ontology/bibo/Map> <http://www.w3.org/2000/01/rdf-schema#label> "Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/ontology/mo/Vinyl> <http://www.w3.org/2000/01/rdf-schema#label> "Schallplatte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1020> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/prodManuscript/1002> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1020> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/prodManuscript/1002> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://resolver.staatsbibliothek-berlin.de/SBB00006B8200000000> <http://www.w3.org/2000/01/rdf-schema#label> "http://resolver.staatsbibliothek-berlin.de/SBB00006B8200000000"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://resolver.sub.uni-goettingen.de/purl?PPN236434969> <http://www.w3.org/2000/01/rdf-schema#label> "http://resolver.sub.uni-goettingen.de/purl?PPN236434969"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://search.ebscohost.com/> <http://www.w3.org/2000/01/rdf-schema#label> "http://search.ebscohost.com/"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7455,6 +7453,7 @@ _:Bb2 <http://purl.org/lobid/lv#numbering> "19"^^<http://www.w3.org/2001/XMLSche
 _:Bb2 <http://purl.org/lobid/lv#numbering> "2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT004984061#!> .
 _:Bb2 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT006514951#!> .
+_:Bb2 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017500108#!> .
 _:Bb2 <http://schema.org/location> "Augsburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Baden-Baden"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7607,7 +7606,6 @@ _:Bb3 <http://purl.org/lobid/lv#numbering> "3,5,1"^^<http://www.w3.org/2001/XMLS
 _:Bb3 <http://purl.org/lobid/lv#numbering> "F2001/F2003]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT006514951#!> .
 _:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT013370531#!> .
-_:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/HT017500108#!> .
 _:Bb3 <http://purl.org/lobid/lv#series> <http://lobid.org/resources/TT001197763#!> .
 _:Bb3 <http://schema.org/location> "Assen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/jsonld/BT000002852
+++ b/src/test/resources/jsonld/BT000002852
@@ -32,7 +32,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/BT000003404
+++ b/src/test/resources/jsonld/BT000003404
@@ -28,7 +28,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/Map",

--- a/src/test/resources/jsonld/BT000040377
+++ b/src/test/resources/jsonld/BT000040377
@@ -40,7 +40,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/BT000041593
+++ b/src/test/resources/jsonld/BT000041593
@@ -40,7 +40,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/BT000067443
+++ b/src/test/resources/jsonld/BT000067443
@@ -40,7 +40,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "note" : [ "Anfang s. Jg. 5 (1985) S. 22-29" ],

--- a/src/test/resources/jsonld/BT000103077
+++ b/src/test/resources/jsonld/BT000103077
@@ -44,7 +44,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "note" : [ "Aus: Fabrik, Familie, Feierabend. Wuppertal 1978, S. 247-271" ],

--- a/src/test/resources/jsonld/BT000110055
+++ b/src/test/resources/jsonld/BT000110055
@@ -31,7 +31,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "note" : [ "Nicht im Sortimentsbuchh." ],

--- a/src/test/resources/jsonld/BT000128754
+++ b/src/test/resources/jsonld/BT000128754
@@ -41,7 +41,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/BT000168595
+++ b/src/test/resources/jsonld/BT000168595
@@ -32,7 +32,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/CT003012479
+++ b/src/test/resources/jsonld/CT003012479
@@ -193,10 +193,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzufÃ¼hren ; Abonnement suspendu ; eine ganz neue groÃe komische Oper in 2 AufzÃ¼gen" ],

--- a/src/test/resources/jsonld/HT000009600
+++ b/src/test/resources/jsonld/HT000009600
@@ -173,7 +173,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "oclcnum" : [ "263589870" ],

--- a/src/test/resources/jsonld/HT000290078
+++ b/src/test/resources/jsonld/HT000290078
@@ -35,7 +35,7 @@
   },
   "isbn" : [ "3209001731", "9783209001733" ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER 10 - 15JAEHRIGE : E. HANDBUCH FUER D. LEHRER ; FACHLICHE ANREGUNGEN U. PRAKTISCHE BEISPIELE MIT VERWENDUNG D. SATZFIGUREN / VERF. VON E. ARBEITSGEMEINSCHAFT IM RAHMEN D. OESTERR. VERSUCHSSCHULWESENS: JOHANN AIGNER .." ],

--- a/src/test/resources/jsonld/HT001310215
+++ b/src/test/resources/jsonld/HT001310215
@@ -41,7 +41,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "THE JOURNAL OF THE AMERICAN DENTAL ASSOCIATION / ED.: ROGER H. SCHOLLE" ],

--- a/src/test/resources/jsonld/HT001898812
+++ b/src/test/resources/jsonld/HT001898812
@@ -105,7 +105,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT002619538
+++ b/src/test/resources/jsonld/HT002619538
@@ -55,7 +55,7 @@
     "label" : "Russisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT003160768
+++ b/src/test/resources/jsonld/HT003160768
@@ -55,7 +55,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT003536695
+++ b/src/test/resources/jsonld/HT003536695
@@ -50,7 +50,7 @@
     "label" : "Latein"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Henrici Regii Ultrajectini Fundamenta physices" ],

--- a/src/test/resources/jsonld/HT006266886
+++ b/src/test/resources/jsonld/HT006266886
@@ -94,8 +94,8 @@
     "label" : "Italienisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"

--- a/src/test/resources/jsonld/HT006698544
+++ b/src/test/resources/jsonld/HT006698544
@@ -43,7 +43,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "mit besonderer Rücksicht auf deutsche Auswanderung und die physischen Verhältnisse des Landes ; mit einem naturwissenschaftlichen Anhange und einer topographisch-geognostisschen Karte von Texas" ],

--- a/src/test/resources/jsonld/HT009719670
+++ b/src/test/resources/jsonld/HT009719670
@@ -60,11 +60,11 @@
     "label" : "Französisch"
   } ],
   "medium" : [ {
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+    "label" : "Print"
+  }, {
     "id" : "http://iflastandards.info/ns/isbd/terms/mediatype/T1008",
     "label" : "http://iflastandards.info/ns"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
-    "label" : "Print"
   } ],
   "otherTitleInformation" : [ "extraits de films de Eric Rohmer" ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT009993506
+++ b/src/test/resources/jsonld/HT009993506
@@ -47,7 +47,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT010662586
+++ b/src/test/resources/jsonld/HT010662586
@@ -31,7 +31,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT010726584
+++ b/src/test/resources/jsonld/HT010726584
@@ -132,10 +132,10 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases" ],

--- a/src/test/resources/jsonld/HT012237361
+++ b/src/test/resources/jsonld/HT012237361
@@ -35,7 +35,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz" ],

--- a/src/test/resources/jsonld/HT012895751
+++ b/src/test/resources/jsonld/HT012895751
@@ -35,7 +35,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Informationen für Bürger, Neubürger & Gäste" ],

--- a/src/test/resources/jsonld/HT012926727
+++ b/src/test/resources/jsonld/HT012926727
@@ -146,7 +146,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "technische, wirtschaftliche und rechtliche Grundlagen" ],

--- a/src/test/resources/jsonld/HT012989088
+++ b/src/test/resources/jsonld/HT012989088
@@ -35,10 +35,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT013077595
+++ b/src/test/resources/jsonld/HT013077595
@@ -69,7 +69,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT013304490
+++ b/src/test/resources/jsonld/HT013304490
@@ -33,7 +33,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "oclcnum" : [ "635743319" ],

--- a/src/test/resources/jsonld/HT013577568
+++ b/src/test/resources/jsonld/HT013577568
@@ -42,7 +42,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT013798403
+++ b/src/test/resources/jsonld/HT013798403
@@ -47,7 +47,7 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT013925945
+++ b/src/test/resources/jsonld/HT013925945
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT014015351
+++ b/src/test/resources/jsonld/HT014015351
@@ -74,7 +74,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Praktiken des Symbolischen ; [Festschrift für Ludwig Jäger zum 60. Geburtstag]" ],

--- a/src/test/resources/jsonld/HT014215912
+++ b/src/test/resources/jsonld/HT014215912
@@ -42,7 +42,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT014319164
+++ b/src/test/resources/jsonld/HT014319164
@@ -55,7 +55,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT014681992
+++ b/src/test/resources/jsonld/HT014681992
@@ -52,7 +52,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT014997977
+++ b/src/test/resources/jsonld/HT014997977
@@ -70,10 +70,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "Leitfaden für den Geschäftsbereich des Landesbetriebes Straßen und Verkehr" ],

--- a/src/test/resources/jsonld/HT015082724
+++ b/src/test/resources/jsonld/HT015082724
@@ -27,7 +27,7 @@
     "label" : "Niederländisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT015183529
+++ b/src/test/resources/jsonld/HT015183529
@@ -60,7 +60,7 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT015414894
+++ b/src/test/resources/jsonld/HT015414894
@@ -64,7 +64,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Internationale Krisenkommunikation - eine Herausforderung im 21. Jahrhundert" ],

--- a/src/test/resources/jsonld/HT015440386
+++ b/src/test/resources/jsonld/HT015440386
@@ -49,7 +49,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT015455455
+++ b/src/test/resources/jsonld/HT015455455
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Rivalen bis zur Fusion ; die frühen Jahre des Ferdinand Porsche" ],

--- a/src/test/resources/jsonld/HT015865114
+++ b/src/test/resources/jsonld/HT015865114
@@ -55,7 +55,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "die Welt nach 1945" ],

--- a/src/test/resources/jsonld/HT015891797
+++ b/src/test/resources/jsonld/HT015891797
@@ -90,7 +90,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT015894164
+++ b/src/test/resources/jsonld/HT015894164
@@ -119,10 +119,10 @@
     "label" : "Französisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT016135351
+++ b/src/test/resources/jsonld/HT016135351
@@ -40,7 +40,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT016382441
+++ b/src/test/resources/jsonld/HT016382441
@@ -103,7 +103,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles für Ihr Rendezvous mit dem Pinguin]" ],

--- a/src/test/resources/jsonld/HT016545462
+++ b/src/test/resources/jsonld/HT016545462
@@ -21,7 +21,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT016604323
+++ b/src/test/resources/jsonld/HT016604323
@@ -51,7 +51,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT016618741
+++ b/src/test/resources/jsonld/HT016618741
@@ -44,10 +44,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT017150239
+++ b/src/test/resources/jsonld/HT017150239
@@ -44,7 +44,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT017411546
+++ b/src/test/resources/jsonld/HT017411546
@@ -64,10 +64,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT017437638
+++ b/src/test/resources/jsonld/HT017437638
@@ -42,10 +42,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT017472134
+++ b/src/test/resources/jsonld/HT017472134
@@ -44,7 +44,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT017480009
+++ b/src/test/resources/jsonld/HT017480009
@@ -56,10 +56,10 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT017529028
+++ b/src/test/resources/jsonld/HT017529028
@@ -72,7 +72,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Studie über Johannes vom Kreuz" ],

--- a/src/test/resources/jsonld/HT018131501
+++ b/src/test/resources/jsonld/HT018131501
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT018187026
+++ b/src/test/resources/jsonld/HT018187026
@@ -28,7 +28,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018239864
+++ b/src/test/resources/jsonld/HT018239864
@@ -78,7 +78,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018290299
+++ b/src/test/resources/jsonld/HT018290299
@@ -49,19 +49,19 @@
   "hbzId" : "HT018290299",
   "id" : "http://lobid.org/resources/HT018290299#!",
   "inSeries" : [ {
-    "numbering" : "19",
-    "series" : [ {
-      "id" : "http://lobid.org/resources/HT006514951#!",
-      "label" : "lobid Ressource"
-    } ],
-    "type" : [ "SeriesRelation" ]
-  }, {
     "numbering" : [ "2", "19" ],
     "series" : [ {
       "id" : "http://lobid.org/resources/HT006514951#!",
       "label" : "lobid Ressource"
     }, {
       "id" : "http://lobid.org/resources/HT017500108#!",
+      "label" : "lobid Ressource"
+    } ],
+    "type" : [ "SeriesRelation" ]
+  }, {
+    "numbering" : "19",
+    "series" : [ {
+      "id" : "http://lobid.org/resources/HT006514951#!",
       "label" : "lobid Ressource"
     } ],
     "type" : [ "SeriesRelation" ]
@@ -83,7 +83,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018295975
+++ b/src/test/resources/jsonld/HT018295975
@@ -63,7 +63,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Bonn - Koblenz - Weimar - Meiningen ; Festschrift für Johannes Mötsch zum 65. Geburtstag" ],

--- a/src/test/resources/jsonld/HT018312899
+++ b/src/test/resources/jsonld/HT018312899
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018454638
+++ b/src/test/resources/jsonld/HT018454638
@@ -68,7 +68,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018468645
+++ b/src/test/resources/jsonld/HT018468645
@@ -63,10 +63,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018585406
+++ b/src/test/resources/jsonld/HT018585406
@@ -65,10 +65,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018612706
+++ b/src/test/resources/jsonld/HT018612706
@@ -93,7 +93,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018617137
+++ b/src/test/resources/jsonld/HT018617137
@@ -46,10 +46,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/jsonld/HT018700720
+++ b/src/test/resources/jsonld/HT018700720
@@ -102,10 +102,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "note" : [ "Literaturangaben" ],

--- a/src/test/resources/jsonld/HT018726005
+++ b/src/test/resources/jsonld/HT018726005
@@ -51,7 +51,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018770176
+++ b/src/test/resources/jsonld/HT018770176
@@ -51,7 +51,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "zugleich ein Beitrag zur Strafzumessungsrelevanz des Vor- und Nachtatverhaltens" ],

--- a/src/test/resources/jsonld/HT018771475
+++ b/src/test/resources/jsonld/HT018771475
@@ -50,7 +50,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018779822
+++ b/src/test/resources/jsonld/HT018779822
@@ -35,7 +35,7 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018786244
+++ b/src/test/resources/jsonld/HT018786244
@@ -63,7 +63,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Subjektentwicklung zwischen Nähe und Distanz" ],

--- a/src/test/resources/jsonld/HT018801101
+++ b/src/test/resources/jsonld/HT018801101
@@ -77,16 +77,16 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
-    "label" : "Datenträger"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
+    "label" : "Datenträger"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018895767
+++ b/src/test/resources/jsonld/HT018895767
@@ -60,10 +60,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "der Schulstreit in Rheinhessen und seine Folgen" ],

--- a/src/test/resources/jsonld/HT018907266
+++ b/src/test/resources/jsonld/HT018907266
@@ -93,16 +93,16 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
-    "label" : "Datenträger"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
+    "label" : "Datenträger"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018924091
+++ b/src/test/resources/jsonld/HT018924091
@@ -42,7 +42,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/jsonld/HT018939763
+++ b/src/test/resources/jsonld/HT018939763
@@ -58,10 +58,10 @@
     "label" : "http://id.loc.gov/vocabulary"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "língua(s) e história(s)" ],

--- a/src/test/resources/jsonld/HT018998891
+++ b/src/test/resources/jsonld/HT018998891
@@ -43,7 +43,7 @@
     "label" : "Latein"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "oclcnum" : [ "VD16 S 9000" ],

--- a/src/test/resources/jsonld/HT019011249
+++ b/src/test/resources/jsonld/HT019011249
@@ -62,10 +62,10 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/TT001210514
+++ b/src/test/resources/jsonld/TT001210514
@@ -36,14 +36,11 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://purl.org/library/BrailleBook",
-    "label" : "http://purl.org/library"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://purl.org/library/BrailleBook",
+    "label" : "http://purl.org/library"
   } ],
   "publication" : [ {
     "location" : "Marburg/Lahn",

--- a/src/test/resources/jsonld/TT001230001
+++ b/src/test/resources/jsonld/TT001230001
@@ -72,8 +72,8 @@
     "label" : "Latein"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1020",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1020",
+    "label" : "http://rdaregistry.info/termList"
   } ],
   "note" : [ "Vorlageform des Erscheinungsvermerks: Avgvstae Vindelicorvm ... Apud Ioannem Praetorium, Anno M.D.XCVI ... - Mikrofiche. München : Saur, 1991. Mikrofiche-Nr. F2001-F2003 : 23x" ],
   "otherTitleInformation" : [ "Cvm Manfredi Regis additionibus", "Reliqva Librorvm Friderici II. Imperatoris, De arte venandi cum auibus" ],

--- a/src/test/resources/jsonld/TT001671747
+++ b/src/test/resources/jsonld/TT001671747
@@ -71,7 +71,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/Map",

--- a/src/test/resources/jsonld/TT001726537
+++ b/src/test/resources/jsonld/TT001726537
@@ -39,11 +39,11 @@
     "label" : "Französisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
-    "id" : "http://rdvocab.info/termList/prodManuscript/1002",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/prodManuscript/1002",
+    "label" : "http://rdaregistry.info/termList"
   } ],
   "note" : [ "Streitschrift gegen Dupré, ...: Le Jesuite Secularisé" ],
   "publication" : [ {

--- a/src/test/resources/jsonld/TT002234042
+++ b/src/test/resources/jsonld/TT002234042
@@ -59,10 +59,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/TT002234459
+++ b/src/test/resources/jsonld/TT002234459
@@ -71,13 +71,13 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
     "id" : "http://purl.org/ontology/bibo/Map",
     "label" : "Karte"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "sameAs" : [ {

--- a/src/test/resources/jsonld/TT002234858
+++ b/src/test/resources/jsonld/TT002234858
@@ -61,10 +61,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "note" : [ "Siehe: http://www.stk.rlp.de" ],

--- a/src/test/resources/jsonld/TT003059252
+++ b/src/test/resources/jsonld/TT003059252
@@ -47,14 +47,14 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
+  }, {
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+    "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
-    "label" : "Print"
   } ],
   "note" : [ "Engl. Original mit dt. Untertiteln" ],
   "otherTitleInformation" : [ "Magical Mystery Tour" ],

--- a/src/test/resources/jsonld/TT003059252_contAndCrea
+++ b/src/test/resources/jsonld/TT003059252_contAndCrea
@@ -47,14 +47,14 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
+  }, {
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+    "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
-    "label" : "Print"
   } ],
   "note" : [ "Engl. Original mit dt. Untertiteln" ],
   "otherTitleInformation" : [ "Magical Mystery Tour" ],

--- a/src/test/resources/jsonld/TT003280170
+++ b/src/test/resources/jsonld/TT003280170
@@ -29,7 +29,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/jsonld/TT050409948
+++ b/src/test/resources/jsonld/TT050409948
@@ -49,10 +49,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/00000/BT000002852.json
+++ b/src/test/resources/output/json/00000/BT000002852.json
@@ -32,7 +32,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/00000/BT000003404.json
+++ b/src/test/resources/output/json/00000/BT000003404.json
@@ -28,7 +28,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/Map",

--- a/src/test/resources/output/json/00000/HT000009600.json
+++ b/src/test/resources/output/json/00000/HT000009600.json
@@ -613,7 +613,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "oclcnum" : [ "263589870" ],

--- a/src/test/resources/output/json/00004/BT000040377.json
+++ b/src/test/resources/output/json/00004/BT000040377.json
@@ -40,7 +40,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/00004/BT000041593.json
+++ b/src/test/resources/output/json/00004/BT000041593.json
@@ -40,7 +40,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/00006/BT000067443.json
+++ b/src/test/resources/output/json/00006/BT000067443.json
@@ -40,7 +40,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "note" : [ "Anfang s. Jg. 5 (1985) S. 22-29" ],

--- a/src/test/resources/output/json/00010/BT000103077.json
+++ b/src/test/resources/output/json/00010/BT000103077.json
@@ -44,7 +44,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "note" : [ "Aus: Fabrik, Familie, Feierabend. Wuppertal 1978, S. 247-271" ],

--- a/src/test/resources/output/json/00011/BT000110055.json
+++ b/src/test/resources/output/json/00011/BT000110055.json
@@ -5,10 +5,10 @@
     "label" : "Nordrhein-Westfälische Bibliographie"
   } ],
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Kall",
       "type" : [ "SubjectHeading", "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
@@ -31,7 +31,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "note" : [ "Nicht im Sortimentsbuchh." ],

--- a/src/test/resources/output/json/00012/BT000128754.json
+++ b/src/test/resources/output/json/00012/BT000128754.json
@@ -41,7 +41,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/00016/BT000168595.json
+++ b/src/test/resources/output/json/00016/BT000168595.json
@@ -32,7 +32,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/00029/HT000290078.json
+++ b/src/test/resources/output/json/00029/HT000290078.json
@@ -57,7 +57,7 @@
   },
   "isbn" : [ "3209001731", "9783209001733" ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER 10 - 15JAEHRIGE : E. HANDBUCH FUER D. LEHRER ; FACHLICHE ANREGUNGEN U. PRAKTISCHE BEISPIELE MIT VERWENDUNG D. SATZFIGUREN / VERF. VON E. ARBEITSGEMEINSCHAFT IM RAHMEN D. OESTERR. VERSUCHSSCHULWESENS: JOHANN AIGNER .." ],

--- a/src/test/resources/output/json/00121/TT001210514.json
+++ b/src/test/resources/output/json/00121/TT001210514.json
@@ -46,14 +46,11 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://purl.org/library/BrailleBook",
-    "label" : "http://purl.org/library"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/1010",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://purl.org/library/BrailleBook",
+    "label" : "http://purl.org/library"
   } ],
   "publication" : [ {
     "location" : "Marburg/Lahn",

--- a/src/test/resources/output/json/00123/TT001230001.json
+++ b/src/test/resources/output/json/00123/TT001230001.json
@@ -83,8 +83,8 @@
     "label" : "Latein"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1020",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1020",
+    "label" : "http://rdaregistry.info/termList"
   } ],
   "note" : [ "Vorlageform des Erscheinungsvermerks: Avgvstae Vindelicorvm ... Apud Ioannem Praetorium, Anno M.D.XCVI ... - Mikrofiche. München : Saur, 1991. Mikrofiche-Nr. F2001-F2003 : 23x" ],
   "otherTitleInformation" : [ "Cvm Manfredi Regis additionibus", "Reliqva Librorvm Friderici II. Imperatoris, De arte venandi cum auibus" ],

--- a/src/test/resources/output/json/00131/HT001310215.json
+++ b/src/test/resources/output/json/00131/HT001310215.json
@@ -52,7 +52,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "THE JOURNAL OF THE AMERICAN DENTAL ASSOCIATION / ED.: ROGER H. SCHOLLE" ],

--- a/src/test/resources/output/json/00167/TT001671747.json
+++ b/src/test/resources/output/json/00167/TT001671747.json
@@ -145,7 +145,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/Map",

--- a/src/test/resources/output/json/00172/TT001726537.json
+++ b/src/test/resources/output/json/00172/TT001726537.json
@@ -61,11 +61,11 @@
     "label" : "Französisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   }, {
-    "id" : "http://rdvocab.info/termList/prodManuscript/1002",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/prodManuscript/1002",
+    "label" : "http://rdaregistry.info/termList"
   } ],
   "note" : [ "Streitschrift gegen Dupré, ...: Le Jesuite Secularisé" ],
   "publication" : [ {

--- a/src/test/resources/output/json/00189/HT001898812.json
+++ b/src/test/resources/output/json/00189/HT001898812.json
@@ -303,7 +303,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/00223/TT002234042.json
+++ b/src/test/resources/output/json/00223/TT002234042.json
@@ -69,10 +69,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/00223/TT002234459.json
+++ b/src/test/resources/output/json/00223/TT002234459.json
@@ -81,13 +81,13 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
     "id" : "http://purl.org/ontology/bibo/Map",
     "label" : "Karte"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "sameAs" : [ {

--- a/src/test/resources/output/json/00223/TT002234858.json
+++ b/src/test/resources/output/json/00223/TT002234858.json
@@ -71,10 +71,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "note" : [ "Siehe: http://www.stk.rlp.de" ],

--- a/src/test/resources/output/json/00261/HT002619538.json
+++ b/src/test/resources/output/json/00261/HT002619538.json
@@ -109,7 +109,7 @@
     "label" : "Russisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/00301/CT003012479.json
+++ b/src/test/resources/output/json/00301/CT003012479.json
@@ -193,10 +193,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzufÃ¼hren ; Abonnement suspendu ; eine ganz neue groÃe komische Oper in 2 AufzÃ¼gen" ],

--- a/src/test/resources/output/json/00305/TT003059252.json
+++ b/src/test/resources/output/json/00305/TT003059252.json
@@ -58,14 +58,14 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
+  }, {
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+    "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
-    "label" : "Print"
   } ],
   "note" : [ "Engl. Original mit dt. Untertiteln" ],
   "otherTitleInformation" : [ "Magical Mystery Tour" ],

--- a/src/test/resources/output/json/00305/TT003059252_contAndCrea.json
+++ b/src/test/resources/output/json/00305/TT003059252_contAndCrea.json
@@ -58,14 +58,14 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
+  }, {
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+    "label" : "Print"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
-    "label" : "Print"
   } ],
   "note" : [ "Engl. Original mit dt. Untertiteln" ],
   "otherTitleInformation" : [ "Magical Mystery Tour" ],

--- a/src/test/resources/output/json/00316/HT003160768.json
+++ b/src/test/resources/output/json/00316/HT003160768.json
@@ -116,7 +116,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/00328/TT003280170.json
+++ b/src/test/resources/output/json/00328/TT003280170.json
@@ -29,7 +29,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/00353/HT003536695.json
+++ b/src/test/resources/output/json/00353/HT003536695.json
@@ -82,7 +82,7 @@
     "label" : "Latein"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Henrici Regii Ultrajectini Fundamenta physices" ],

--- a/src/test/resources/output/json/00626/HT006266886.json
+++ b/src/test/resources/output/json/00626/HT006266886.json
@@ -105,8 +105,8 @@
     "label" : "Italienisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"

--- a/src/test/resources/output/json/00669/HT006698544.json
+++ b/src/test/resources/output/json/00669/HT006698544.json
@@ -65,7 +65,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "mit besonderer Rücksicht auf deutsche Auswanderung und die physischen Verhältnisse des Landes ; mit einem naturwissenschaftlichen Anhange und einer topographisch-geognostisschen Karte von Texas" ],

--- a/src/test/resources/output/json/00971/HT009719670.json
+++ b/src/test/resources/output/json/00971/HT009719670.json
@@ -70,11 +70,11 @@
     "label" : "Französisch"
   } ],
   "medium" : [ {
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
+    "label" : "Print"
+  }, {
     "id" : "http://iflastandards.info/ns/isbd/terms/mediatype/T1008",
     "label" : "http://iflastandards.info/ns"
-  }, {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
-    "label" : "Print"
   } ],
   "otherTitleInformation" : [ "extraits de films de Eric Rohmer" ],
   "publication" : [ {

--- a/src/test/resources/output/json/00999/HT009993506.json
+++ b/src/test/resources/output/json/00999/HT009993506.json
@@ -1,20 +1,20 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Hinrichs, Fritz",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Sankt Sebastianus-Schützenbruderschaft <Reusrath>",
       "type" : [ "CorporateBody" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
@@ -69,7 +69,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01066/HT010662586.json
+++ b/src/test/resources/output/json/01066/HT010662586.json
@@ -41,7 +41,7 @@
     "label" : "hbz Verbundkatalog"
   },
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01072/HT010726584.json
+++ b/src/test/resources/output/json/01072/HT010726584.json
@@ -462,10 +462,10 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases" ],

--- a/src/test/resources/output/json/01223/HT012237361.json
+++ b/src/test/resources/output/json/01223/HT012237361.json
@@ -46,7 +46,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz" ],

--- a/src/test/resources/output/json/01289/HT012895751.json
+++ b/src/test/resources/output/json/01289/HT012895751.json
@@ -46,7 +46,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Informationen für Bürger, Neubürger & Gäste" ],

--- a/src/test/resources/output/json/01292/HT012926727.json
+++ b/src/test/resources/output/json/01292/HT012926727.json
@@ -552,7 +552,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "technische, wirtschaftliche und rechtliche Grundlagen" ],

--- a/src/test/resources/output/json/01298/HT012989088.json
+++ b/src/test/resources/output/json/01298/HT012989088.json
@@ -45,10 +45,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01307/HT013077595.json
+++ b/src/test/resources/output/json/01307/HT013077595.json
@@ -102,7 +102,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01330/HT013304490.json
+++ b/src/test/resources/output/json/01330/HT013304490.json
@@ -65,7 +65,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "oclcnum" : [ "635743319" ],

--- a/src/test/resources/output/json/01357/HT013577568.json
+++ b/src/test/resources/output/json/01357/HT013577568.json
@@ -42,7 +42,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01379/HT013798403.json
+++ b/src/test/resources/output/json/01379/HT013798403.json
@@ -58,7 +58,7 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01392/HT013925945.json
+++ b/src/test/resources/output/json/01392/HT013925945.json
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01401/HT014015351.json
+++ b/src/test/resources/output/json/01401/HT014015351.json
@@ -184,7 +184,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Praktiken des Symbolischen ; [Festschrift für Ludwig Jäger zum 60. Geburtstag]" ],

--- a/src/test/resources/output/json/01421/HT014215912.json
+++ b/src/test/resources/output/json/01421/HT014215912.json
@@ -42,7 +42,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01431/HT014319164.json
+++ b/src/test/resources/output/json/01431/HT014319164.json
@@ -77,7 +77,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01468/HT014681992.json
+++ b/src/test/resources/output/json/01468/HT014681992.json
@@ -63,7 +63,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01499/HT014997977.json
+++ b/src/test/resources/output/json/01499/HT014997977.json
@@ -70,10 +70,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "Leitfaden für den Geschäftsbereich des Landesbetriebes Straßen und Verkehr" ],

--- a/src/test/resources/output/json/01508/HT015082724.json
+++ b/src/test/resources/output/json/01508/HT015082724.json
@@ -38,7 +38,7 @@
     "label" : "Niederländisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01518/HT015183529.json
+++ b/src/test/resources/output/json/01518/HT015183529.json
@@ -71,7 +71,7 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01541/HT015414894.json
+++ b/src/test/resources/output/json/01541/HT015414894.json
@@ -74,7 +74,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Internationale Krisenkommunikation - eine Herausforderung im 21. Jahrhundert" ],

--- a/src/test/resources/output/json/01544/HT015440386.json
+++ b/src/test/resources/output/json/01544/HT015440386.json
@@ -60,7 +60,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01545/HT015455455.json
+++ b/src/test/resources/output/json/01545/HT015455455.json
@@ -65,7 +65,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Rivalen bis zur Fusion ; die frühen Jahre des Ferdinand Porsche" ],

--- a/src/test/resources/output/json/01586/HT015865114.json
+++ b/src/test/resources/output/json/01586/HT015865114.json
@@ -95,7 +95,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "die Welt nach 1945" ],

--- a/src/test/resources/output/json/01589/HT015891797.json
+++ b/src/test/resources/output/json/01589/HT015891797.json
@@ -211,7 +211,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01589/HT015894164.json
+++ b/src/test/resources/output/json/01589/HT015894164.json
@@ -369,10 +369,10 @@
     "label" : "Französisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01613/HT016135351.json
+++ b/src/test/resources/output/json/01613/HT016135351.json
@@ -51,7 +51,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01638/HT016382441.json
+++ b/src/test/resources/output/json/01638/HT016382441.json
@@ -334,7 +334,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles für Ihr Rendezvous mit dem Pinguin]" ],

--- a/src/test/resources/output/json/01654/HT016545462.json
+++ b/src/test/resources/output/json/01654/HT016545462.json
@@ -21,7 +21,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01660/HT016604323.json
+++ b/src/test/resources/output/json/01660/HT016604323.json
@@ -62,7 +62,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01661/HT016618741.json
+++ b/src/test/resources/output/json/01661/HT016618741.json
@@ -54,10 +54,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01715/HT017150239.json
+++ b/src/test/resources/output/json/01715/HT017150239.json
@@ -44,7 +44,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01741/HT017411546.json
+++ b/src/test/resources/output/json/01741/HT017411546.json
@@ -114,10 +114,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "nwbibspatial" : [ {
@@ -142,10 +142,10 @@
     "id" : "http://ld.zdb-services.de/resource/2685248-2",
     "label" : "http://ld.zdb-services.de/resource"
   } ],
-  "secondaryPublication" : [ {
+  "secondaryPublication" : {
     "description" : [ "Münster : Universitäts- und Landesbibliothek, 2012. (Digitale Sammlungen der Universitäts- und Landesbibliothek Münster)", "Digitalisierte Ausg." ],
     "startDate" : "2012"
-  } ],
+  },
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
     "label" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092"

--- a/src/test/resources/output/json/01743/HT017437638.json
+++ b/src/test/resources/output/json/01743/HT017437638.json
@@ -52,10 +52,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01747/HT017472134.json
+++ b/src/test/resources/output/json/01747/HT017472134.json
@@ -44,7 +44,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01748/HT017480009.json
+++ b/src/test/resources/output/json/01748/HT017480009.json
@@ -67,10 +67,10 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01752/HT017529028.json
+++ b/src/test/resources/output/json/01752/HT017529028.json
@@ -93,7 +93,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Studie über Johannes vom Kreuz" ],

--- a/src/test/resources/output/json/01813/HT018131501.json
+++ b/src/test/resources/output/json/01813/HT018131501.json
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01818/HT018187026.json
+++ b/src/test/resources/output/json/01818/HT018187026.json
@@ -58,7 +58,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01823/HT018239864.json
+++ b/src/test/resources/output/json/01823/HT018239864.json
@@ -166,7 +166,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01829/HT018290299.json
+++ b/src/test/resources/output/json/01829/HT018290299.json
@@ -138,7 +138,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01829/HT018295975.json
+++ b/src/test/resources/output/json/01829/HT018295975.json
@@ -96,7 +96,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Bonn - Koblenz - Weimar - Meiningen ; Festschrift für Johannes Mötsch zum 65. Geburtstag" ],

--- a/src/test/resources/output/json/01831/HT018312899.json
+++ b/src/test/resources/output/json/01831/HT018312899.json
@@ -43,7 +43,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01845/HT018454638.json
+++ b/src/test/resources/output/json/01845/HT018454638.json
@@ -90,7 +90,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01846/HT018468645.json
+++ b/src/test/resources/output/json/01846/HT018468645.json
@@ -73,10 +73,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01858/HT018585406.json
+++ b/src/test/resources/output/json/01858/HT018585406.json
@@ -75,10 +75,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01861/HT018612706.json
+++ b/src/test/resources/output/json/01861/HT018612706.json
@@ -143,7 +143,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01861/HT018617137.json
+++ b/src/test/resources/output/json/01861/HT018617137.json
@@ -56,10 +56,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "nwbibspatial" : [ {

--- a/src/test/resources/output/json/01870/HT018700720.json
+++ b/src/test/resources/output/json/01870/HT018700720.json
@@ -113,10 +113,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "note" : [ "Literaturangaben" ],

--- a/src/test/resources/output/json/01872/HT018726005.json
+++ b/src/test/resources/output/json/01872/HT018726005.json
@@ -51,7 +51,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01877/HT018770176.json
+++ b/src/test/resources/output/json/01877/HT018770176.json
@@ -73,7 +73,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "zugleich ein Beitrag zur Strafzumessungsrelevanz des Vor- und Nachtatverhaltens" ],

--- a/src/test/resources/output/json/01877/HT018771475.json
+++ b/src/test/resources/output/json/01877/HT018771475.json
@@ -50,7 +50,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01877/HT018779822.json
+++ b/src/test/resources/output/json/01877/HT018779822.json
@@ -45,7 +45,7 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01878/HT018786244.json
+++ b/src/test/resources/output/json/01878/HT018786244.json
@@ -129,7 +129,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "otherTitleInformation" : [ "Subjektentwicklung zwischen Nähe und Distanz" ],

--- a/src/test/resources/output/json/01880/HT018801101.json
+++ b/src/test/resources/output/json/01880/HT018801101.json
@@ -88,16 +88,16 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
-    "label" : "Datenträger"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
+    "label" : "Datenträger"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01889/HT018895767.json
+++ b/src/test/resources/output/json/01889/HT018895767.json
@@ -90,10 +90,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "der Schulstreit in Rheinhessen und seine Folgen" ],

--- a/src/test/resources/output/json/01890/HT018907266.json
+++ b/src/test/resources/output/json/01890/HT018907266.json
@@ -104,16 +104,16 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
-    "label" : "Datenträger"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1050",
+    "label" : "http://rdaregistry.info/termList"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1050",
-    "label" : "http://rdvocab.info/termList"
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
+    "label" : "Datenträger"
   }, {
     "id" : "http://purl.org/ontology/bibo/AudioVisualDocument",
     "label" : "http://purl.org/ontology"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/01892/HT018924091.json
+++ b/src/test/resources/output/json/01892/HT018924091.json
@@ -53,7 +53,7 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "nwbibsubject" : [ {

--- a/src/test/resources/output/json/01893/HT018939763.json
+++ b/src/test/resources/output/json/01893/HT018939763.json
@@ -68,10 +68,10 @@
     "label" : "http://id.loc.gov/vocabulary"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "otherTitleInformation" : [ "língua(s) e história(s)" ],

--- a/src/test/resources/output/json/01899/HT018998891.json
+++ b/src/test/resources/output/json/01899/HT018998891.json
@@ -53,7 +53,7 @@
     "label" : "Latein"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDAproductionMethod/#1010",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
     "label" : "Print"
   } ],
   "oclcnum" : [ "VD16 S 9000" ],

--- a/src/test/resources/output/json/01901/HT019011249.json
+++ b/src/test/resources/output/json/01901/HT019011249.json
@@ -72,10 +72,10 @@
     "label" : "Englisch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/output/json/05040/TT050409948.json
+++ b/src/test/resources/output/json/05040/TT050409948.json
@@ -1,20 +1,20 @@
 {
   "@context" : "http://lobid.org/context/lobid-resources.json",
   "contribution" : [ {
-    "agent" : [ {
+    "agent" : {
       "label" : "Irlenbusch, Lars",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/ctb",
       "label" : "Mitwirkende"
     } ],
     "type" : [ "Contribution" ]
   }, {
-    "agent" : [ {
+    "agent" : {
       "label" : "Siekmann, Holger",
       "type" : [ "Person" ]
-    } ],
+    },
     "role" : [ {
       "id" : "http://id.loc.gov/vocabulary/relators/cre",
       "label" : "Autor/in"
@@ -49,10 +49,10 @@
     "label" : "Deutsch"
   } ],
   "medium" : [ {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1010",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1010",
     "label" : "Datenträger"
   }, {
-    "id" : "http://rdvocab.info/termList/RDACarrierType/1018",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018",
     "label" : "Online-Ressource"
   } ],
   "publication" : [ {

--- a/src/test/resources/reverseTest/output/nt/00000/BT000002852.nt
+++ b/src/test/resources/reverseTest/output/nt/00000/BT000002852.nt
@@ -24,7 +24,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000002852#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/BT000002852#!> <http://iflastandards.info/ns/isbd/elements/P1053> "46 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/elements/1.1/coverage> "Freudenberg <Siegen-Wittgenstein>"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/terms/title> "Stadt Freudenberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/4018466-3"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -51,4 +51,4 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000002852#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DBT000002852> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s240000> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00000/BT000003404.nt
+++ b/src/test/resources/reverseTest/output/nt/00000/BT000003404.nt
@@ -36,7 +36,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/BT000100437#!> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/dc/terms/title> "Deutschland, 2: Nordrhein-Westfalen, Niedersachsen-S\u00FCd"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/lobid/lv#hbzID> "BT000003404"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -71,4 +71,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://purl.org/lobid/nwbib#s126000> <http://www.w3.org/2000/01/rdf-schema#label> "Karten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n01> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/ontology/bibo/Map> <http://www.w3.org/2000/01/rdf-schema#label> "Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00000/HT000009600.nt
+++ b/src/test/resources/reverseTest/output/nt/00000/HT000009600.nt
@@ -318,7 +318,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT000009600> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000009600#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/dc/terms/title> "Der Angestellte Hamburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000009600#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/37043-5"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -388,5 +388,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT006886479#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007527436#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012299746#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://worldcat.org/oclc/263589870> <http://www.w3.org/2000/01/rdf-schema#label> "http://worldcat.org/oclc"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00004/BT000040377.nt
+++ b/src/test/resources/reverseTest/output/nt/00004/BT000040377.nt
@@ -28,7 +28,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/elements/1.1/coverage> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/bibliographicCitation> "Rheine gestern, heute, morgen. - 11 (1983), S. 26-38 : Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT003759287#!> .
-<http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/title> "Die Vogelwelt der Stadt Rheine."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT003759287#!> .
@@ -48,4 +48,4 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT003759287#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s584060> <http://www.w3.org/2000/01/rdf-schema#label> "Tierschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00004/BT000041593.nt
+++ b/src/test/resources/reverseTest/output/nt/00004/BT000041593.nt
@@ -16,7 +16,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/bibliographicCitation> "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT007751353#!> .
-<http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/title> "Das Portrait einer Region: Kreis Coesfeld."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT007751353#!> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/10880724X"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -34,4 +34,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s543000> <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaftsstruktur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n97> <http://www.w3.org/2000/01/rdf-schema#label> "Kreise"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00006/BT000067443.nt
+++ b/src/test/resources/reverseTest/output/nt/00006/BT000067443.nt
@@ -16,7 +16,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/bibliographicCitation> "Kiebitz. - 6 (1986), S. 29-36, S. 63-67"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT006990419#!> .
-<http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/title> "Bestandsaufnahme der Amphibien im Raum Coesfeld-Billerbeck"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT006990419#!> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118033948"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -36,4 +36,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s163060> <http://www.w3.org/2000/01/rdf-schema#label> "Lurche"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n97> <http://www.w3.org/2000/01/rdf-schema#label> "Kreise"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00010/BT000103077.nt
+++ b/src/test/resources/reverseTest/output/nt/00010/BT000103077.nt
@@ -25,7 +25,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/bibliographicCitation> "Vom Kohlenpott zu Deutschlands \"starkem St\u00FCck\".; von J\u00FCrgen Reulecke; 1990; S. 49-76 ; graph. Darst., 1 Tab."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/von> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/title> "Von der Dorfschule zum Schulsystem"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/von> .
@@ -46,4 +46,4 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/von> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s783000> <http://www.w3.org/2000/01/rdf-schema#label> "Schulgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00011/BT000110055.nt
+++ b/src/test/resources/reverseTest/output/nt/00011/BT000110055.nt
@@ -26,7 +26,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000110055#!> <http://bibframe.org/vocab/contribution> _:b4 .
 <http://lobid.org/resources/BT000110055#!> <http://iflastandards.info/ns/isbd/elements/P1053> "28 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/elements/1.1/coverage> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/dc/terms/title> "Kall im Naturpark Nordeifel"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#contributorOrder> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -48,4 +48,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s102000> <http://www.w3.org/2000/01/rdf-schema#label> "Landesbeschreibungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s582000> <http://www.w3.org/2000/01/rdf-schema#label> "Umweltschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00012/BT000128754.nt
+++ b/src/test/resources/reverseTest/output/nt/00012/BT000128754.nt
@@ -39,7 +39,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/abstract> "Erinnerungen an d. 1. FC K\u00F6ln u. Borussia M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/bibliographicCitation> "Nach dem Spiel ist vor dem Spiel : die wunderbare Welt des Fu\u00DFballs / Wolfgang Frank (Hg.); Orig.-Ausg.; 1996; S. 101-[108]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT007138775#!> .
-<http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/title> "Alle B\u00F6cke bei\u00DFen oder in Feindschaft fest"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT007138775#!> .
@@ -68,4 +68,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT007138775#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s736050> <http://www.w3.org/2000/01/rdf-schema#label> "Sportvereine"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00016/BT000168595.nt
+++ b/src/test/resources/reverseTest/output/nt/00016/BT000168595.nt
@@ -43,7 +43,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/BT000168595> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/BT000168595#!> <http://iflastandards.info/ns/isbd/elements/P1053> "42 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/title> "Frauen, Kultur, Politik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/5265186-1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -77,4 +77,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://purl.org/lobid/nwbib#s724040> <http://www.w3.org/2000/01/rdf-schema#label> "Frauen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s731000> <http://www.w3.org/2000/01/rdf-schema#label> "Kulturpolitik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n01> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00029/HT000290078.nt
+++ b/src/test/resources/reverseTest/output/nt/00029/HT000290078.nt
@@ -35,7 +35,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT000290078> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT000290078#!> <http://iflastandards.info/ns/isbd/elements/P1053> "X, 99 S. : GRAPH. DARST."^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT000290078#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT000290078#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/dc/terms/title> "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER- ZEHN- BIS FUENFZEHNJAEHRIGE"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/174737203"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/lobid/lv#hbzID> "HT000290078"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -50,4 +50,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT000290078#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000290078> .
 <http://lobid.org/resources/HT000290078#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT000290078> .
 <http://lobid.org/resources/HT000290078#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT000290078> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00121/TT001210514.nt
+++ b/src/test/resources/reverseTest/output/nt/00121/TT001210514.nt
@@ -39,8 +39,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001210514#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://purl.org/library/BrailleBook> .
-<http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
-<http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/title> "Mein Kampf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118551655"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/lobid/lv#hbzID> "TT001210514"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -55,5 +54,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001210514#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001210514> .
 <http://lobid.org/resources/TT001210514#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001210514> .
 <http://purl.org/library/BrailleBook> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/library"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00123/TT001230001.nt
+++ b/src/test/resources/reverseTest/output/nt/00123/TT001230001.nt
@@ -104,7 +104,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001230001#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[8] Bl., 414, [1] S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/TT001197763#!> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/lat> .
-<http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1020> .
+<http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1020> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/dc/terms/title> "Reliqua librorum Friderici II. ... de arte venandi cum avibus"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118535765 | http://d-nb.info/gnd/118577018 | http://d-nb.info/gnd/118637649"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://purl.org/lobid/lv#hbzID> "TT001230001"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -121,4 +121,4 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001230001#!> <http://www.w3.org/2004/02/skos/core#note> "Vorlageform des Erscheinungsvermerks: Avgvstae Vindelicorvm ... Apud Ioannem Praetorium, Anno M.D.XCVI ... - Mikrofiche. M\u00FCnchen : Saur, 1991. Mikrofiche-Nr. F2001-F2003 : 23x"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001230001> .
 <http://lobid.org/resources/TT001230001#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001230001> .
-<http://rdvocab.info/termList/RDACarrierType/1020> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1020> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00131/HT001310215.nt
+++ b/src/test/resources/reverseTest/output/nt/00131/HT001310215.nt
@@ -33,7 +33,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001310215> <http://purl.org/dc/terms/created> "19950206"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215#!> <http://bibframe.org/vocab/contribution> _:b3 .
-<http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/title> "JOURNAL"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/177572388 | http://d-nb.info/gnd/37460-X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/lobid/lv#hbzID> "HT001310215"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -45,4 +45,4 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001310215#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001310215> .
 <http://lobid.org/resources/HT001310215#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT001310215> .
 <http://lobid.org/resources/HT001310215#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT001310215> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00167/TT001671747.nt
+++ b/src/test/resources/reverseTest/output/nt/00167/TT001671747.nt
@@ -103,7 +103,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002808565#!> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/subject> _:b7 .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/dc/terms/title> "Geographisch-landeskundlicher Atlas von Westfalen, 3,5,1: Bev\u00F6lkerungsdichte der Gemeinden 1871 - 1987 und Ver\u00E4nderung 1818 - 1987"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/137082479 | http://d-nb.info/gnd/2056181-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -138,5 +138,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001671747#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001671747> .
 <http://lobid.org/resources/TT001671747#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001671747> .
 <http://purl.org/ontology/bibo/Map> <http://www.w3.org/2000/01/rdf-schema#label> "Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n710> <http://www.w3.org/2000/01/rdf-schema#label> "Geographie"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00172/TT001726537.nt
+++ b/src/test/resources/reverseTest/output/nt/00172/TT001726537.nt
@@ -41,8 +41,8 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001726537#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/TT001726537#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[2] Bl., 116 S. : Ill. (Kupfert.)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
-<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
-<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/prodManuscript/1002> .
+<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
+<http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/prodManuscript/1002> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/title> "Critique Du Jesuite Secularis\u00E9"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/115541802"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/lobid/lv#hbzID> "TT001726537"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -55,5 +55,5 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT001726537#!> <http://www.w3.org/2004/02/skos/core#note> "Streitschrift gegen Dupr\u00E9, ...: Le Jesuite Secularis\u00E9"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001726537> .
 <http://lobid.org/resources/TT001726537#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT001726537> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/prodManuscript/1002> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/prodManuscript/1002> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00189/HT001898812.nt
+++ b/src/test/resources/reverseTest/output/nt/00189/HT001898812.nt
@@ -187,7 +187,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001381485#!> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/pol> .
-<http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/subject> _:b7 .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=3362189&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/dc/terms/title> "Gro\u00DFw\u00F6rterbuch Polnisch-Deutsch, 2: O - \u017B"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -226,4 +226,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001898812> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT001898812> .
 <http://lobid.org/resources/HT001898812#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT001898812> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234042.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234042.nt
@@ -31,8 +31,8 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/hasVersion> <http://www.edoweb-rlp.de/resource/edoweb:1638076> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/hasVersion> <https://www.edoweb-rlp.de/resource/edoweb:1638076> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/title> "2. Nachtragshaushaltssatzung und 1. Nachtragshaushaltsplan 2001"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/lobid/lv#contributorOrder> "Lierschied"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -54,7 +54,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT002234042#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002234042> .
 <http://lobid.org/resources/TT002234042#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT002234042> .
 <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-1513> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-1513"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.edoweb-rlp.de/resource/edoweb:1638076> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.edoweb-rlp.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://www.edoweb-rlp.de/resource/edoweb:1638076> <http://www.w3.org/2000/01/rdf-schema#label> "https://www.edoweb-rlp.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234459.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234459.nt
@@ -62,8 +62,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/subject> _:b13 .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/title> "Jakobswege : der Lahn-Camino"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#contributorOrder> "Kranz, Heinrich | M\u00FCller, Guntram | Rhein-Lahn-Kreis | Wirtschaftsf\u00F6rderungs-Gesellschaft Rhein-Lahn"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -89,6 +89,6 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT002234459#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT002234459> .
 <http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/ontology/bibo/Map> <http://www.w3.org/2000/01/rdf-schema#label> "Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.rhein-lahn-info.de/jakobsweg/> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.rhein-lahn-info.de/jakobsweg"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234858.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234858.nt
@@ -37,8 +37,8 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6267588&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/hasVersion> <https://www.edoweb-rlp.de/resource/edoweb:49> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/subject> _:b2 .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/title> "Rheinland-Pfalz - Staatskanzlei"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2029758-0"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -59,6 +59,6 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT002234858#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002234858> .
 <http://lobid.org/resources/TT002234858#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT002234858> .
 <http://nbn-resolving.de/urn:nbn:de:hbz:929:01-8578> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-8578"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://www.edoweb-rlp.de/resource/edoweb:49> <http://www.w3.org/2000/01/rdf-schema#label> "https://www.edoweb-rlp.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00261/HT002619538.nt
+++ b/src/test/resources/reverseTest/output/nt/00261/HT002619538.nt
@@ -83,7 +83,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/rus> .
-<http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/dc/terms/title> "Annual bulletin of transport statistics for Europe and North America"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT002619538#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2023669-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -103,4 +103,4 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1257-9> .
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT002619538> .
 <http://lobid.org/resources/HT002619538#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT002619538> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00301/CT003012479.nt
+++ b/src/test/resources/reverseTest/output/nt/00301/CT003012479.nt
@@ -161,8 +161,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://bibframe.org/voca
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/isFormatOf> <http://lobid.org/resources/HT016511663#!> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT017290519#!> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/source> <http://lobid.org/resources/HT016511663#!> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/title> "Elise, Gr\u00C3\u00A4finn von Hillburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/119055716 | http://d-nb.info/gnd/123633206 | http://d-nb.info/gnd/116620153 | http://d-nb.info/gnd/141927135 | http://d-nb.info/gnd/142027901 | http://d-nb.info/gnd/14216075X | http://d-nb.info/gnd/118512536 | http://d-nb.info/gnd/1041277814 | http://d-nb.info/gnd/141834919 | http://d-nb.info/gnd/141889810 | http://d-nb.info/gnd/142061166 | http://d-nb.info/gnd/141891173 | http://d-nb.info/gnd/16068028-1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -184,5 +184,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://bibframe.org/voca
 <http://lobid.org/resources/HT016511663#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017290519#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00305/TT003059252.nt
+++ b/src/test/resources/reverseTest/output/nt/00305/TT003059252.nt
@@ -33,8 +33,8 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT003059252#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
-<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/dc/terms/title> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2005535-3 | http://d-nb.info/gnd/2005535-3"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/lobid/lv#hbzID> "TT003059252"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -49,5 +49,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT003059252#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003059252> .
 <http://lobid.org/resources/TT003059252#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT003059252> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/ontology"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00305/TT003059252_contAndCrea.nt
+++ b/src/test/resources/reverseTest/output/nt/00305/TT003059252_contAndCrea.nt
@@ -34,8 +34,8 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/dc/terms/title> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2005535-3 | http://d-nb.info/gnd/2005535-3"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/lobid/lv#hbzID> "TT003059252_contAndCrea"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -50,5 +50,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003059252_contAndCrea> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT003059252_contAndCrea> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/ontology"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00316/HT003160768.nt
+++ b/src/test/resources/reverseTest/output/nt/00316/HT003160768.nt
@@ -72,7 +72,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT003160768#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/elements/1.1/coverage> "M\u00FCnster <Westfalen, Bezirk>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/dc/terms/title> "Gebietsentwicklungsplan"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2019209-5"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -103,4 +103,4 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s572030> <http://www.w3.org/2000/01/rdf-schema#label> "Regionalplanung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n96> <http://www.w3.org/2000/01/rdf-schema#label> "Regierungsbezirke"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00328/TT003280170.nt
+++ b/src/test/resources/reverseTest/output/nt/00328/TT003280170.nt
@@ -14,7 +14,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT003280170#!> <http://iflastandards.info/ns/isbd/elements/P1053> "171 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001245500#!> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/dc/terms/title> "Festschrift zum 60. Geburtstag von Professor Dr. Ing. habil. Franz P\u00F6pel am 4. Oktober 1961"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/lobid/lv#hbzID> "TT003280170"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/lobid/lv#inSeries> _:b0 .
@@ -26,4 +26,4 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT003280170#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003280170> .
 <http://lobid.org/resources/TT003280170#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003280170> .
 <http://lobid.org/resources/TT003280170#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT003280170> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00353/HT003536695.nt
+++ b/src/test/resources/reverseTest/output/nt/00353/HT003536695.nt
@@ -62,7 +62,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT003536695#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[8] Bl., 306 S., [1] gef. Bl. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/hasVersion> <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/lat> .
-<http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/dc/terms/title> "Fundamenta physices"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/119026074"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/lobid/lv#fulltextOnline> <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> .
@@ -81,5 +81,5 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT003536695#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT003536695> .
 <http://lobid.org/resources/HT003536695#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT003536695> .
 <http://nbn-resolving.de/urn:nbn:de:bvb:12-bsb10057885-8> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:bvb:12-bsb10057885-8"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.mdz-nbn-resolving.de/urn"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00626/HT006266886.nt
+++ b/src/test/resources/reverseTest/output/nt/00626/HT006266886.nt
@@ -71,7 +71,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT006266886#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Videokassette (VHS, 93 Min.) : farb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/ita> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/dc/terms/title> "Il giardino dei Finzi-Contini"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118677942 | http://d-nb.info/gnd/118657496 | http://d-nb.info/gnd/143102893 | http://d-nb.info/gnd/141618302 | http://d-nb.info/gnd/141649429 | http://d-nb.info/gnd/120454874"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/lobid/lv#hbzID> "HT006266886"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -85,4 +85,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT006266886#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006266886> .
 <http://lobid.org/resources/HT006266886#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT006266886> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/ontology"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00669/HT006698544.nt
+++ b/src/test/resources/reverseTest/output/nt/00669/HT006698544.nt
@@ -54,7 +54,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT006698544#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT006698544#!> <http://iflastandards.info/ns/isbd/elements/P1053> "XIV, 464 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/hasVersion> <http://resolver.sub.uni-goettingen.de/purl?PPN236434969> .
-<http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/dc/terms/title> "Texas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/116583053"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -74,5 +74,5 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006698544> .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006698544> .
 <http://lobid.org/resources/HT006698544#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT006698544> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://resolver.sub.uni-goettingen.de/purl?PPN236434969> <http://www.w3.org/2000/01/rdf-schema#label> "http://resolver.sub.uni-goettingen.de/purl?PPN236434969"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00971/HT009719670.nt
+++ b/src/test/resources/reverseTest/output/nt/00971/HT009719670.nt
@@ -49,7 +49,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT009719670#!> <http://bibframe.org/vocab/contribution> _:b4 .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/medium> <http://iflastandards.info/ns/isbd/terms/mediatype/T1008> .
-<http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/title> "Le cin\u00E9ma de la vie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/172026644 | http://d-nb.info/gnd/133991210 | http://d-nb.info/gnd/11860225X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/lobid/lv#hbzID> "HT009719670"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -63,4 +63,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT009719670#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009719670> .
 <http://lobid.org/resources/HT009719670#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT009719670> .
 <http://lobid.org/resources/HT009719670#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT009719670> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00999/HT009993506.nt
+++ b/src/test/resources/reverseTest/output/nt/00999/HT009993506.nt
@@ -42,7 +42,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT009993506#!> <http://bibframe.org/vocab/contribution> _:b5 .
 <http://lobid.org/resources/HT009993506#!> <http://iflastandards.info/ns/isbd/elements/P1053> "56 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/title> "500 Jahre Bruderschaften Reusrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/lobid/lv#contributorOrder> "Hinrichs, Fritz | Sankt Sebastianus-Sch\u00FCtzenbruderschaft Reusrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/lobid/lv#hbzID> "HT009993506"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -55,4 +55,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT009993506#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009993506> .
 <http://lobid.org/resources/HT009993506#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT009993506> .
 <http://lobid.org/resources/HT009993506#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT009993506> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01066/HT010662586.nt
+++ b/src/test/resources/reverseTest/output/nt/01066/HT010662586.nt
@@ -27,7 +27,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT010662586> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT010662586#!> <http://iflastandards.info/ns/isbd/elements/P1053> "23 p."^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/title> "The Common man in the great Civil War"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118839055"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/lobid/lv#hbzID> "HT010662586"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -39,4 +39,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT010662586#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010662586> .
 <http://lobid.org/resources/HT010662586#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT010662586> .
 <http://lobid.org/resources/HT010662586#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010662586> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01072/HT010726584.nt
+++ b/src/test/resources/reverseTest/output/nt/01072/HT010726584.nt
@@ -259,8 +259,8 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/hasVersion> <http://search.ebscohost.com/> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/subject> _:b1 .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/dc/terms/title> "Physics of plasmas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010726584#!> <http://purl.org/lobid/lv#fulltextOnline> <http://search.ebscohost.com/> .
@@ -322,7 +322,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT010726584#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1472746-8> .
 <http://lobid.org/resources/HT010726584#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT010726584> .
 <http://lobid.org/resources/HT010726584#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT010726584> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://search.ebscohost.com/> <http://www.w3.org/2000/01/rdf-schema#label> "http://search.ebscohost.com/"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.bibliothek.uni-regensburg.de/ezeit/?1472746> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.bibliothek.uni-regensburg.de/ezeit"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01223/HT012237361.nt
+++ b/src/test/resources/reverseTest/output/nt/01223/HT012237361.nt
@@ -29,7 +29,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012237361> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012237361#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/title> "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz / L / 4 / 6"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/36467-8"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/lobid/lv#hbzID> "HT012237361"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -42,4 +42,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/590016-5> .
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012237361> .
 <http://lobid.org/resources/HT012237361#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012237361> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01289/HT012895751.nt
+++ b/src/test/resources/reverseTest/output/nt/01289/HT012895751.nt
@@ -37,7 +37,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012895751#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT012895751#!> <http://iflastandards.info/ns/isbd/elements/P1053> "76 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/title> "Mainz-Kinzig-Kreis"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2037247-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -56,6 +56,6 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012895751> .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012895751> .
 <http://lobid.org/resources/HT012895751#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012895751> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n140> <http://www.w3.org/2000/01/rdf-schema#label> "Pflichtexemplar Region Koblenz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n710> <http://www.w3.org/2000/01/rdf-schema#label> "Geographie"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01292/HT012926727.nt
+++ b/src/test/resources/reverseTest/output/nt/01292/HT012926727.nt
@@ -313,7 +313,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012926727#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT012926727#!> <http://iflastandards.info/ns/isbd/elements/P1053> "XIV, 514 S. : graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1533597&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/dc/terms/title> "Handbuch der Elektrizit\u00E4tswirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -397,4 +397,4 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012926727#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012926727> .
 <http://lobid.org/resources/HT012926727#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012926727> .
 <http://lobid.org/resources/HT012926727#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012926727> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01298/HT012989088.nt
+++ b/src/test/resources/reverseTest/output/nt/01298/HT012989088.nt
@@ -42,8 +42,8 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/hasVersion> <http://gso.gbv.de/DB=5.85/PPNSET?PPN=%2024428153X> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?2013112> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/subject> _:b1 .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/dc/terms/title> "EC tax review"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/lobid/lv#fulltextOnline> <http://gso.gbv.de/DB=5.85/PPNSET?PPN=%2024428153X> .
@@ -83,6 +83,6 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012989088#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2013112-4> .
 <http://lobid.org/resources/HT012989088#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012989088> .
 <http://lobid.org/resources/HT012989088#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT012989088> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.bibliothek.uni-regensburg.de/ezeit/?2013112> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.bibliothek.uni-regensburg.de/ezeit"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01307/HT013077595.nt
+++ b/src/test/resources/reverseTest/output/nt/01307/HT013077595.nt
@@ -84,7 +84,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld <Kreis>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/subject> _:b9 .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/dc/terms/title> "Geschichte hier"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/11079267X | http://d-nb.info/gnd/109490312 | http://d-nb.info/gnd/128755-2"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -133,4 +133,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://purl.org/lobid/nwbib#s240000> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s784080> <http://www.w3.org/2000/01/rdf-schema#label> "Unterricht"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n97> <http://www.w3.org/2000/01/rdf-schema#label> "Kreise"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01330/HT013304490.nt
+++ b/src/test/resources/reverseTest/output/nt/01330/HT013304490.nt
@@ -58,7 +58,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013304490> <http://purl.org/dc/terms/modified> "20130724"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013304490> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/subject> _:b1 .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/dc/terms/title> "D\u00E9cid\u00E9"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/lobid/lv#hbzID> "HT013304490"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -87,5 +87,5 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013304490#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013304490> .
 <http://lobid.org/resources/HT013304490#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013304490> .
 <http://lobid.org/resources/HT013304885#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://worldcat.org/oclc/635743319> <http://www.w3.org/2000/01/rdf-schema#label> "http://worldcat.org/oclc"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01357/HT013577568.nt
+++ b/src/test/resources/reverseTest/output/nt/01357/HT013577568.nt
@@ -55,7 +55,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/bibliographicCitation> "Kontinuit\u00E4t und Diskontinuit\u00E4t / hrsg. von Thomas Gr\u00FCnewald ... - Berlin [u.a.], 2003. - (Reallexikon der germanischen Altertumskunde : Erg\u00E4nzungsb\u00E4nde ; 35). - S. [266]-344 : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013538692#!> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/title> "Ubier, Chatten, Bataver"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT013538692#!> .
@@ -86,4 +86,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s226040> <http://www.w3.org/2000/01/rdf-schema#label> "Germanen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n03> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01379/HT013798403.nt
+++ b/src/test/resources/reverseTest/output/nt/01379/HT013798403.nt
@@ -33,7 +33,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013798403#!> <http://iflastandards.info/ns/isbd/elements/P1053> "56 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT004520034#!> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/dc/terms/title> "Do fixed-term contracts increase the long-term employment opportunities of the unemployment?"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/13017923X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/lobid/lv#hbzID> "HT013798403"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -48,4 +48,4 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013798403#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013798403> .
 <http://lobid.org/resources/HT013798403#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013798403> .
 <http://lobid.org/resources/HT013798403#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT013798403> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01392/HT013925945.nt
+++ b/src/test/resources/reverseTest/output/nt/01392/HT013925945.nt
@@ -33,7 +33,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/bibliographicCitation> "Heimatbl\u00E4tter. - 82 (2002), S. 149-152 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT006991655#!> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/terms/title> "Zur Kapellenrestaurierung in Schwarzenraben 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT006991655#!> .
@@ -59,4 +59,4 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s240000> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s844030> <http://www.w3.org/2000/01/rdf-schema#label> "Kirchenbau. Kirchenausstattung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01401/HT014015351.nt
+++ b/src/test/resources/reverseTest/output/nt/01401/HT014015351.nt
@@ -120,7 +120,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014015351#!> <http://bibframe.org/vocab/contribution> _:b4 .
 <http://lobid.org/resources/HT014015351#!> <http://iflastandards.info/ns/isbd/elements/P1053> "324 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/title> "Spuren, Lekt\u00FCren"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/129016713 | http://d-nb.info/gnd/136788548"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -149,4 +149,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014015351> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014015351> .
 <http://lobid.org/resources/HT014015351#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014015351> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01421/HT014215912.nt
+++ b/src/test/resources/reverseTest/output/nt/01421/HT014215912.nt
@@ -33,7 +33,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/bibliographicCitation> "Karl der Gro\u00DFe und Europa / hrsg. von der Schweizerischen Botschaft in der Bundesrepublik Deutschland ... - Frankfurt am Main [u.a.], 2004. - S. 67-86 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT014168843#!> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/title> "Karl der Gro\u00DFe und sein Bild"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT014168843#!> .
@@ -72,4 +72,4 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s240000> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n01> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01431/HT014319164.nt
+++ b/src/test/resources/reverseTest/output/nt/01431/HT014319164.nt
@@ -58,7 +58,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/elements/1.1/coverage> "Bad Honnef"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/elements/1.1/coverage> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/dc/terms/title> "Titus Reinarz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/133595935 | http://d-nb.info/gnd/159865794"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -87,7 +87,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014319164#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014319164> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s841070> <http://www.w3.org/2000/01/rdf-schema#label> "K\u00FCnstler"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n130> <http://www.w3.org/2000/01/rdf-schema#label> "Landeskunde Region Koblenz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n140> <http://www.w3.org/2000/01/rdf-schema#label> "Pflichtexemplar Region Koblenz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n500> <http://www.w3.org/2000/01/rdf-schema#label> "Bildende Kunst"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01468/HT014681992.nt
+++ b/src/test/resources/reverseTest/output/nt/01468/HT014681992.nt
@@ -39,7 +39,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014681992#!> <http://iflastandards.info/ns/isbd/elements/P1053> "[ca. 50 Bl.] : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/elements/1.1/coverage> "Neuss-Selikum"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/dc/terms/title> "Herzlich Willkommen zum Appeltaatefest 2005"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/6509781-6 | http://d-nb.info/gnd/5176874-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -64,4 +64,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s704090> <http://www.w3.org/2000/01/rdf-schema#label> "Vereine der Brauchtumspflege"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s734000> <http://www.w3.org/2000/01/rdf-schema#label> "Feiern und Feste"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01499/HT014997977.nt
+++ b/src/test/resources/reverseTest/output/nt/01499/HT014997977.nt
@@ -42,8 +42,8 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014997977#!> <http://iflastandards.info/ns/isbd/elements/P1053> "15, [14] S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/subject> _:b7 .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/title> "Leitfaden f\u00FCr die Behandlung von Ausbauasphalt und Stra\u00DFenaufbruch mit teer-/pechtypischen Bestandteilen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/3062366-2 | http://d-nb.info/gnd/10048424-4 | http://d-nb.info/gnd/2092393-4"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -65,6 +65,6 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014997977#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT014997977> .
 <http://lobid.org/resources/RPB> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/rpb#n574040> <http://www.w3.org/2000/01/rdf-schema#label> "Stra\u00DFenbau"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n940> <http://www.w3.org/2000/01/rdf-schema#label> "Nachrichten- und Verkehrswesen"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01508/HT015082724.nt
+++ b/src/test/resources/reverseTest/output/nt/01508/HT015082724.nt
@@ -40,7 +40,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/isPartOf> <http://ld.zdb-services.de/resource/208524-0> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001373475#!> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/nld> .
-<http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/dc/terms/title> "Tijdschrift voor geschiedenis, 119"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/lobid/lv#hbzID> "HT015082724"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -59,4 +59,4 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015082724> .
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015082724> .
 <http://lobid.org/resources/HT015082724#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015082724> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01518/HT015183529.nt
+++ b/src/test/resources/reverseTest/output/nt/01518/HT015183529.nt
@@ -49,7 +49,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015183529#!> <http://iflastandards.info/ns/isbd/elements/P1053> "LV, 225 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT004984061#!> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/dc/terms/title> "The great Gatsby"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118533592 | http://d-nb.info/gnd/119468476"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/lobid/lv#hbzID> "HT015183529"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -65,4 +65,4 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015183529#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015183529> .
 <http://lobid.org/resources/HT015183529#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015183529> .
 <http://lobid.org/resources/HT015183529#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015183529> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01541/HT015414894.nt
+++ b/src/test/resources/reverseTest/output/nt/01541/HT015414894.nt
@@ -39,7 +39,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/bibliographicCitation> "Medien und Terrorismus; Christian Schicha ... (Hg.); 2002; S. 80 - 93"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013384949#!> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/title> "Die Terrorkrise als Medienereignis?"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT013384949#!> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/122021878 | http://d-nb.info/gnd/186186193 | http://d-nb.info/gnd/11075851X"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -53,4 +53,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015414894#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015414894> .
 <http://lobid.org/resources/HT015414894#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015414894> .
 <http://lobid.org/resources/HT015414894#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015414894> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01544/HT015440386.nt
+++ b/src/test/resources/reverseTest/output/nt/01544/HT015440386.nt
@@ -47,7 +47,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015440386#!> <http://iflastandards.info/ns/isbd/elements/P1053> "181, VIII S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002091108#!> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/dc/terms/title> "Jago"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/111614597"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -93,4 +93,4 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015440386#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015440386> .
 <http://purl.org/lobid/nwbib#s841070> <http://www.w3.org/2000/01/rdf-schema#label> "K\u00FCnstler"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n01> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01545/HT015455455.nt
+++ b/src/test/resources/reverseTest/output/nt/01545/HT015455455.nt
@@ -106,7 +106,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015455455#!> <http://iflastandards.info/ns/isbd/elements/P1053> "291 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=2957975&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/subject> _:b9 .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/dc/terms/title> "Austro-Daimler und Steyr"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/124897274"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -140,5 +140,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015455455#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015455455> .
 <http://lobid.org/resources/HT015455455#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015455455> .
 <http://lobid.org/resources/HT015455455#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015455455> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n650> <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaft und Arbeit"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01586/HT015865114.nt
+++ b/src/test/resources/reverseTest/output/nt/01586/HT015865114.nt
@@ -64,7 +64,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015865114#!> <http://bibframe.org/vocab/contribution> _:b5 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013370531#!> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/dc/terms/title> "Von der Teilung zur Einheit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/105667129"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -94,7 +94,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015865114> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015865114> .
 <http://lobid.org/resources/HT015865114#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015865114> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n107> <http://www.w3.org/2000/01/rdf-schema#label> "Schulb\u00FCcher"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n120> <http://www.w3.org/2000/01/rdf-schema#label> "Erziehung, Bildung, Unterricht"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n139> <http://www.w3.org/2000/01/rdf-schema#label> "Belegexemplare Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01589/HT015891797.nt
+++ b/src/test/resources/reverseTest/output/nt/01589/HT015891797.nt
@@ -138,7 +138,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002786685#!> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT015845132#!> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/dc/terms/title> "Die letzten Lebensjahre, 1963 - 1967, 2: September 1965 - April 1967"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/11850066X | http://d-nb.info/gnd/109702662"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -170,5 +170,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015891797> .
 <http://lobid.org/resources/HT015891797#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015891797> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n610> <http://www.w3.org/2000/01/rdf-schema#label> "Politik"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01589/HT015894164.nt
+++ b/src/test/resources/reverseTest/output/nt/01589/HT015894164.nt
@@ -198,8 +198,8 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.1787/9789264273085-fr> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/isPartOf> _:b2 .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
-<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/dc/terms/title> "Examens en mati\u00E8re de coop\u00E9ration pour le d\u00E9veloppement : Danemark 1999"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/lobid/lv#contributorOrder> "Organisation de coop\u00E9ration et de d\u00E9veloppement \u00E9conomiques"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/lobid/lv#fulltextOnline> <http://dx.doi.org/10.1787/9789264273085-fr> .
@@ -240,5 +240,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015894164#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015894164> .
 <http://lobid.org/resources/HT015894164#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015894164> .
 <http://lobid.org/resources/HT015894164#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT015894164> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01613/HT016135351.nt
+++ b/src/test/resources/reverseTest/output/nt/01613/HT016135351.nt
@@ -38,7 +38,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016135351#!> <http://iflastandards.info/ns/isbd/elements/P1053> "32 gez. S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/elements/1.1/coverage> "Harsewinkel-Marienfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/dc/terms/title> "Lutter-Wasserm\u00FChle Roberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/186931808"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -61,4 +61,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016135351#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016135351> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s708029> <http://www.w3.org/2000/01/rdf-schema#label> "Sonstige Landwirtschaftliche Geb\u00E4ude. M\u00FChlen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
+++ b/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
@@ -190,7 +190,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/alternative> "Linux for dummies <dt.>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=3474380&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027722&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/title> "Linux f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -232,5 +232,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016382441> .
 <http://lobid.org/resources/HT016382441#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016382441> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n820> <http://www.w3.org/2000/01/rdf-schema#label> "Informatik, Kybernetik"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01654/HT016545462.nt
+++ b/src/test/resources/reverseTest/output/nt/01654/HT016545462.nt
@@ -31,7 +31,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016545462> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/elements/1.1/coverage> "Nordkirchen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/dc/terms/title> "Verzeichnis der Geb\u00E4ude und ihrer Eigent\u00FCmer auf dem Gebiet der Altgemeinde Nordkirchen 1805, 1900, 1955 und 2000"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/lobid/lv#hbzID> "HT016545462"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -50,4 +50,4 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s503050> <http://www.w3.org/2000/01/rdf-schema#label> "Einwohnerverzeichnisse"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s843060> <http://www.w3.org/2000/01/rdf-schema#label> "Wohnh\u00E4user"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01660/HT016604323.nt
+++ b/src/test/resources/reverseTest/output/nt/01660/HT016604323.nt
@@ -55,7 +55,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016604323> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://bibframe.org/vocab/contribution> _:b4 .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/title> "Bericht der Beschwerdekommission"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/16090142-X | http://d-nb.info/gnd/4065786-3"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -79,4 +79,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s534000> <http://www.w3.org/2000/01/rdf-schema#label> "Krankenversorgung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n05> <http://www.w3.org/2000/01/rdf-schema#label> "Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01661/HT016618741.nt
+++ b/src/test/resources/reverseTest/output/nt/01661/HT016618741.nt
@@ -26,8 +26,8 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016618741#!> <http://iflastandards.info/ns/isbd/elements/P1053> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/hasVersion> <http://deposit.ddb.de/cgi-bin/dokserv?idn=1^010809261> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/dc/terms/title> "Ver\u00E4nderungen in der Zellmorphologie und Zellzyklusverteilung unter dem Einfluss einer Paclitaxel (Taxol\u00AE) induzierten Wachstumsinhibition im Nierenzellkarzinom"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/143001299"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/lobid/lv#fulltextOnline> <http://deposit.ddb.de/cgi-bin/dokserv?idn=1^010809261> .
@@ -45,5 +45,5 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016618741#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016618741> .
 <http://lobid.org/resources/HT016618741#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT016618741> .
 <http://nbn-resolving.de/urn:nbn:de:hbz:061-20101201-135613-9> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:061-20101201-135613-9"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01715/HT017150239.nt
+++ b/src/test/resources/reverseTest/output/nt/01715/HT017150239.nt
@@ -26,7 +26,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/bibliographicCitation> "Westfalen; 88. 2010 (2012), S. 175-179"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001374559#!> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/title> "Situationsbericht Fachbereich Praktische Denkmalpflege"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT001374559#!> .
@@ -49,4 +49,4 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s844200> <http://www.w3.org/2000/01/rdf-schema#label> "Denkmalpflege. Denkmalschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n05> <http://www.w3.org/2000/01/rdf-schema#label> "Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01741/HT017411546.nt
+++ b/src/test/resources/reverseTest/output/nt/01741/HT017411546.nt
@@ -116,8 +116,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT017411546#!> <http://bibframe.org/vocab/contribution> _:b10 .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/subject> _:b11 .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/dc/terms/title> "Westf\u00E4lische Bibliographie zur Geschichte, Landeskunde und Volkskunde"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/2140069-6"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -165,5 +165,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://purl.org/lobid/nwbib#s101000> <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographien"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s102000> <http://www.w3.org/2000/01/rdf-schema#label> "Landesbeschreibungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n05> <http://www.w3.org/2000/01/rdf-schema#label> "Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01743/HT017437638.nt
+++ b/src/test/resources/reverseTest/output/nt/01743/HT017437638.nt
@@ -36,8 +36,8 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017437638#!> <http://bibframe.org/vocab/contribution> _:b3 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/hasVersion> <http://beck-online.beck.de/Default.aspx?vpath=bibdata%5Ckomm%5Cpewkokagbefrvo_1%5Ccont%5Cpewkokagbefrvo.htm&pos=0&hlwords=pewestorf%C3%90adrian%C3%90+adrian+%C3%90+pewestorf+#xhlhit> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/title> "Kurzarbeitergeld-BefristungsVO"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/133658104"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -62,5 +62,5 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017437638> .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017437638> .
 <http://lobid.org/resources/HT017437638#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017437638> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01747/HT017472134.nt
+++ b/src/test/resources/reverseTest/output/nt/01747/HT017472134.nt
@@ -42,7 +42,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/bibliographicCitation> "Nachrichten aus der Netter Geschichte; 2 (2011), S. 18-35 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT016593925#!> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/title> "Der Name Dorhoff in Urkunden im Wandel der Zeiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT016593925#!> .
@@ -63,4 +63,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017472134#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017472134> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s207020> <http://www.w3.org/2000/01/rdf-schema#label> "Einzelne Familien"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01748/HT017480009.nt
+++ b/src/test/resources/reverseTest/output/nt/01748/HT017480009.nt
@@ -32,8 +32,8 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.4126/38m-004826540> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/dc/terms/title> "Immunohistochemical localization of complement regulatory proteins in the human retina"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1028627270"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -56,5 +56,5 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017480009#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017480009> .
 <http://lobid.org/resources/HT017480009#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017480009> .
 <http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01752/HT017529028.nt
+++ b/src/test/resources/reverseTest/output/nt/01752/HT017529028.nt
@@ -84,7 +84,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017529028#!> <http://iflastandards.info/ns/isbd/elements/P1053> "XXXVII, 265 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT012848847#!> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/dc/terms/title> "Edith-Stein-Gesamtausgabe, 18: Kreuzeswissenschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118617230 | http://d-nb.info/gnd/12226861X | http://d-nb.info/gnd/120534983"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -135,4 +135,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017529028#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017529028> .
 <http://lobid.org/resources/HT017529028#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT017529028> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01813/HT018131501.nt
+++ b/src/test/resources/reverseTest/output/nt/01813/HT018131501.nt
@@ -33,7 +33,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/bibliographicCitation> "Der Gie\u00DFerjunge; 34 (2014),1, S. 14-15"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT007072426#!> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/title> "D\u00FCsseldorf und das bergische Territorium"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT007072426#!> .
@@ -84,4 +84,4 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s240000> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n46> <http://www.w3.org/2000/01/rdf-schema#label> "Grafschaft, Herzogtum, Gro\u00DFherzogtum Berg"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01818/HT018187026.nt
+++ b/src/test/resources/reverseTest/output/nt/01818/HT018187026.nt
@@ -30,7 +30,7 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018187026> <http://purl.org/dc/terms/modified> "20140610"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/dc/terms/title> "Gesundheit und Pflege - aus der Hochschule in die Praxis"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/lobid/lv#hbzID> "HT018187026"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/ontology/bibo/issn> "21955131"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -43,4 +43,4 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018187026#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018187026> .
 <http://lobid.org/resources/HT018187026#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018187026> .
 <http://lobid.org/resources/HT018187026#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018187026> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01823/HT018239864.nt
+++ b/src/test/resources/reverseTest/output/nt/01823/HT018239864.nt
@@ -108,7 +108,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4584991&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT016777884#!> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764417&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/dc/terms/title> "Irmgard Keun: Zeit und Zitat"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -151,5 +151,5 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018239864#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018239864> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s768030> <http://www.w3.org/2000/01/rdf-schema#label> "Einzelne Autoren (Sekund\u00E4rliteratur)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n200> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsche Sprache und Literatur"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01829/HT018290299.nt
+++ b/src/test/resources/reverseTest/output/nt/01829/HT018290299.nt
@@ -98,7 +98,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT006514951#!> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT017500108#!> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6261756&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/dc/terms/title> "\"Uns verschleppten sie nach K\u00C3\u00B6ln ...\""^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -174,4 +174,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018290299#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018290299> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s240000> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01829/HT018295975.nt
+++ b/src/test/resources/reverseTest/output/nt/01829/HT018295975.nt
@@ -81,7 +81,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018295975#!> <http://iflastandards.info/ns/isbd/elements/P1053> "596 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4685554&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852707&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/dc/terms/title> "Th\u00FCringische und rheinische Forschungen"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -118,7 +118,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018295975> .
 <http://lobid.org/resources/HT018295975#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018295975> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n130> <http://www.w3.org/2000/01/rdf-schema#label> "Landeskunde Region Koblenz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n330> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n560> <http://www.w3.org/2000/01/rdf-schema#label> "Buch, Bibl., Information und Dok."^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01831/HT018312899.nt
+++ b/src/test/resources/reverseTest/output/nt/01831/HT018312899.nt
@@ -35,7 +35,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/bibliographicCitation> "Grabbe-Jahrbuch ...; 32. 2013 (2014), S. 80-95"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT002156174#!> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/title> "Theatraler Exzess und \u0090\u0090\u0090,gespielte\u2018 Sinnlosigkeit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT002156174#!> .
@@ -62,4 +62,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s768030> <http://www.w3.org/2000/01/rdf-schema#label> "Einzelne Autoren (Sekund\u00E4rliteratur)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s769030> <http://www.w3.org/2000/01/rdf-schema#label> "Drama"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01845/HT018454638.nt
+++ b/src/test/resources/reverseTest/output/nt/01845/HT018454638.nt
@@ -69,7 +69,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018454638#!> <http://iflastandards.info/ns/isbd/elements/P1053> "122 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/elements/1.1/coverage> "Bergisch Gladbach- Herkenrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/dc/terms/title> "Gottes Haus - Tor des Himmels"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/172845785 | http://d-nb.info/gnd/1060772442 | http://d-nb.info/gnd/2175350-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -98,4 +98,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018454638#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018454638> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s611030> <http://www.w3.org/2000/01/rdf-schema#label> "Kirchengemeinden"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01846/HT018468645.nt
+++ b/src/test/resources/reverseTest/output/nt/01846/HT018468645.nt
@@ -61,8 +61,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/hasVersion> <http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/dc/terms/title> "\"Arisierung\" und \"Wiedergutmachung\" in deutschen St\u00C3\u00A4dten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/128495626 | http://d-nb.info/gnd/122511158"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -118,7 +118,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018468645#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018468645> .
 <http://lobid.org/resources/HT018468645#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018468645> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n330> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n380> <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschafts- und Sozialgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01858/HT018585406.nt
+++ b/src/test/resources/reverseTest/output/nt/01858/HT018585406.nt
@@ -53,8 +53,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018585406#!> <http://bibframe.org/vocab/contribution> _:b4 .
 <http://lobid.org/resources/HT018585406#!> <http://iflastandards.info/ns/isbd/elements/P1053> "45 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/subject> _:b7 .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/dc/terms/title> "Endbericht Workshop Der Oberrhein als Europ\u00E4ische Metropolregion"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/121842118 | http://d-nb.info/gnd/16080300-7 | http://d-nb.info/gnd/5079636-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -84,8 +84,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018585406#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018585406> .
 <http://lobid.org/resources/RPB> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/rpb#n572020> <http://www.w3.org/2000/01/rdf-schema#label> "Landesplanung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n106> <http://www.w3.org/2000/01/rdf-schema#label> "Amtsdruckschriften Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n131> <http://www.w3.org/2000/01/rdf-schema#label> "Landeskunde Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n740> <http://www.w3.org/2000/01/rdf-schema#label> "Umweltschutz, Raumordn., Landschaft"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01861/HT018612706.nt
+++ b/src/test/resources/reverseTest/output/nt/01861/HT018612706.nt
@@ -134,7 +134,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/description> <http://deposit.d-nb.de/cgi-bin/dokserv?id=5203696&prov=M&dok_var=1&dok_ext=htm> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT014679525#!> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/subject> _:b14 .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/dc/terms/title> "Wie die Pop Art nach Deutschland kam"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1050748387 | http://d-nb.info/gnd/1069643262 | http://d-nb.info/gnd/10040152-1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -260,4 +260,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s841060> <http://www.w3.org/2000/01/rdf-schema#label> "Kunstausstellungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s842000> <http://www.w3.org/2000/01/rdf-schema#label> "Kunstgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01861/HT018617137.nt
+++ b/src/test/resources/reverseTest/output/nt/01861/HT018617137.nt
@@ -26,8 +26,8 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018617137#!> <http://iflastandards.info/ns/isbd/elements/P1053> "55 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/hasVersion> <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/dc/terms/title> "Nachhaltige Forschung an Fachhochschulen in NRW"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/lobid/lv#contributorOrder> "Helm, Eva Maria"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/lobid/lv#fulltextOnline> <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128> .
@@ -51,5 +51,5 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128> <http://www.w3.org/2000/01/rdf-schema#label> "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s796000> <http://www.w3.org/2000/01/rdf-schema#label> "Fachhochschulen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib-spatial#n01> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01870/HT018700720.nt
+++ b/src/test/resources/reverseTest/output/nt/01870/HT018700720.nt
@@ -71,8 +71,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT015550020#!> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/subject> _:b13 .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/dc/terms/title> "Die Hochaltrigen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/136371671 | http://d-nb.info/gnd/129961604 | Ottovay, Kathrin | http://d-nb.info/gnd/115325859 | http://d-nb.info/gnd/2006655-7"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -94,5 +94,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/2004/02/skos/core#note> "Literaturangaben"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018700720> .
 <http://lobid.org/resources/HT018700720#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018700720> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01872/HT018726005.nt
+++ b/src/test/resources/reverseTest/output/nt/01872/HT018726005.nt
@@ -27,7 +27,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/hasVersion> <http://www.bibliothek.uni-regensburg.de/ezeit/?2655603> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT013878511#!> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/title> "Eine Marke sucht ihren Platz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT013878511#!> .
@@ -49,5 +49,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018726005#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018726005> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s802080> <http://www.w3.org/2000/01/rdf-schema#label> "Schauspieler"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.bibliothek.uni-regensburg.de/ezeit/?2655603> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.bibliothek.uni-regensburg.de/ezeit"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018770176.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018770176.nt
@@ -43,7 +43,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018770176#!> <http://iflastandards.info/ns/isbd/elements/P1053> "276 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT001252640#!> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/tableOfContents> <http://d-nb.info/1076583180/04> .
 <http://lobid.org/resources/HT018770176#!> <http://purl.org/dc/terms/title> "Strafzumessungstatsachen zwischen Verbrechenslehre und Straftheorie"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -66,4 +66,4 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018770176> .
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018770176> .
 <http://lobid.org/resources/HT018770176#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018770176> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018771475.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018771475.nt
@@ -42,7 +42,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/elements/1.1/coverage> "Bergisch Gladbach- Bensberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/isPartOf> _:b2 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/subject> _:b7 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/tableOfContents> <http://d-nb.info/1074113608/04> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/terms/title> "7. Schloss Bensberg Classics"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -65,4 +65,4 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018771475#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018771475> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s733030> <http://www.w3.org/2000/01/rdf-schema#label> "Kulturveranstaltungen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018779822.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018779822.nt
@@ -25,7 +25,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018779822#!> <http://bibframe.org/vocab/contribution> _:b2 .
 <http://lobid.org/resources/HT018779822#!> <http://iflastandards.info/ns/isbd/elements/P1053> "264 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/dc/terms/title> "Humor in contemporary junior literature"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/143846655"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/lobid/lv#hbzID> "HT018779822"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -38,4 +38,4 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018779822#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018779822> .
 <http://lobid.org/resources/HT018779822#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018779822> .
 <http://lobid.org/resources/HT018779822#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018779822> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01878/HT018786244.nt
+++ b/src/test/resources/reverseTest/output/nt/01878/HT018786244.nt
@@ -74,7 +74,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018786244#!> <http://iflastandards.info/ns/isbd/elements/P1053> "353 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT004394800#!> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6774059&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/dc/terms/tableOfContents> <http://www.folkwang-uni.de/fileadmin/medien/Downloads/Bibliothek/Inhaltsverzeichnisse/HT018786244.pdf> .
@@ -98,5 +98,5 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018786244#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018786244> .
 <http://lobid.org/resources/HT018786244#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018786244> .
 <http://lobid.org/resources/HT018786244#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018786244> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.folkwang-uni.de/fileadmin/medien/Downloads/Bibliothek/Inhaltsverzeichnisse/HT018786244.pdf> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.folkwang-uni.de/fileadmin"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01880/HT018801101.nt
+++ b/src/test/resources/reverseTest/output/nt/01880/HT018801101.nt
@@ -58,9 +58,9 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/hasVersion> <https://repository.publisso.de/resource/frl:6399387> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/subject> _:b9 .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/dc/terms/title> "PUBLISSO - Das ZB MED Open-Access-Publikationsportal"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1072011352 | http://d-nb.info/gnd/1080327355 | http://d-nb.info/gnd/1049793021 | http://d-nb.info/gnd/1088345387"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -77,7 +77,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018801101#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018801101> .
 <http://lobid.org/resources/HT018801101#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018801101> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/ontology"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://repository.publisso.de/resource/frl:6399387> <http://www.w3.org/2000/01/rdf-schema#label> "https://repository.publisso.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01889/HT018895767.nt
+++ b/src/test/resources/reverseTest/output/nt/01889/HT018895767.nt
@@ -52,8 +52,8 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018895767#!> <http://iflastandards.info/ns/isbd/elements/P1053> "7 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT017447882#!> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/subject> _:b4 .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/dc/terms/title> "\"Schulkrieg\" in Rheinland-Pfalz?"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1019562781"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -82,8 +82,8 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018895767#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018895767> .
 <http://lobid.org/resources/RPB> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/rpb#n784010> <http://www.w3.org/2000/01/rdf-schema#label> "Schulpolitik"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n106> <http://www.w3.org/2000/01/rdf-schema#label> "Amtsdruckschriften Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n120> <http://www.w3.org/2000/01/rdf-schema#label> "Erziehung, Bildung, Unterricht"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://w3id.org/lobid/rpb2#n130> <http://www.w3.org/2000/01/rdf-schema#label> "Landeskunde Region Koblenz"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01890/HT018907266.nt
+++ b/src/test/resources/reverseTest/output/nt/01890/HT018907266.nt
@@ -68,9 +68,9 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT018907246#!> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://purl.org/ontology/bibo/AudioVisualDocument> .
-<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
-<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1050> .
+<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1050> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/dc/terms/title> "Digital object identifiers (DOIs) for research data and publications in the field of life sciences, 1: DOI registration with ZB MED"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1080327010 | http://d-nb.info/gnd/1080327355 | http://d-nb.info/gnd/105204266X | http://d-nb.info/gnd/1080064435 | http://d-nb.info/gnd/1072011352 | http://d-nb.info/gnd/1088345387"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/lobid/lv#hbzID> "HT018907266"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -85,6 +85,6 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018907266#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018907266> .
 <http://lobid.org/resources/HT018907266#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018907266> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "http://purl.org/ontology"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdvocab.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1050> <http://www.w3.org/2000/01/rdf-schema#label> "http://rdaregistry.info/termList"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01892/HT018924091.nt
+++ b/src/test/resources/reverseTest/output/nt/01892/HT018924091.nt
@@ -40,7 +40,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/elements/1.1/coverage> "Dinslaken"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/elements/1.1/coverage> "Duisburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/dc/terms/title> "Der Ferd das Buch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1093886471"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -64,4 +64,4 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018924091#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018924091> .
 <http://lobid.org/resources/NWBib> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://purl.org/lobid/nwbib#s841070> <http://www.w3.org/2000/01/rdf-schema#label> "K\u00FCnstler"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
+++ b/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
@@ -61,8 +61,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018939763#!> <http://iflastandards.info/ns/isbd/elements/P1053> "1 Online-Ressource (265 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/por> .
-<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/subject> _:b5 .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/dc/terms/title> "Din\u00E2micas Afro-Latinas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/1068655429 | http://d-nb.info/gnd/185493769"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -91,5 +91,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018939763> .
 <http://lobid.org/resources/HT018939763#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018939763> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01899/HT018998891.nt
+++ b/src/test/resources/reverseTest/output/nt/01899/HT018998891.nt
@@ -35,7 +35,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT018998832#!> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/lat> .
-<http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDAproductionMethod/#1010> .
+<http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/title> "Historische || Ertzehlung || vnd || Leychpredigten || Etlicher Hocherleuchter Keyser/|| K\u00F6nige vnd Churf[ue]rsten/ Sampt jhrem || Christlichen Leben/ Wandel vnd T[oe]dt=||lichem Abgang.|| De\u00DFgleichen derselben Contrafacturen vnnd Bild=||nissen/ auch Epitaphijs oder Grabschrifften ... || in Druck verordnet/|| Durch || M. THOMAM STYBARVM,|| der Freyen Herrschafft vom Wolffstein Super-||intendenten zu Pyrbawm.||, 1"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/130303402"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/lobid/lv#hbzID> "HT018998891"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -52,6 +52,6 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018998891#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/VD16%20S%209000> .
 <http://lobid.org/resources/HT018998891#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018998891> .
 <http://lobid.org/resources/HT018998891#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT018998891> .
-<http://rdvocab.info/termList/RDAproductionMethod/#1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDAproductionMethod/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Print"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://resolver.staatsbibliothek-berlin.de/SBB00006B8200000000> <http://www.w3.org/2000/01/rdf-schema#label> "http://resolver.staatsbibliothek-berlin.de/SBB00006B8200000000"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://worldcat.org/oclc/VD16%20S%209000> <http://www.w3.org/2000/01/rdf-schema#label> "http://worldcat.org/oclc"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01901/HT019011249.nt
+++ b/src/test/resources/reverseTest/output/nt/01901/HT019011249.nt
@@ -35,8 +35,8 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/hasVersion> <http://langsci-press.org//catalog/book/91> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/isPartOf> <http://lobid.org/resources/HT018839495#!> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
-<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/dc/terms/title> "Roots of language"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/185844154"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/lobid/lv#fulltextOnline> <http://edocs.fu-berlin.de/docs/receive/FUDOCS_document_000000023900> .
@@ -56,5 +56,5 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT019011249#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019011249> .
 <http://lobid.org/resources/HT019011249#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019011249> .
 <http://lobid.org/resources/HT019011249#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DHT019011249> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/05040/TT050409948.nt
+++ b/src/test/resources/reverseTest/output/nt/05040/TT050409948.nt
@@ -43,8 +43,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT050409948#!> <http://bibframe.org/vocab/contribution> _:b6 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.1007/978-3-642-20784-6> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
-<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1010> .
-<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdvocab.info/termList/RDACarrierType/1018> .
+<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1010> .
+<http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/title> "Operationsberichte Unfallchirurgie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#contributorOrder> "Irlenbusch, Lars | Siekmann, Holger"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -64,5 +64,5 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT050409948#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT050409948> .
 <http://lobid.org/resources/TT050409948#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT050409948> .
 <http://lobid.org/resources/TT050409948#!> <http://xmlns.com/foaf/0.1/isPrimaryTopicOf> <http://193.30.112.134/F/?func=find-c&ccl_term=IDN%3DTT050409948> .
-<http://rdvocab.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://rdvocab.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1010> <http://www.w3.org/2000/01/rdf-schema#label> "Datentr\u00E4ger"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://rdaregistry.info/termList/RDACarrierType/1018> <http://www.w3.org/2000/01/rdf-schema#label> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .


### PR DESCRIPTION
…gitignore

Updated namespace, deleted http://www.rdvocab.info/RDARelationshipsWEMI/workManifested
because it's deprecated and was no longer used except in labels.json. And of course
updated context.json, labels.json, morph-hbz01-to-lobid.xml, output files, reverseTest/output
and jsonld test files. Also updated .gitignore so there is no danger of committing
input/nt files.

Resolves #97 .