### PR TITLE
Remove superfluous @type & @container from context

### DIFF
--- a/src/main/java/de/hbz/lobid/helper/EtikettMaker.java
+++ b/src/main/java/de/hbz/lobid/helper/EtikettMaker.java
@@ -226,12 +226,12 @@ public class EtikettMaker implements EtikettMakerInterface {
 		Map<String, Object> pmap;
 		Map<String, Object> cmap = new HashMap<>();
 		for (Etikett l : labels) {
-			if ("class".equals(l.referenceType) || l.referenceType == null
+			if ((l.referenceType != null && "class".equals(l.referenceType))
 					|| l.name == null)
 				continue;
 			pmap = new HashMap<>();
 			pmap.put("@id", l.uri);
-			if (!"String".equals(l.referenceType)) {
+			if (l.referenceType != null && !"String".equals(l.referenceType)) {
 				pmap.put("@type", l.referenceType);
 			}
 			if (l.container != null) {

--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -706,14 +706,12 @@
       "name" : "SeriesRelation"
    },
    {
-      "container" : "@set",
       "name" : "MultiVolumeWorkRelation",
       "label" : "MultiVolumeWorkRelation",
       "uri" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation",
       "multilangLabel" : {}
    },
    {
-      "container" : "@set",
       "name" : "ArchivalResource",
       "uri" : "http://data.archiveshub.ac.uk/def/ArchivalResource",
       "label" : "ArchivalResource",

--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -58,7 +58,6 @@
       "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear"
    },
    {
-      "referenceType" : "@id",
       "uri" : "http://schema.org/PublicationEvent",
       "multilangLabel" : {},
       "name" : "PublicationEvent"
@@ -66,7 +65,6 @@
    {
       "name" : "SecondaryPublicationEvent",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#SecondaryPublicationEvent"
    },
    {
@@ -536,25 +534,19 @@
       "container" : "@set"
    },
    {
-      "container" : "@set",
       "name" : "Image",
       "multilangLabel" : {},
       "label" : "Bild",
-      "uri" : "http://purl.org/ontology/bibo/Image",
-      "referenceType" : "String"
+      "uri" : "http://purl.org/ontology/bibo/Image"
    },
    {
       "name" : "Standard",
-      "container" : "@set",
-      "referenceType" : "String",
       "uri" : "http://purl.org/ontology/bibo/Standard",
       "label" : "Standard",
       "multilangLabel" : {}
    },
    {
       "name" : "Contribution",
-      "container" : "@set",
-      "referenceType" : "@id",
       "uri" : "http://id.loc.gov/ontologies/bibframe/Contribution",
       "label" : "Mitwirkung",
       "multilangLabel" : {}
@@ -711,8 +703,6 @@
       "multilangLabel" : {},
       "label" : "SeriesRelation",
       "uri" : "http://purl.org/lobid/lv#SeriesRelation",
-      "referenceType" : "@id",
-      "container" : "@set",
       "name" : "SeriesRelation"
    },
    {
@@ -720,7 +710,6 @@
       "name" : "MultiVolumeWorkRelation",
       "label" : "MultiVolumeWorkRelation",
       "uri" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation",
-      "referenceType" : "@id",
       "multilangLabel" : {}
    },
    {
@@ -728,236 +717,170 @@
       "name" : "ArchivalResource",
       "uri" : "http://data.archiveshub.ac.uk/def/ArchivalResource",
       "label" : "ArchivalResource",
-      "referenceType" : "@id",
       "multilangLabel" : {}
    },
    {
       "name" : "Article",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/ontology/bibo/Article"
    },
    {
-      "container" : "@set",
       "name" : "BibliographicResource",
       "uri" : "http://purl.org/dc/terms/BibliographicResource",
-      "referenceType" : "@id",
       "multilangLabel" : {}
    },
    {
-      "container" : "@set",
       "name" : "Bibliography",
       "uri" : "http://purl.org/lobid/lv#Bibliography",
-      "referenceType" : "@id",
       "multilangLabel" : {}
    },
    {
       "name" : "Biography",
-      "container" : "@set",
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#Biography",
       "multilangLabel" : {}
    },
    {
-      "referenceType" : "@id",
       "uri" : "http://purl.org/ontology/bibo/Book",
       "multilangLabel" : {},
-      "name" : "Book",
-      "container" : "@set"
+      "name" : "Book"
    },
    {
       "uri": "http://www.loc.gov/mads/rdf/v1#ComplexSubject",
       "name": "ComplexSubject",
-      "referenceType": "@id",
-      "multilangLabel": { }
+      "multilangLabel": {}
    },
    {
-      "referenceType" : "@id",
       "uri" : "http://id.loc.gov/ontologies/bibframe/Collection",
       "multilangLabel" : {},
-      "name" : "Collection",
-      "container" : "@set"
+      "name" : "Collection"
    },
    {
-      "referenceType" : "@id",
       "uri" : "http://d-nb.info/standards/elementset/gnd#ConferenceOrEvent",
       "multilangLabel" : {},
-      "name" : "ConferenceOrEvent",
-      "container" : "@set"
+      "name" : "ConferenceOrEvent"
    },
    {
       "name" : "CorporateBody",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://d-nb.info/standards/elementset/gnd#CorporateBody"
    },
    {
       "multilangLabel" : {},
       "uri" : "http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson",
-      "referenceType" : "@id",
-      "container" : "@set",
       "name" : "DifferentiatedPerson"
    },
    {
       "name" : "EditedVolume",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#EditedVolume"
    },
    {
       "name" : "Family",
-      "container" : "@set",
-      "referenceType" : "@id",
       "uri" : "http://d-nb.info/standards/elementset/gnd#Family",
       "multilangLabel" : {}
    },
    {
       "name" : "Festschrift",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#Festschrift"
    },
    {
-      "container" : "@set",
       "name" : "Game",
       "uri" : "http://schema.org/Game",
-      "referenceType" : "@id",
       "multilangLabel" : {}
    },
    {
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#Legislation",
-      "name" : "Legislation",
-      "container" : "@set"
+      "name" : "Legislation"
    },
    {
       "name" : "Miscellaneous",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#Miscellaneous"
    },
    {
-      "container" : "@set",
       "name" : "MultiVolumeBook",
       "uri" : "http://purl.org/ontology/bibo/MultiVolumeBook",
-      "referenceType" : "@id",
       "multilangLabel" : {}
    },
    {
       "uri" : "http://purl.org/ontology/bibo/Newspaper",
-      "referenceType" : "@id",
       "multilangLabel" : {},
-      "container" : "@set",
       "name" : "Newspaper"
    },
    {
-      "container" : "@set",
       "name" : "OfficialPublication",
       "multilangLabel" : {},
-      "uri" : "http://purl.org/lobid/lv#OfficialPublication",
-      "referenceType" : "@id"
+      "uri" : "http://purl.org/lobid/lv#OfficialPublication"
    },
    {
       "uri" : "http://purl.org/ontology/bibo/Periodical",
-      "referenceType" : "@id",
       "multilangLabel" : {},
-      "container" : "@set",
       "name" : "Periodical"
    },
    {
       "name" : "Report",
-      "container" : "@set",
-      "referenceType" : "@id",
       "uri" : "http://purl.org/ontology/bibo/Report",
       "multilangLabel" : {}
    },
    {
       "multilangLabel" : {},
       "uri" : "http://purl.org/lobid/lv#ArchivedWebPage",
-      "referenceType" : "@id",
-      "container" : "@set",
       "name" : "ArchivedWebPage"
    },
    {
       "name" : "Person",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://d-nb.info/standards/elementset/gnd#Person"
    },
    {
       "uri" : "http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName",
-      "referenceType" : "@id",
       "multilangLabel" : {},
-      "container" : "@set",
       "name" : "PlaceOrGeographicName"
    },
    {
       "multilangLabel" : {},
       "uri" : "http://purl.org/ontology/bibo/Proceedings",
-      "referenceType" : "@id",
-      "container" : "@set",
       "name" : "Proceedings"
    },
    {
-      "container" : "@set",
       "name" : "PublishedScore",
       "multilangLabel" : {},
-      "uri" : "http://purl.org/ontology/mo/PublishedScore",
-      "referenceType" : "@id"
+      "uri" : "http://purl.org/ontology/mo/PublishedScore"
    },
    {
       "name" : "Item",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://id.loc.gov/ontologies/bibframe/Item"
    },
    {
       "name" : "ReferenceSource",
-      "container" : "@set",
-      "referenceType" : "@id",
       "uri" : "http://purl.org/ontology/bibo/ReferenceSource",
       "multilangLabel" : {}
    },
    {
       "name" : "Schoolbook",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/lobid/lv#Schoolbook"
    },
    {
       "name" : "Series",
-      "container" : "@set",
       "multilangLabel" : {},
-      "referenceType" : "@id",
       "uri" : "http://purl.org/ontology/bibo/Series"
    },
    {
       "uri" : "http://d-nb.info/standards/elementset/gnd#SubjectHeading",
-      "referenceType" : "@id",
       "multilangLabel" : {},
-      "container" : "@set",
       "name" : "SubjectHeading"
    },
    {
-      "container" : "@set",
       "name" : "Thesis",
       "multilangLabel" : {},
-      "uri" : "http://purl.org/ontology/bibo/Thesis",
-      "referenceType" : "@id"
+      "uri" : "http://purl.org/ontology/bibo/Thesis"
    },
    {
       "name" : "Work",
-      "container" : "@set",
-      "referenceType" : "@id",
       "uri" : "http://d-nb.info/standards/elementset/gnd#Work",
       "multilangLabel" : {}
    }

--- a/src/main/resources/labels/labels.json
+++ b/src/main/resources/labels/labels.json
@@ -13673,7 +13673,7 @@
    },
    {
       "uri" : "http://rdaregistry.info/termList/RDAproductionMethod/1010",
-      "name" : "Print"
+      "label" : "Print"
    },
    {
       "uri":"http://purl.org/ontology/mo/Vinyl",

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -195,8 +195,7 @@
       "@id" : "http://purl.org/lobid/lv#Schoolbook"
     },
     "MultiVolumeWorkRelation" : {
-      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation"
     },
     "dateOfBirth" : {
       "@type" : "http://www.w3.org/2001/XMLSchema#gYear",
@@ -250,8 +249,7 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/agent"
     },
     "ArchivalResource" : {
-      "@id" : "http://data.archiveshub.ac.uk/def/ArchivalResource",
-      "@container" : "@set"
+      "@id" : "http://data.archiveshub.ac.uk/def/ArchivalResource"
     },
     "Miscellaneous" : {
       "@id" : "http://purl.org/lobid/lv#Miscellaneous"

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -9,7 +9,6 @@
       "@container" : "@set"
     },
     "SecondaryPublicationEvent" : {
-      "@type" : "@id",
       "@id" : "http://purl.org/lobid/lv#SecondaryPublicationEvent"
     },
     "altLabel" : {
@@ -18,23 +17,16 @@
     },
     "type" : "@type",
     "Image" : {
-      "@id" : "http://purl.org/ontology/bibo/Image",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Image"
     },
     "ReferenceSource" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/ReferenceSource",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/ReferenceSource"
     },
     "PlaceOrGeographicName" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName"
     },
     "Item" : {
-      "@type" : "@id",
-      "@id" : "http://id.loc.gov/ontologies/bibframe/Item",
-      "@container" : "@set"
+      "@id" : "http://id.loc.gov/ontologies/bibframe/Item"
     },
     "contribution" : {
       "@type" : "@id",
@@ -47,14 +39,10 @@
       "@container" : "@set"
     },
     "Book" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Book",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Book"
     },
     "Work" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#Work",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#Work"
     },
     "id" : "@id",
     "spatial" : {
@@ -79,19 +67,13 @@
       "@container" : "@set"
     },
     "MultiVolumeBook" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/MultiVolumeBook"
     },
     "Newspaper" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Newspaper",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Newspaper"
     },
     "Game" : {
-      "@type" : "@id",
-      "@id" : "http://schema.org/Game",
-      "@container" : "@set"
+      "@id" : "http://schema.org/Game"
     },
     "issn" : {
       "@id" : "http://purl.org/ontology/bibo/issn",
@@ -106,9 +88,7 @@
       "@id" : "http://purl.org/dc/terms/bibliographicCitation"
     },
     "Person" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#Person",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#Person"
     },
     "startDate" : {
       "@type" : "http://www.w3.org/2001/XMLSchema#gYear",
@@ -147,9 +127,7 @@
       "@container" : "@set"
     },
     "Article" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Article",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Article"
     },
     "hasItem" : {
       "@type" : "@id",
@@ -161,9 +139,7 @@
       "@container" : "@set"
     },
     "Festschrift" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#Festschrift",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#Festschrift"
     },
     "predecessor" : {
       "@type" : "@id",
@@ -176,9 +152,7 @@
       "@container" : "@set"
     },
     "ConferenceOrEvent" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#ConferenceOrEvent",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#ConferenceOrEvent"
     },
     "volumeIn" : {
       "@type" : "@id",
@@ -202,9 +176,7 @@
       "@id" : "http://www.w3.org/2007/05/powder-s#describedby"
     },
     "PublishedScore" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/mo/PublishedScore",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/mo/PublishedScore"
     },
     "oclcNumber" : {
       "@id" : "http://purl.org/ontology/bibo/oclcnum",
@@ -220,12 +192,9 @@
       "@container" : "@set"
     },
     "Schoolbook" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#Schoolbook",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#Schoolbook"
     },
     "MultiVolumeWorkRelation" : {
-      "@type" : "@id",
       "@id" : "http://purl.org/lobid/lv#MultiVolumeWorkRelation",
       "@container" : "@set"
     },
