### PR TITLE
Remove redundant and deprecated elements from context

### DIFF
--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -840,13 +840,6 @@
    {
       "multilangLabel" : {},
       "referenceType" : "@id",
-      "uri" : "http://purl.org/ontology/bibo/Periodical",
-      "name" : "Journal",
-      "container" : "@set"
-   },
-   {
-      "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#Legislation",
       "name" : "Legislation",
       "container" : "@set"

--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -709,14 +709,6 @@
       "name" : "describedBy"
    },
    {
-      "referenceType" : "@id",
-      "label" : "Beschreibt",
-      "uri" : "http://xmlns.com/foaf/0.1/primaryTopic",
-      "multilangLabel" : {},
-      "name" : "primaryTopic",
-      "container" : "@set"
-   },
-   {
       "multilangLabel" : {},
       "label" : "SeriesRelation",
       "uri" : "http://purl.org/lobid/lv#SeriesRelation",


### PR DESCRIPTION
As we have bibo:Periodical twice, I remove the one with the wrong JSON key "Journal".