### PR TITLE
Remove subjectChain from context

### DIFF
--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -451,14 +451,6 @@
       "container" : "@set"
    },
    {
-      "name" : "subjectChain",
-      "container" : "@set",
-      "multilangLabel" : {},
-      "referenceType" : "String",
-      "uri" : "http://purl.org/lobid/lv#subjectChain",
-      "label" : "Schlagwortkette"
-   },
-   {
       "container" : "@set",
       "name" : "subjectAltLabel",
       "uri" : "http://purl.org/lobid/lv#subjectAltLabel",

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -283,10 +283,6 @@
       "@id" : "http://purl.org/ontology/bibo/shortTitle",
       "@container" : "@set"
     },
-    "subjectChain" : {
-      "@id" : "http://purl.org/lobid/lv#subjectChain",
-      "@container" : "@set"
-    },
     "frequency" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/frequency",
       "@container" : "@set"


### PR DESCRIPTION
See #187

Removes the leftover `subjectChain` from the context.