### PR TITLE
Remove shortcut S.l. for publication place

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -738,6 +738,7 @@
 				<regexp match="^\[.*\]"/>
 				<replace pattern="^\[" with=""/>
 				<replace pattern="\]$" with=""/>
+				<replace pattern="[sS]\.l\." with=""/>
 			</data>
 			<data source="@placeOfPublication_"/>
 		</choose>

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -8695,7 +8695,6 @@ _:Bb1 <http://schema.org/location> "Marburg/Lahn"^^<http://www.w3.org/2001/XMLSc
 _:Bb1 <http://schema.org/location> "N\u00FCrnberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "New York"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "Paderborn"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb1 <http://schema.org/location> "S.l."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "Ulm"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "WIEN"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/publishedBy> "American Institute of Physics"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9305,7 +9304,6 @@ _:Bb4 <http://schema.org/location> "Kissing"^^<http://www.w3.org/2001/XMLSchema#
 _:Bb4 <http://schema.org/location> "M\u00FCnchen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://schema.org/location> "Opladen"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://schema.org/location> "S.l."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://schema.org/location> "Schmallenberg-Holthausen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://schema.org/location> "Sinzig"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://schema.org/publishedBy> "Fink"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/jsonld/HT010662586
+++ b/src/test/resources/jsonld/HT010662586
@@ -36,7 +36,6 @@
     "label" : "Print"
   } ],
   "publication" : [ {
-    "location" : "S.l.",
     "publishedBy" : "Leicester Univ. Pr.",
     "startDate" : "1957",
     "type" : [ "PublicationEvent" ]

--- a/src/test/resources/jsonld/HT010726584
+++ b/src/test/resources/jsonld/HT010726584
@@ -306,7 +306,6 @@
     "label" : "Physics of fluids / B"
   } ],
   "publication" : [ {
-    "location" : "S.l.",
     "publishedBy" : "American Institute of Physics",
     "startDate" : "1994",
     "type" : [ "PublicationEvent" ]

--- a/src/test/resources/jsonld/HT016608165
+++ b/src/test/resources/jsonld/HT016608165
@@ -79,7 +79,6 @@
   } ],
   "otherTitleInformation" : [ "[L 15]" ],
   "publication" : [ {
-    "location" : "S.l.",
     "startDate" : "1980",
     "type" : [ "PublicationEvent" ]
   } ],

--- a/src/test/resources/output/json/01066/HT010662586.json
+++ b/src/test/resources/output/json/01066/HT010662586.json
@@ -41,7 +41,6 @@
     "label" : "Print"
   } ],
   "publication" : [ {
-    "location" : "S.l.",
     "publishedBy" : "Leicester Univ. Pr.",
     "startDate" : "1957",
     "type" : [ "PublicationEvent" ]

--- a/src/test/resources/output/json/01072/HT010726584.json
+++ b/src/test/resources/output/json/01072/HT010726584.json
@@ -471,7 +471,6 @@
     "label" : "Physics of fluids / B"
   } ],
   "publication" : [ {
-    "location" : "S.l.",
     "publishedBy" : "American Institute of Physics",
     "startDate" : "1994",
     "type" : [ "PublicationEvent" ]

--- a/src/test/resources/output/json/01660/HT016608165.json
+++ b/src/test/resources/output/json/01660/HT016608165.json
@@ -84,7 +84,6 @@
   } ],
   "otherTitleInformation" : [ "[L 15]" ],
   "publication" : [ {
-    "location" : "S.l.",
     "startDate" : "1980",
     "type" : [ "PublicationEvent" ]
   } ],

--- a/src/test/resources/reverseTest/output/nt/01066/HT010662586.nt
+++ b/src/test/resources/reverseTest/output/nt/01066/HT010662586.nt
@@ -1,7 +1,6 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118839055> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://schema.org/location> "S.l."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/publishedBy> "Leicester Univ. Pr."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1957"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .

--- a/src/test/resources/reverseTest/output/nt/01072/HT010726584.nt
+++ b/src/test/resources/reverseTest/output/nt/01072/HT010726584.nt
@@ -1,6 +1,5 @@
 _:b0 <http://www.loc.gov/mads/rdf/v1#componentList> _:b3 .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b1 <http://schema.org/location> "S.l."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/publishedBy> "American Institute of Physics"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1994"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .

--- a/src/test/resources/reverseTest/output/nt/01660/HT016608165.nt
+++ b/src/test/resources/reverseTest/output/nt/01660/HT016608165.nt
@@ -10,7 +10,6 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b3 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/119080389> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b4 <http://schema.org/location> "S.l."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1980"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .


### PR DESCRIPTION
Resolves #363

Removed S.l. (sine locum, without a place). See [example (production)](http://lobid.org/resources/HT016608165) / [example (test)](http://test.lobid.org/resources/HT016608165).