### PR TITLE
Support bulk requests

### DIFF
--- a/web/app/controllers/resources/Accept.java
+++ b/web/app/controllers/resources/Accept.java
@@ -20,7 +20,8 @@ public class Accept {
 
 	enum Format {
 		JSON_LD("json(.+)?", "application/json", "application/ld+json"), //
-		HTML("html", "text/html");
+		HTML("html", "text/html"), //
+		BULK("bulk", "application/x-jsonlines");
 
 		String[] types;
 		String queryParamString;

--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -26,11 +26,19 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.children.InternalChildren;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.search.sort.SortParseElement;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -179,28 +187,32 @@ public class Application extends Controller {
 		if (cachedResult != null)
 			return cachedResult;
 		Logger.debug("Not cached: {}, will cache for one hour", cacheId);
-		Promise<Result> result = Promise.promise(() -> {
-			Index index = new Index();
-			String queryString = index.buildQueryString(q, agent, name, subject, id,
-					publisher, issued, medium, t, set);
-			Index queryResources = index.queryResources(queryString, from, size, sort,
-					owner, aggregations);
-			String responseFormat =
-					Accept.formatFor(format, request().acceptedTypes());
-			boolean returnSuggestions = responseFormat.startsWith("json:");
-			JsonNode json = returnSuggestions
-					? toSuggestions(queryResources.getResult(), format.split(":")[1])
-					: queryResources.getResult();
-			String s = json.toString();
-			boolean htmlRequested =
-					responseFormat.equals(Accept.Format.HTML.queryParamString);
-			return htmlRequested
-					? ok(query.render(s, q, agent, name, subject, id, publisher, issued,
-							medium, from, size, queryResources.getTotal(), owner, t, sort,
-							set))
-					: (returnSuggestions ? withCallback(json)
-							: prettyJsonOk(withQueryMetadata(json, index)));
-		});
+		String responseFormat = Accept.formatFor(format, request().acceptedTypes());
+		Index index = new Index();
+		String queryString = index.buildQueryString(q, agent, name, subject, id,
+				publisher, issued, medium, t, set);
+		Promise<Result> result;
+		if (responseFormat.equals(Accept.Format.BULK.queryParamString)) {
+			result = bulkResult(q, owner, index);
+		} else {
+			result = Promise.promise(() -> {
+				Index queryResources = index.queryResources(queryString, from, size,
+						sort, owner, aggregations);
+				boolean returnSuggestions = responseFormat.startsWith("json:");
+				JsonNode json = returnSuggestions
+						? toSuggestions(queryResources.getResult(), format.split(":")[1])
+						: queryResources.getResult();
+				String s = json.toString();
+				boolean htmlRequested =
+						responseFormat.equals(Accept.Format.HTML.queryParamString);
+				return htmlRequested
+						? ok(query.render(s, q, agent, name, subject, id, publisher, issued,
+								medium, from, size, queryResources.getTotal(), owner, t, sort,
+								set))
+						: (returnSuggestions ? withCallback(json)
+								: prettyJsonOk(withQueryMetadata(json, index)));
+			});
+		}
 		cacheOnRedeem(cacheId, result, ONE_HOUR);
 		return result.recover((Throwable throwable) -> {
 			Html html = query.render("[]", q, agent, name, subject, id, publisher,
@@ -214,6 +226,46 @@ public class Application extends Controller {
 			}
 			Logger.error(message);
 			return internalServerError(html);
+		});
+	}
+
+	private static Promise<Result> bulkResult(final String q, final String owner,
+			Index index) {
+		return Promise.promise(() -> {
+			Chunks<String> chunks = StringChunks.whenReady(out -> {
+				SearchResponse lastResponse =
+						index.<SearchResponse> withClient((Client client) -> {
+							QueryBuilder query =
+									owner.isEmpty() ? QueryBuilders.queryStringQuery(q)
+											: Index.ownerQuery(q, owner);
+							Index.validate(client, query);
+							Logger.trace("bulkResources: q={}, owner={}, query={}", q, owner,
+									query);
+							TimeValue keepAlive = new TimeValue(60000);
+							SearchResponse scrollResp = client.prepareSearch(Index.INDEX_NAME)
+									.addSort(SortParseElement.DOC_FIELD_NAME, SortOrder.ASC)
+									.setScroll(keepAlive).setQuery(query)
+									.setSize(100 /* hits per shard for each scroll */).get();
+							String scrollId = scrollResp.getScrollId();
+							while (scrollResp.getHits().getHits().length > 0) {
+								for (SearchHit hit : scrollResp.getHits().getHits()) {
+									out.write(hit.getSourceAsString());
+									out.write("\n");
+								}
+								scrollResp = client.prepareSearchScroll(scrollId)
+										.setScroll(keepAlive).execute().actionGet();
+								scrollId = scrollResp.getScrollId();
+							}
+							out.close();
+							return scrollResp;
+						});
+				Logger.trace("Last search response for bulk request: " + lastResponse);
+			});
+			response().setHeader("Content-Disposition",
+					String.format(
+							"attachment; filename=\"lobid-resources-bulk-%s.jsonl\"",
+							System.currentTimeMillis()));
+			return ok(chunks).as(Accept.Format.BULK.types[0]);
 		});
 	}
 

--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.children.InternalChildren;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -247,11 +246,11 @@ public class Application extends Controller {
 									.setScroll(keepAlive).setQuery(query)
 									.setSize(100 /* hits per shard for each scroll */).get();
 							String scrollId = scrollResp.getScrollId();
-							while (scrollResp.getHits().getHits().length > 0) {
-								for (SearchHit hit : scrollResp.getHits().getHits()) {
+							while (scrollResp.getHits().iterator().hasNext()) {
+								scrollResp.getHits().forEach((hit) -> {
 									out.write(hit.getSourceAsString());
 									out.write("\n");
-								}
+								});
 								scrollResp = client.prepareSearchScroll(scrollId)
 										.setScroll(keepAlive).execute().actionGet();
 								scrollId = scrollResp.getScrollId();

--- a/web/app/controllers/resources/Index.java
+++ b/web/app/controllers/resources/Index.java
@@ -200,7 +200,7 @@ public class Index {
 		return resultIndex;
 	}
 
-	private static void validate(Client client, QueryBuilder query) {
+	static void validate(Client client, QueryBuilder query) {
 		ValidateQueryResponse validate =
 				client.admin().indices().prepareValidateQuery(INDEX_NAME)
 						.setTypes(TYPE_RESOURCE).setQuery(query).get();
@@ -209,7 +209,7 @@ public class Index {
 		}
 	}
 
-	private static QueryBuilder ownerQuery(String q, String owner) {
+	static QueryBuilder ownerQuery(String q, String owner) {
 		final String prefix = Lobid.ORGS_BETA_ROOT;
 		BoolQueryBuilder ownersQuery = QueryBuilders.boolQuery();
 		final String[] owners = owner.split(",");

--- a/web/test/tests/IntegrationTests.java
+++ b/web/test/tests/IntegrationTests.java
@@ -87,6 +87,19 @@ public class IntegrationTests extends LocalIndexSetup {
 	}
 
 	@Test
+	public void bulkRequest() {
+		running(testServer(3333), () -> {
+			Result result =
+					route(fakeRequest(GET, "/resources/search?q=buch&format=bulk"));
+			assertThat(result).isNotNull();
+			assertThat(Helpers.contentType(result))
+					.isEqualTo("application/x-jsonlines");
+			String text = Helpers.contentAsString(result);
+			assertThat(text.split("\\n").length).isGreaterThanOrEqualTo(10);
+		});
+	}
+
+	@Test
 	public void sizeRequest() {
 		running(testServer(3333), () -> {
 			Index index = new Index();


### PR DESCRIPTION
Will resolve https://github.com/hbz/lobid-resources/issues/330.

Sample usage (increasing response size):

`curl "http://localhost:9000/resources/search?q=ehrenfeld&format=bulk" > ehrenfeld.jsonl`
`curl "http://localhost:9000/resources/search?q=dom&format=bulk" > dom.jsonl`
`curl "http://localhost:9000/resources/search?q=*&format=bulk" > resources.jsonl`

Response format for `format=bulk` is JSON lines (see http://jsonlines.org/).

Updates since a specific date can be requested as part of the query (was `scroll=20100101` in 1.x):

`curl "http://localhost:9000/resources/search?q=ehrenfeld+AND+describedBy.dateModified:>20100101&format=bulk" > ehrenfeld-since-2010.jsonl`

Compression will be provided via Apache, as for 1.x.

All of this works with a Play instance running locally (57.8G in about 2:40 hours for `q=*`), also when curling from a different machine on our local network. When deployed on our servers (tested on quaoar1 and weywot3), the `q=*` request stalls after downloading about half of the heap size (about 500M with default activator settings). I'm currently working on setting up an environment to closely mirror my machine on weywot3.

@dr0i I'd suggest that you try to reproduce this on your machine, and if that works too we merge and deploy this, since the implementation does not seem to be the problem. Also many common use cases, like getting the NWBib, holdings of a specific library, etc. require way less data and seem to work fine. We can then work on issues with our server setup for the specific case of very large dumps in a separate issue, without delaying the basic bulk download functionality.