### PR TITLE
Change default for corporations with MAB 2?[02468][-a].9 to issuing body

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -1258,9 +1258,8 @@
 				<replace pattern="&lt;" with=""/>
 			</data>
 		</combine>
-		<choose name="@creatorPersonOrCoorporateBodyBnodeOrId" flushWith="@GNDPersonId|@bnodeCreatorPersonLabel|@creatorCorporateBodyId">
+		<choose name="@creatorPersonOrId" flushWith="@GNDPersonId|@bnodeCreatorPersonLabel">
 			<data source="@GNDPersonId"/>
-			<data source="@creatorCorporateBodyId"/>
 			<data source="@bnodeCreatorPersonLabel"/>
 		</choose>
 		<!-- bnode for contributor when no ID -->
@@ -1388,7 +1387,7 @@
 			<data source="[29]??[-abcfep][12].c" name="c"/>
 		</combine>
 		<data
-			source="@contributorPersonBnodeOrId|@contributorCorporateBodyBnodeOrId|@creatorPersonOrCoorporateBodyBnodeOrId"
+			source="@contributorPersonBnodeOrId|@contributorCorporateBodyBnodeOrId|@creatorPersonOrId|@creatorCorporateBodyId"
 			name="@agentId"/>
 		<combine value="_:${a}${b}" name="@contributionBnode" sameEntity="true">
 			<data source="@agentId" name="a"/>
@@ -1449,7 +1448,7 @@
 		<combine name="$[ns-lobid-vocab]contributorOrder" value="${a}">
 			<concat delimiter=" | " name="a">
 				<data
-					source="@creatorPersonOrCoorporateBodyBnodeOrId|@contributorPersonBnodeOrId|@contributorCorporateBodyBnodeOrId">
+					source="@creatorPersonOrId|@contributorPersonBnodeOrId|@contributorCorporateBodyBnodeOrId|@creatorCorporateBodyId">
 					<replace pattern="_:" with=""/>
 				</data>
 			</concat>
@@ -1660,7 +1659,7 @@
 		</data>
 		<combine name="@relator" value="${a}">
 			<choose name="a"
-				flushWith="@contributorPersonBnodeOrId|@contributorCorporateBodyBnodeOrId|@creatorPersonOrCoorporateBodyBnodeOrId">
+				flushWith="@contributorPersonBnodeOrId|@contributorCorporateBodyBnodeOrId|@creatorPersonOrId|@creatorCorporateBodyId">
 				<!-- map literals to marc relator property -->
 				<data source="@marcrelName" name="a">
 					<regexp match="[dD]ars|^\[act\]$|^(act)$" format="http://id.loc.gov/vocabulary/relators/act"/>
@@ -1777,8 +1776,12 @@
 				<data source="@contributorPersonBnodeOrId" name="a">
 					<regexp match=".*" format="http://id.loc.gov/vocabulary/relators/ctb"/>
 				</data>
+				<!-- always issuing body -->
+				<data source="@creatorCorporateBodyId" name="a">
+					<regexp match=".*" format="http://id.loc.gov/vocabulary/relators/isb"/>
+				</data>
 				<!-- always creator -->
-				<data source="@creatorPersonOrCoorporateBodyBnodeOrId" name="a">
+				<data source="@creatorPersonOrId" name="a">
 					<regexp match=".*" format="http://id.loc.gov/vocabulary/relators/cre"/>
 				</data>
 			</choose>

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -9550,6 +9550,7 @@ _:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary
 _:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/drt> .
 _:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
+_:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/pht> .
 _:Bb0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/red> .
 _:Bb0 <http://purl.org/dc/terms/description> "Digital. Ausg."^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/jsonld/BT000002852