@@ -263,18 +232,14 @@
       "@container" : "@set"
     },
     "Family" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#Family",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#Family"
     },
     "ismn" : {
       "@id" : "http://purl.org/ontology/mo/ismn",
       "@container" : "@set"
     },
     "Bibliography" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#Bibliography",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#Bibliography"
     },
     "publishedBy" : {
       "@id" : "http://schema.org/publishedBy",
@@ -285,17 +250,13 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/agent"
     },
     "ArchivalResource" : {
-      "@type" : "@id",
       "@id" : "http://data.archiveshub.ac.uk/def/ArchivalResource",
       "@container" : "@set"
     },
     "Miscellaneous" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#Miscellaneous",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#Miscellaneous"
     },
     "ComplexSubject" : {
-      "@type" : "@id",
       "@id" : "http://www.loc.gov/mads/rdf/v1#ComplexSubject"
     },
     "subject" : {
@@ -338,9 +299,7 @@
       "@container" : "@set"
     },
     "Proceedings" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Proceedings",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Proceedings"
     },
     "publication" : {
       "@id" : "http://schema.org/publication",
@@ -352,14 +311,10 @@
       "@container" : "@set"
     },
     "DifferentiatedPerson" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#DifferentiatedPerson"
     },
     "CorporateBody" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#CorporateBody",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#CorporateBody"
     },
     "numbering" : {
       "@id" : "http://purl.org/lobid/lv#numbering",
@@ -374,38 +329,26 @@
       "@id" : "http://purl.org/dc/terms/isFormatOf"
     },
     "Legislation" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#Legislation",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#Legislation"
     },
     "responsibilityStatement" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/responsibilityStatement",
       "@container" : "@set"
     },
     "Thesis" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Thesis",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Thesis"
     },
     "ArchivedWebPage" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#ArchivedWebPage",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#ArchivedWebPage"
     },
     "BibliographicResource" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/dc/terms/BibliographicResource",
