### PR TITLE
Add language labels

### DIFF
--- a/src/main/resources/labels/labels.json
+++ b/src/main/resources/labels/labels.json
@@ -13592,8 +13592,32 @@
       }
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/abk",
+      "label" : "Abchasisch"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/afr",
       "label" : "Afrikaans"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/akk",
+      "label" : "Akkadisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/akk",
+      "label" : "Albanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/alg",
+      "label" : "Algonkin-Sprachen (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/amh",
+      "label" : "Amharisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ang",
+      "label" : "Altenglisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/ara",
@@ -13602,6 +13626,14 @@
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/arm",
       "label" : "Armenisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ath",
+      "label" : "Athapaskische Sprachen (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/aym",
+      "label" : "Aymará-Sprache"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/aze",
@@ -13616,16 +13648,40 @@
       "label" : "Weißrussisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ben",
+      "label" : "Bengali"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/bnt",
+      "label" : "Bantusprachen (Andere)"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/bos",
       "label" : "Bosnisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/bre",
+      "label" : "Bretonisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/bul",
       "label" : "Bulgarisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/bur",
+      "label" : "Birmanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/cai",
+      "label" : "Indianersprachen, Zentralamerika (Andere)"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/cat",
       "label" : "Katalanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/cel",
+      "label" : "Keltische Sprachen (Andere)"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/che",
@@ -13636,8 +13692,28 @@
       "label" : "Chinesisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/chu",
+      "label" : "Kirchenslawisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/cop",
+      "label" : "Koptisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/cor",
+      "label" : "Kornisch"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/cos",
       "label" : "Korsisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/crp",
