### PR TITLE
Update query param for advanced search over all fields

### DIFF
--- a/web/app/views/query.scala.html
+++ b/web/app/views/query.scala.html
@@ -51,7 +51,7 @@
 }
 
 @main("lobid-resources - Ergebnisliste") {
-    @if(Seq(agent, name, subject, id, publisher, issued).exists(!_.isEmpty)){
+    @if(Seq(agent, name, id, publisher).exists(!_.isEmpty)){ @* advanced search, not shown in facets *@
       @tags.search_advanced("Suche aktualisieren", q, agent, name, subject, id, publisher, issued, sortParam)
     } else {
       @tags.search_form(q)

--- a/web/app/views/tags/search_advanced.scala.html
+++ b/web/app/views/tags/search_advanced.scala.html
@@ -76,12 +76,12 @@ function suggests(term){
 
 @helper.form(action = controllers.resources.routes.Application.query(), 
     'id -> "resources-form", 'role -> "form", 'class -> "form-inline") {
-  @defining(TreeMap("name"->name,"agent"->agent,"corporation"->corporation,"subject"->Lobid.withoutUris(subject), "id"->id,"publisher"->publisher,"word"->word).filter({case (k,v) => !v.isEmpty && (k != "subject" || (k == "subject" && !v.startsWith("http")))})) { fields =>
+  @defining(TreeMap("name"->name,"agent"->agent,"corporation"->corporation,"subject"->Lobid.withoutUris(subject), "id"->id,"publisher"->publisher,"q"->q).filter({case (k,v) => !v.isEmpty && (k != "subject" || (k == "subject" && !v.startsWith("http")))})) { fields =>
   @for(((k,v),i)<- (if(fields.isEmpty) TreeMap("q" -> "") else fields).zipWithIndex){
   <div class="search-field row" id="search-field-@i">
       <div class="form-group col col-md-2">
             <select id="query-select" class="form-control" onChange="setAutosuggest()">
-              <option value="word" @if(k=="word"){selected="selected"})>Alles</option>
+              <option value="q" @if(k=="q"){selected="selected"})>Alles</option>
               <option value="id" @if(k=="id"){selected="selected"}>ISBN/ISSN</option>
               <option value="name" @if(k=="name"){selected="selected"}>Titel</option>
               <option value="agent" @if(k=="agent"){selected="selected"}>Mitwirkende</option>


### PR DESCRIPTION
Will resolve #222.

Deployed to staging, see `köln` in search bar for:
http://test.lobid.org/resources/search?q=k%C3%B6ln&issued=1462-1842&owner=http%3A%2F%2Flobid.org%2Forganisations%2FDE-38