### PR TITLE
Increase timeout for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ before_script:
   - cd web
   - wget http://downloads.typesafe.com/typesafe-activator/${ACTIVATOR_VERSION}/typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
   - unzip typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
+  - travis_wait ./activator-${ACTIVATOR_VERSION}-minimal/bin/activator compile
 script:
   - ./activator-${ACTIVATOR_VERSION}-minimal/bin/activator "test-only tests.TravisTests"


### PR DESCRIPTION
Will resolve https://github.com/hbz/lobid-resources/issues/273

See build details: https://travis-ci.org/hbz/lobid-resources/builds/206095808

Configured as documented in:
https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

Add a separate compilation step with increased timeout to avoid higher timeout when actually running tests (where timing out would indicate a problem).