### PR TITLE
Remove obsolete java option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 						<test>UnitTests</test>
 						<forkCount>3</forkCount>
 						<reuseForks>true</reuseForks>
-						<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+						<argLine>-Xmx1024m</argLine>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
As the "Permanent Generation" was removed in Java 8, on some machines
maven fails with "Unrecognized VM option 'MaxPermSize=256m'".
It's safe to simply remove this option.