### PR TITLE
Replace bibo with bibframe Collection

### DIFF
--- a/src/main/resources/context.json
+++ b/src/main/resources/context.json
@@ -451,7 +451,7 @@
     },
     "Collection" : {
       "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Collection",
+      "@id" : "http://id.loc.gov/ontologies/bibframe/Collection",
       "@container" : "@set"
     },
     "SeriesRelation" : {

--- a/src/main/resources/labels/labels.json
+++ b/src/main/resources/labels/labels.json
@@ -6586,7 +6586,7 @@
         "multilangLabel": { }
     },
     {
-        "uri": "http://purl.org/ontology/bibo/Collection",
+        "uri": "http://id.loc.gov/ontologies/bibframe/Collection",
         "name": "Collection",
         "referenceType": "@id",
         "container": "@set",


### PR DESCRIPTION
Resolves #234

Also removes the input and output folders of HT013480902 and HT019093814 as they are removed from the hbz01XmlClobs.tar.gz.