### PR TITLE
Support wildcards in issued range queries

### DIFF
--- a/web/app/views/tags/issued_facet.scala.html
+++ b/web/app/views/tags/issued_facet.scala.html
@@ -91,7 +91,7 @@ $(function() {
 		range: true,
 		min: min,
 		max: max,
-		values: [from.length==0 ? min : from, to.length==0 ? max : to],
+		values: [from.length<=1 ? min : from, to.length<=1 ? max : to],
 		slide: function( event, ui ) {
 			var curFrom = ui.values[0];
 			var curTo = ui.values[1];
@@ -115,7 +115,7 @@ function issuedLink(newVal) {
 	var oldHref = $("#issued-link").attr("href");
 	var newIssued = "issued="+newVal;
 	var newHref = oldHref.indexOf("issued=") >= 0 ?
-		oldHref.replace(/issued=[\d\-]+/, newIssued) :
+		oldHref.replace(/issued=[\d\-\*]+/, newIssued) :
 		oldHref + (oldHref.indexOf("?") >= 0 ? "&" : "?") + newIssued;
 	return newHref;
 }

--- a/web/test/tests/ExternalIntegrationTest.java
+++ b/web/test/tests/ExternalIntegrationTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import controllers.resources.Application;
 import controllers.resources.Index;
 import play.mvc.Http;
 import play.test.Helpers;
@@ -42,9 +41,10 @@ public class ExternalIntegrationTest {
 	@Test
 	public void testFacets() {
 		running(testServer(3333), () -> {
+			Index index = new Index();
 			String queryString =
-					Application.buildQueryString("köln", "", "", "", "", "", "", "", "");
-			Index queryResources = new Index().queryResources(queryString);
+					index.buildQueryString("köln", "", "", "", "", "", "", "", "");
+			Index queryResources = index.queryResources(queryString);
 			JsonNode facets = queryResources.getAggregations();
 			assertThat(facets.get("type").findValues("key").stream()
 					.map(e -> e.asText()).collect(Collectors.toList())).contains(

--- a/web/test/tests/IndexUnitTest.java
+++ b/web/test/tests/IndexUnitTest.java
@@ -1,0 +1,38 @@
+/* Copyright 2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package tests;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+import controllers.resources.Index;
+
+/**
+ * Unit tests for functionality provided by the {@link Index} class.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ */
+@SuppressWarnings("javadoc")
+public class IndexUnitTest {
+
+	private Index index = new Index();
+
+	@Test
+	public void testBuildQueryString() {
+		assertThat(index.buildQueryString("")).isEqualTo("*");
+		assertThat(index.buildQueryString("", "Melville"))
+				.isEqualTo("* AND ( +contribution.agent.label:Melville)");
+		assertThat(index.buildQueryString("", "http://d-nb.info/gnd/118580604"))
+				.contains("contribution.agent.id");
+		assertThat(index.buildQueryString("", "", "", "", "", "", "1999-2001"))
+				.isEqualTo("* AND ( +publication.startDate:[1999 TO 2001])");
+		assertThat(index.buildQueryString("", "", "", "", "", "", "1999-*"))
+				.isEqualTo("* AND ( +publication.startDate:[1999 TO *])");
+		assertThat(index.buildQueryString("", "", "", "", "", "", "*-2001"))
+				.isEqualTo("* AND ( +publication.startDate:[* TO 2001])");
+		assertThat(index.buildQueryString("", "", "", "", "", "", "*-*"))
+				.isEqualTo("* AND ( +publication.startDate:[* TO *])");
+	}
+
+}

--- a/web/test/tests/TravisTests.java
+++ b/web/test/tests/TravisTests.java
@@ -14,7 +14,7 @@ import org.junit.runners.Suite.SuiteClasses;
  */
 @RunWith(Suite.class)
 @SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class,
-		AcceptUnitTest.class })
+		AcceptUnitTest.class, IndexUnitTest.class })
 public class TravisTests {
 	//
 }


### PR DESCRIPTION
Will resolve https://github.com/hbz/lobid-resources-web/issues/35

Support via `*`, see: [http://test.lobid.org/resources/search?issued=2010-*](http://test.lobid.org/resources/search?issued=2010-*)

While adding this, I've cleaned up the code and added general tests for building the query, so this is a good changeset and should be merged in principle. However, considering documentation for this brings up an issue we did not discuss yet: since the web UI evolved from NWBib, it still uses the NWBib query parameters (like `issued` here). These are internally mapped to the queryString syntax. For this example:

http://test.lobid.org/resources/search?q=*%20AND%20(%20+publication.startDate:[2010%20TO%20*])

So we would not need many of the parameters, however the queryString is quite verbose as an API.