+++ b/src/test/resources/jsonld/BT000002852
@@ -11,8 +11,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT001310215
+++ b/src/test/resources/jsonld/HT001310215
@@ -19,8 +19,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT003160768
+++ b/src/test/resources/jsonld/HT003160768
@@ -7,8 +7,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT003654516
+++ b/src/test/resources/jsonld/HT003654516
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT004381366
+++ b/src/test/resources/jsonld/HT004381366
@@ -7,8 +7,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT012237361
+++ b/src/test/resources/jsonld/HT012237361
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT012895751
+++ b/src/test/resources/jsonld/HT012895751
@@ -7,8 +7,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT016604323
+++ b/src/test/resources/jsonld/HT016604323
@@ -11,8 +11,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   }, {

--- a/src/test/resources/jsonld/HT017468042
+++ b/src/test/resources/jsonld/HT017468042
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT018147158
+++ b/src/test/resources/jsonld/HT018147158
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT018771475
+++ b/src/test/resources/jsonld/HT018771475
@@ -23,8 +23,8 @@
       "type" : [ "ConferenceOrEvent" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/HT019248596
+++ b/src/test/resources/jsonld/HT019248596
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/TT002234858
+++ b/src/test/resources/jsonld/TT002234858
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/jsonld/TT003059252_contAndCrea
+++ b/src/test/resources/jsonld/TT003059252_contAndCrea
@@ -20,8 +20,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00000/BT000002852.json
+++ b/src/test/resources/output/json/00000/BT000002852.json
@@ -11,8 +11,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00131/HT001310215.json
+++ b/src/test/resources/output/json/00131/HT001310215.json
@@ -19,8 +19,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00223/TT002234858.json
+++ b/src/test/resources/output/json/00223/TT002234858.json
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00305/TT003059252_contAndCrea.json
+++ b/src/test/resources/output/json/00305/TT003059252_contAndCrea.json
@@ -20,8 +20,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00316/HT003160768.json
+++ b/src/test/resources/output/json/00316/HT003160768.json
@@ -7,8 +7,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00365/HT003654516.json
+++ b/src/test/resources/output/json/00365/HT003654516.json
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/00438/HT004381366.json
+++ b/src/test/resources/output/json/00438/HT004381366.json
@@ -7,8 +7,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/01223/HT012237361.json
+++ b/src/test/resources/output/json/01223/HT012237361.json
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/01289/HT012895751.json
+++ b/src/test/resources/output/json/01289/HT012895751.json
@@ -7,8 +7,8 @@
       "type" : [ "PlaceOrGeographicName" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/01660/HT016604323.json
+++ b/src/test/resources/output/json/01660/HT016604323.json
@@ -11,8 +11,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   }, {

--- a/src/test/resources/output/json/01746/HT017468042.json
+++ b/src/test/resources/output/json/01746/HT017468042.json
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/01814/HT018147158.json
+++ b/src/test/resources/output/json/01814/HT018147158.json
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/01877/HT018771475.json
+++ b/src/test/resources/output/json/01877/HT018771475.json
@@ -23,8 +23,8 @@
       "type" : [ "ConferenceOrEvent" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/output/json/01924/HT019248596.json
+++ b/src/test/resources/output/json/01924/HT019248596.json
@@ -8,8 +8,8 @@
       "type" : [ "CorporateBody" ]
     },
     "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
   } ],

--- a/src/test/resources/reverseTest/output/nt/00000/BT000002852.nt
+++ b/src/test/resources/reverseTest/output/nt/00000/BT000002852.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/4018466-3> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
@@ -22,7 +22,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/4020517-4> <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/7749153-1> <http://www.w3.org/2000/01/rdf-schema#label> "Gemeinsame Normdatei (GND)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-BT000002852> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/organisations/DE-6#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Organisation"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000002852> <http://purl.org/dc/terms/created> "19960513"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00131/HT001310215.nt
+++ b/src/test/resources/reverseTest/output/nt/00131/HT001310215.nt
@@ -2,7 +2,7 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1775723
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/37460-X> .
-_:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b2 <http://schema.org/location> "CHICAGO, ILL."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/publishedBy> "AMERICAN DENTAL ASSOCIATION"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -19,8 +19,8 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/37460-X> <http://www.w3.org/2004/02/skos/core#altLabel> "ADA"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/37460-X> <http://www.w3.org/2004/02/skos/core#altLabel> "Dental Association"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT001310215> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#label> "Mitwirkende"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT001310215:DE-294:ZMC134> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT001310215:DE-294:ZMC134#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-294> .
 <http://lobid.org/items/HT001310215:DE-294:ZMC134#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT001310215#!> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234858.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234858.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2029758-0> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
@@ -19,7 +19,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6267588&custom_att_2=simple_viewer> <http://www.w3.org/2000/01/rdf-schema#label> "Digitool"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-TT002234858> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/TT002234858:DE-929:> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/TT002234858:DE-929:#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-929> .
 <http://lobid.org/items/TT002234858:DE-929:#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/TT002234858#!> .

--- a/src/test/resources/reverseTest/output/nt/00305/TT003059252_contAndCrea.nt
+++ b/src/test/resources/reverseTest/output/nt/00305/TT003059252_contAndCrea.nt
@@ -2,7 +2,7 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2005535
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2005535-3> .
-_:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b2 <http://schema.org/location> "s.l."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/publishedBy> "Apple Films"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -17,8 +17,8 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/2004/02/skos/core#altLabel> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-TT003059252_contAndCrea> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/eng> <http://www.w3.org/2000/01/rdf-schema#label> "Englisch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#label> "Mitwirkende"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/TT003059252_contAndCrea:DE-5-58:9%2F041> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/TT003059252_contAndCrea:DE-5-58:9%2F041#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-5-58> .
 <http://lobid.org/items/TT003059252_contAndCrea:DE-5-58:9%2F041#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/TT003059252_contAndCrea#!> .

--- a/src/test/resources/reverseTest/output/nt/00316/HT003160768.nt
+++ b/src/test/resources/reverseTest/output/nt/00316/HT003160768.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2019209-5> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
@@ -26,7 +26,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/7749153-1> <http://www.w3.org/2000/01/rdf-schema#label> "Gemeinsame Normdatei (GND)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT003160768> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT003160768:DE-385:ONG%2Fg52127> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT003160768:DE-385:ONG%2Fg52127#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-385> .
 <http://lobid.org/items/HT003160768:DE-385:ONG%2Fg52127#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT003160768#!> .

--- a/src/test/resources/reverseTest/output/nt/00365/HT003654516.nt
+++ b/src/test/resources/reverseTest/output/nt/00365/HT003654516.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2005827-5> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
@@ -40,7 +40,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://dewey.info/class/670/> <http://www.w3.org/2000/01/rdf-schema#label> "Industrielle Fertigung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT003654516> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT003654516:DE-294:ZRC458-1988%2F89> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT003654516:DE-294:ZRC458-1988%2F89#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-294> .
 <http://lobid.org/items/HT003654516:DE-294:ZRC458-1988%2F89#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT003654516#!> .

--- a/src/test/resources/reverseTest/output/nt/00438/HT004381366.nt
+++ b/src/test/resources/reverseTest/output/nt/00438/HT004381366.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2019209-5> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
@@ -41,7 +41,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/7749153-1> <http://www.w3.org/2000/01/rdf-schema#label> "Gemeinsame Normdatei (GND)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT004381366> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-6-007> .
 <http://lobid.org/items/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT004381366#!> .

--- a/src/test/resources/reverseTest/output/nt/01223/HT012237361.nt
+++ b/src/test/resources/reverseTest/output/nt/01223/HT012237361.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/36467-8> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://schema.org/endDate> "1975"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://schema.org/location> "Bad Ems"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -14,7 +14,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/36467-8> <http://www.w3.org/2004/02/skos/core#altLabel> "Statistisches Landesamt Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT012237361> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://ld.zdb-services.de/resource/590016-5> <http://www.w3.org/2000/01/rdf-schema#label> "http://ld.zdb-services.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT012237361:DE-107:Per.%205157> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT012237361:DE-107:Per.%205157#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-107> .

--- a/src/test/resources/reverseTest/output/nt/01289/HT012895751.nt
+++ b/src/test/resources/reverseTest/output/nt/01289/HT012895751.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2037247-4> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
@@ -26,7 +26,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/7749153-1> <http://www.w3.org/2000/01/rdf-schema#label> "Gemeinsame Normdatei (GND)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT012895751> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT012895751:DE-929:C2001A%2F13> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT012895751:DE-929:C2001A%2F13#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-929> .
 <http://lobid.org/items/HT012895751:DE-929:C2001A%2F13#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT012895751#!> .

--- a/src/test/resources/reverseTest/output/nt/01660/HT016604323.nt
+++ b/src/test/resources/reverseTest/output/nt/01660/HT016604323.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/16090142-X> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/4065786-3> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
@@ -44,8 +44,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://dewey.info/class/610/> <http://www.w3.org/2000/01/rdf-schema#label> "Medizin und Gesundheit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT016604323> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#label> "Mitwirkende"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://ld.zdb-services.de/resource/2581964-1> <http://www.w3.org/2000/01/rdf-schema#label> "http://ld.zdb-services.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT016604323:DE-6:XB%203534> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT016604323:DE-6:XB%203534#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-6> .

--- a/src/test/resources/reverseTest/output/nt/01746/HT017468042.nt
+++ b/src/test/resources/reverseTest/output/nt/01746/HT017468042.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/5293676-4> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://schema.org/location> "N\u00FCrnberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/publishedBy> "Homannianos Heredes"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -39,7 +39,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://d-nb.info/gnd/5293676-4> <http://www.w3.org/2004/02/skos/core#altLabel> "Verlag Homann"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT017468042> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/lat> <http://www.w3.org/2000/01/rdf-schema#label> "Latein"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT017468042:DE-6:RK%2013> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT017468042:DE-6:RK%2013#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-6> .
 <http://lobid.org/items/HT017468042:DE-6:RK%2013#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT017468042#!> .

--- a/src/test/resources/reverseTest/output/nt/01814/HT018147158.nt
+++ b/src/test/resources/reverseTest/output/nt/01814/HT018147158.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2078024-2> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/frequency> <http://marc21rdf.info/terms/continuingfre#a> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/note> "Ersch. j\u00E4hrl."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -20,7 +20,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://dewey.info/class/330/> <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT018147158> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://ld.zdb-services.de/resource/2754074-1> <http://www.w3.org/2000/01/rdf-schema#label> "http://ld.zdb-services.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/organisations/DE-101#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Organisation"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/organisations/DE-1141#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Organisation"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018771475.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018771475.nt
@@ -2,7 +2,7 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1026545
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1074109953> .
-_:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1074109953> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
@@ -39,8 +39,8 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://dewey.info/class/796/> <http://www.w3.org/2000/01/rdf-schema#label> "Sportarten, Sportspiele"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT018771475> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#label> "Mitwirkende"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/organisations/DE-61#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Organisation"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie (NWBib)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475> <http://purl.org/dc/terms/created> "20151005"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01924/HT019248596.nt
+++ b/src/test/resources/reverseTest/output/nt/01924/HT019248596.nt
@@ -1,5 +1,5 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/3061200-7> .
-_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
+_:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/isb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://schema.org/location> "Oppenheim"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/publishedBy> "[Landesamt f\u00FCr Umwelt, Wasserwirtschaft und Gewerbeaufsicht Rheinland-Pfalz]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -19,7 +19,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://dewey.info/class/914/> <http://www.w3.org/2000/01/rdf-schema#label> "Geografie Europas und Reisen in Europa"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT019248596> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
+<http://id.loc.gov/vocabulary/relators/isb> <http://www.w3.org/2000/01/rdf-schema#label> "Herausgeber/in"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT019248596:DE-107:> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Bestandsressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/items/HT019248596:DE-107:#!> <http://id.loc.gov/ontologies/bibframe/heldBy> <http://lobid.org/organisations/DE-107> .
 <http://lobid.org/items/HT019248596:DE-107:#!> <http://id.loc.gov/ontologies/bibframe/itemOf> <http://lobid.org/resources/HT019248596#!> .


### PR DESCRIPTION
The label for issuing body is "Herausgeber/in" which fits better than "Autor/in".

Resolves https://github.com/hbz/lobid-resources-web/issues/37