+      "label" : "Kreolische Sprachen | Pidginsprachen (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/csb",
+      "label" : "Kaschubisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/cze",
@@ -13648,8 +13724,24 @@
       "label" : "Dänisch"
    },
    {
-      "uri":"http://id.loc.gov/vocabulary/iso639-2/deu",
-      "label":"Deutsch"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/den",
+      "label" : "Slave-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/deu",
+      "label" : "Deutsch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/dum",
+      "label" : "Mittelniederländisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/dut",
+      "label" : "Niederländisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/dzo",
+      "label" : "Dzongkha"
    },
    {
       "uri":"http://id.loc.gov/vocabulary/iso639-2/egy",
@@ -13664,12 +13756,24 @@
       "label":"Englisch"
    },
    {
+      "uri":"http://id.loc.gov/vocabulary/iso639-2/enm",
+      "label":"Mittelenglisch"
+   },
+   {
       "uri":"http://id.loc.gov/vocabulary/iso639-2/epo",
       "label":"Esperanto"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/est",
       "label" : "Estnisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ewe",
+      "label" : "Ewe-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/fao",
+      "label" : "Färöisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/fas",
@@ -13688,8 +13792,28 @@
       "label":"Französisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/frm",
+      "label" : "Mittelfranzösisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/fro",
+      "label" : "Altfranzösisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/fur",
+      "label" : "Friulisch"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/geo",
       "label" : "Georgisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+      "label" : "Deutsch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/gez",
+      "label" : "Altäthiopisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/gla",
@@ -13700,12 +13824,24 @@
       "label" : "Irisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/glg",
+      "label" : "Galicisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/glv",
+      "label" : "Manx"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/gmh",
       "label" : "Mittelhochdeutsch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/goh",
       "label" : "Althochdeutsch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/got",
+      "label" : "Gotisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/grc",
@@ -13716,12 +13852,28 @@
       "label" : "Neugriechisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/grn",
+      "label" : "Guaraní-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/guj",
+      "label" : "Gujarati-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/hau",
+      "label" : "Haussa-Sprache"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/heb",
       "label" : "Hebräisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/hin",
       "label" : "Hindi"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/hit",
+      "label" : "Hethitisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/hrv",
@@ -13736,16 +13888,68 @@
       "label" : "Isländisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/iku",
+      "label" : "Inuktitut"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ind",
+      "label" : "Bahasa Indonesia"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ira",
+      "label" : "Iranische Sprachen (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/iro",
+      "label" : "Irokesische Sprachen"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/isl",
       "label" : "Isländisch"
    },
    {
-      "uri":"http://id.loc.gov/vocabulary/iso639-2/ita",
-      "label":"Italienisch"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ita",
+      "label" : "Italienisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/jav",
+      "label" : "Javanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/jpn",
+      "label" : "Japanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/kal",
+      "label" : "Grönländisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/kan",
+      "label" : "Kannada"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/kat",
       "label" : "Georgisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/kaz",
+      "label" : "Kasachisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/khm",
+      "label" : "Kambodschanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/kin",
+      "label" : "Rwanda-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/kir",
+      "label" : "Kirgisisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/kon",
+      "label" : "Kongo-Sprache"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/kor",
@@ -13756,20 +13960,60 @@
       "label" : "Kurdisch"
    },
    {
-      "uri":"http://id.loc.gov/vocabulary/iso639-2/lat",
-      "label":"Latein"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/lad",
+      "label" : "Judenspanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/lao",
+      "label" : "Laotisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/lat",
+      "label" : "Latein"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/lav",
       "label" : "Lettisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/lin",
+      "label" : "Lingala"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/lit",
+      "label" : "Litauisch"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/ltz",
       "label" : "Luxemburgisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/mac",
+      "label" : "Makedonisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/mal",
+      "label" : "Malayalam"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/mar",
+      "label" : "Marathi"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/may",
+      "label" : "Malaiisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/mlg",
+      "label" : "Malagassi-Sprache"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/mlt",
       "label" : "Maltesisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/mnc",
+      "label" : "Mandschurisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/mon",
@@ -13780,20 +14024,64 @@
       "label" : "Mehrere Sprachen"
    },
    {
-      "uri":"http://id.loc.gov/vocabulary/iso639-2/nds",
-      "label":"Niederdeutsch"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/myn",
+      "label" : "Maya-Sprachen"
+   },
+	 {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/nah",
+      "label" : "Nahuatl"
    },
    {
-      "uri":"http://id.loc.gov/vocabulary/iso639-2/nld",
-      "label":"Niederländisch"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/nai",
+      "label" : "Indianersprachen, Nordamerika (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/nds",
+      "label" : "Niederdeutsch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/nep",
+      "label" : "Nepali"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/nld",
+      "label" : "Niederländisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/nor",
       "label" : "Norwegisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/oci",
+      "label" : "Okzitanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ota",
+      "label" : "Osmanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/paa",
+      "label" : "Papuasprachen (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/pal",
+      "label" : "Mittelpersisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/pan",
+      "label" : "Pandschabi-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/pap",
+      "label" : "Papiamento"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/per",
       "label" : "Persisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/pli",
+      "label" : "P?li"
    },
    {
       "uri":"http://id.loc.gov/vocabulary/iso639-2/pol",
@@ -13802,6 +14090,30 @@
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/por",
       "label" : "Portugiesisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/pra",
+      "label" : "Pr?krit"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/pus",
+      "label" : "Paschtu"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/que",
+      "label" : "Quechua-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/raj",
+      "label" : "R?jasth?n?"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/roa",
+      "label" : "Romanische Sprachen (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/roh",
+      "label" : "Rätoromanisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/ron",
@@ -13816,12 +14128,24 @@
       "label":"Russisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/sai",
+      "label" : "Indianersprachen, Südamerika (Andere)"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/san",
+      "label" : "Sanskrit"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/scn",
       "label" : "Sizilianisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/sco",
       "label" : "Schottisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/sla",
+      "label" : "Slawische Sprachen (Andere)"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/slk",
@@ -13836,36 +14160,160 @@
       "label" : "Slowenisch"
    },
    {
-      "uri" : "http://id.loc.gov/vocabulary/iso639-2/srp",
-      "label" : "Serbisch"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/smi",
+      "label" : "Saamisch"
    },
    {
-      "uri" : "http://id.loc.gov/vocabulary/iso639-2/swe",
-      "label" : "Schwedisch"
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/smo",
+      "label" : "Samoanisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/sna",
+      "label" : "Schona-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/som",
+      "label" : "Somali"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/sot",
+      "label" : "Somali"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/spa",
       "label" : "Spanisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/srd",
+      "label" : "Sardisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/srp",
+      "label" : "Serbisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/sun",
+      "label" : "Sundanesisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/sux",
+      "label" : "Sumerisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/swa",
+      "label" : "Swahili"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/swe",
+      "label" : "Schwedisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/syc",
+      "label" : "Syrisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/syr",
+      "label" : "Neuostaramäisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tam",
+      "label" : "Tamil"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tat",
+      "label" : "Tatarisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tel",
+      "label" : "Telugu-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tgk",
+      "label" : "Tadschikisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tgl",
+      "label" : "Tagalog"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tha",
+      "label" : "Thailändisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ton",
+      "label" : "Tongaisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tuk",
+      "label" : "Turkmenisch"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/tur",
       "label" : "Türkisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/twi",
+      "label" : "Twi-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/tyv",
+      "label" : "Tuwinisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/uig",
+      "label" : "Uigurisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/ukr",
+      "label" : "Ukrainisch"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/und",
       "label" : "Nicht zu entscheiden"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/urd",
+      "label" : "Urdu"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/uzb",
+      "label" : "Usbekisch"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/vie",
       "label" : "Vietnamesisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/vol",
+      "label" : "Volapük"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/wel",
+      "label" : "Kymrisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/wen",
+      "label" : "Sorbisch (Andere)"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/wln",
       "label" : "Wallonisch"
    },
    {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/xho",
+      "label" : "Xhosa-Sprache"
+   },
+   {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/yid",
       "label" : "Jiddisch"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/yor",
+      "label" : "Yoruba-Sprache"
+   },
+   {
+      "uri" : "http://id.loc.gov/vocabulary/iso639-2/zul",
+      "label" : "Zulu-Sprache"
    },
    {
       "uri" : "http://id.loc.gov/vocabulary/iso639-2/zxx",


### PR DESCRIPTION
Added language labels if at least 10 resources had that language.

Resolves #439

Assigning it to dr0i for deployment because the scale of the changes isn't visible in the test set. After the deployment I will check if the language label of "http://id.loc.gov/vocabulary/iso639-2/crp" is shown correctly.