-      "@container" : "@set"
+      "@id" : "http://purl.org/dc/terms/BibliographicResource"
     },
     "Collection" : {
-      "@type" : "@id",
-      "@id" : "http://id.loc.gov/ontologies/bibframe/Collection",
-      "@container" : "@set"
+      "@id" : "http://id.loc.gov/ontologies/bibframe/Collection"
     },
     "SeriesRelation" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#SeriesRelation",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#SeriesRelation"
     },
     "tableOfContents" : {
       "@type" : "@id",
@@ -413,9 +356,7 @@
       "@container" : "@set"
     },
     "SubjectHeading" : {
-      "@type" : "@id",
-      "@id" : "http://d-nb.info/standards/elementset/gnd#SubjectHeading",
-      "@container" : "@set"
+      "@id" : "http://d-nb.info/standards/elementset/gnd#SubjectHeading"
     },
     "note" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/note",
@@ -448,8 +389,7 @@
       "@container" : "@set"
     },
     "Standard" : {
-      "@id" : "http://purl.org/ontology/bibo/Standard",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Standard"
     },
     "medium" : {
       "@type" : "@id",
@@ -478,28 +418,20 @@
       "@container" : "@set"
     },
     "Biography" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#Biography",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#Biography"
     },
     "coverage" : {
       "@id" : "http://purl.org/dc/elements/1.1/coverage",
       "@container" : "@set"
     },
     "OfficialPublication" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#OfficialPublication",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#OfficialPublication"
     },
     "Periodical" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Periodical",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Periodical"
     },
     "Report" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Report",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Report"
     },
     "webPageArchived" : {
       "@type" : "@id",
@@ -515,14 +447,10 @@
       "@container" : "@set"
     },
     "EditedVolume" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/lobid/lv#EditedVolume",
-      "@container" : "@set"
+      "@id" : "http://purl.org/lobid/lv#EditedVolume"
     },
     "Series" : {
-      "@type" : "@id",
-      "@id" : "http://purl.org/ontology/bibo/Series",
-      "@container" : "@set"
+      "@id" : "http://purl.org/ontology/bibo/Series"
     },
     "subjectAltLabel" : {
       "@id" : "http://purl.org/lobid/lv#subjectAltLabel",
@@ -533,7 +461,6 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/itemOf"
     },
     "PublicationEvent" : {
-      "@type" : "@id",
       "@id" : "http://schema.org/PublicationEvent"
     },
     "location" : {
@@ -541,9 +468,7 @@
       "@container" : "@set"
     },
     "Contribution" : {
-      "@type" : "@id",
-      "@id" : "http://id.loc.gov/ontologies/bibframe/Contribution",
-      "@container" : "@set"
+      "@id" : "http://id.loc.gov/ontologies/bibframe/Contribution"
     },
     "sameAs" : {
       "@type" : "@id",


### PR DESCRIPTION
When dealing with owl:class the definitions in the context json-ld
shouldn't use the @type nor the @container infos.

Resolves hbz/lobid-rdf-to-json#59.