### PR TITLE
Fix double numbering entry

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -1622,7 +1622,7 @@
 				</data>
 			</combine>
 		</entity>
-		<entity name="http://purl.org/lobid/lv#inSeries" flushWith="4[56789]3[-ab]1.a">
+		<entity name="http://purl.org/lobid/lv#inSeries" flushWith="4[56789]3[-ab]1.a" reset="true">
 			<data source="@idTitleSeries" name="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">
 				<regexp match=".*" format="$[ns-lobid-vocab]SeriesRelation"/>
 			</data>

--- a/src/test/resources/jsonld/HT018290299
+++ b/src/test/resources/jsonld/HT018290299
@@ -56,11 +56,8 @@
     } ],
     "type" : [ "SeriesRelation" ]
   }, {
-    "numbering" : [ "2", "19" ],
+    "numbering" : "2",
     "series" : [ {
-      "id" : "http://lobid.org/resources/HT006514951#!",
-      "label" : "lobid Ressource"
-    }, {
       "id" : "http://lobid.org/resources/HT017500108#!",
       "label" : "lobid Ressource"
     } ],


### PR DESCRIPTION
Resolves #172.

Some resources are part of multiple series and in such a case
the "numbering" could have multiple entries, expected were just one.

The morph "reset" fixes this.