### PR TITLE
Support customizable aggregations, none as default

### DIFF
--- a/web/conf/resources.routes
+++ b/web/conf/resources.routes
@@ -9,7 +9,7 @@ GET    /*path/                controllers.resources.Application.redirect(path: S
 GET    /resources                       controllers.resources.Application.index()
 GET    /resources/api                   controllers.resources.Application.api()
 GET    /resources/advanced              controllers.resources.Application.advanced()
-GET    /resources/search                controllers.resources.Application.query(q?="", agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int?=0, size:Int?=15, owner?="", t?="", sort ?= "", set?="", format ?= null)
+GET    /resources/search                controllers.resources.Application.query(q?="", agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int?=0, size:Int?=15, owner?="", t?="", sort ?= "", set?="", format ?= null, aggregations ?= "")
 GET    /resources/facets                controllers.resources.Application.facets(q,agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int,size:Int,owner,t,field,sort,set?="")
 
 GET    /resources/stars                 controllers.resources.Application.showStars(format?="", ids?="")

--- a/web/test/tests/AggregationsTest.java
+++ b/web/test/tests/AggregationsTest.java
@@ -1,0 +1,93 @@
+/* Copyright 2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package tests;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.test.Helpers.GET;
+import static play.test.Helpers.fakeApplication;
+import static play.test.Helpers.fakeRequest;
+import static play.test.Helpers.route;
+import static play.test.Helpers.running;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import play.libs.Json;
+import play.mvc.Http.Status;
+import play.mvc.Result;
+import play.test.FakeRequest;
+import play.test.Helpers;
+import scala.Option;
+
+/**
+ * Test customizable aggregations.
+ * 
+ * See https://github.com/hbz/lobid-resources/pull/243
+ * 
+ * @author Fabian Steeg (fsteeg)
+ */
+@SuppressWarnings("javadoc")
+@RunWith(Parameterized.class)
+public class AggregationsTest {
+
+	// test data parameters, formatted as "input /*->*/ expected output"
+	@Parameters(name = "{0} -> {1}")
+	public static Collection<Object[]> data() {
+		// @formatter:off
+		return Arrays.asList(new Object[][] {
+			// neither supported header nor supported format given, return default:
+			{ "", /*->*/ 0, Status.OK },
+			{ "&aggregations=", /*->*/ 0, Status.OK },
+			{ "&aggregations=type", /*->*/ 1, Status.OK },
+			{ "&aggregations=type,subject.id", /*->*/ 2, Status.OK },
+			{ "&aggregations=invalid", /*->*/ 0, Status.BAD_REQUEST },});
+	} // @formatter:on
+
+	private FakeRequest fakeRequest;
+	private int expectedNumberOfAggragations;
+	private int expectedResponseStatus;
+
+	public AggregationsTest(String param, int expectedNumberOfAggragations,
+			int status) {
+		this.fakeRequest =
+				fakeRequest(GET, "/resources/search?format=json&q=*" + param);
+		this.expectedNumberOfAggragations = expectedNumberOfAggragations;
+		this.expectedResponseStatus = status;
+	}
+
+	@Test
+	public void test() {
+		running(fakeApplication(), () -> {
+			Result route = route(fakeRequest);
+			int responseStatus = Helpers.status(route);
+			assertThat(responseStatus).as("response status")
+					.isEqualTo(expectedResponseStatus);
+			if (responseStatus == Status.OK) {
+				JsonNode aggregationNode =
+						Json.parse(Helpers.contentAsString(route)).findValue("aggregation");
+				Option<String> aggregationsQueryParam =
+						fakeRequest.getWrappedRequest().getQueryString("aggregations");
+				if (!aggregationsQueryParam.isDefined()
+						|| aggregationsQueryParam.get().equals("")) {
+					assertThat(aggregationNode).isNull();
+				} else {
+					int numberOfAggregations =
+							Json.fromJson(aggregationNode, Map.class).keySet().size();
+					assertThat(numberOfAggregations)
+							.as("resulting number of aggregations")
+							.isEqualTo(expectedNumberOfAggragations);
+				}
+			}
+		});
+
+	}
+
+}

--- a/web/test/tests/AllQuickTests.java
+++ b/web/test/tests/AllQuickTests.java
@@ -14,7 +14,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class,
 		ExternalIntegrationTest.class, AcceptUnitTest.class,
-		AcceptIntegrationTest.class, IndexIntegrationTest.class })
+		AcceptIntegrationTest.class, IndexIntegrationTest.class,
+		AggregationsTest.class })
 public class AllQuickTests {
 	//
 }

--- a/web/test/tests/InputStringsTest.java
+++ b/web/test/tests/InputStringsTest.java
@@ -83,7 +83,7 @@ public class InputStringsTest {
 		running(testServer(3333), () -> {
 			Result result = Helpers.callAction(
 					controllers.resources.routes.ref.Application.query(input, "", "", "",
-							"", "", "", "", 0, 10, "", "", "", "", ""),
+							"", "", "", "", 0, 10, "", "", "", "", "", ""),
 					new FakeRequest(Helpers.GET, "/")
 							.withFormUrlEncodedBody(ImmutableMap.of()));
 			// we don't expect any server errors (see


### PR DESCRIPTION
See https://github.com/hbz/lobid-resources-web/issues/26

Deployed to staging:

http://test.lobid.org/resources/search?q=glessen&format=json (no aggregations)
http://test.lobid.org/resources/search?q=glessen&format=json&aggregations=subject.id,owner (supported)
http://test.lobid.org/resources/search?q=glessen&format=json&aggregations=title (unsupported)