### PR TITLE
Remove mapping of MAB 551 to "PublishedScore"

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -737,7 +737,7 @@
 		<data source="334-1.a" name="@rdftype">
 			<regexp match="Musikdruck" format="http://purl.org/ontology/mo/PublishedScore"/>
 		</data>
-		<data source="541[-ab]?.?|551??.?" name="@rdftype">
+		<data source="541[-ab]?.?" name="@rdftype">
 			<regexp match=".*" format="http://purl.org/ontology/mo/PublishedScore"/>
 		</data>
 		<!-- amtliche Druckschrift -->

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -7191,7 +7191,7 @@
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:Bb16 .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015090208> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015090208> .
@@ -7532,7 +7532,6 @@
 <http://lobid.org/resources/HT016382441#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
@@ -7577,7 +7576,7 @@
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/lobid/lv#hbzID> "HT016556189"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016556189> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016556189> .
@@ -9174,7 +9173,6 @@
 <http://lobid.org/resources/HT018939763#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.3726/978-3-653-05265-7> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
@@ -9471,7 +9469,7 @@
 <http://lobid.org/resources/TT000075751#!> <http://purl.org/lobid/lv#hbzID> "TT000075751"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000075751> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000075751> .

--- a/src/test/resources/jsonld/HT015090208
+++ b/src/test/resources/jsonld/HT015090208
@@ -252,5 +252,5 @@
   "subjectAltLabel" : [ "Goethe, Johann Wolfgang von (Faust et le second Faust)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4128140-8, DVD-Video" ],
   "title" : "Peter Stein inszeniert Faust",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/jsonld/HT016382441
+++ b/src/test/resources/jsonld/HT016382441
@@ -284,7 +284,7 @@
     "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer",
     "label" : "Digitool"
   } ],
-  "subject" : [ {
+  "subject" : [ { }, {
     "id" : "https://w3id.org/lobid/rpb2#n820",
     "label" : "Informatik, Kybernetik",
     "source" : {
@@ -309,5 +309,5 @@
     "label" : "Digitool"
   } ],
   "title" : "Linux für Dummies",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/jsonld/HT016556189
+++ b/src/test/resources/jsonld/HT016556189
@@ -149,5 +149,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Jabberwocky",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/jsonld/HT018939763
+++ b/src/test/resources/jsonld/HT018939763
@@ -133,5 +133,5 @@
   "subjectAltLabel" : [ "Sprachenkontakt", "Iberoamerika", "Kontaktlinguistik", "Sprachbeziehungen", "Sprachberührung", "Portugiesische Sprache", "Lusophones Afrika" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6" ],
   "title" : "Dinâmicas Afro-Latinas",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/jsonld/TT000075751
+++ b/src/test/resources/jsonld/TT000075751
@@ -133,5 +133,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Complete folk song arrangements",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/00007/TT000075751.json
+++ b/src/test/resources/output/json/00007/TT000075751.json
@@ -138,5 +138,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Complete folk song arrangements",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/01509/HT015090208.json
+++ b/src/test/resources/output/json/01509/HT015090208.json
@@ -277,5 +277,5 @@
   "subjectAltLabel" : [ "Goethe, Johann Wolfgang von (Faust et le second Faust)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4128140-8, DVD-Video" ],
   "title" : "Peter Stein inszeniert Faust",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/01638/HT016382441.json
+++ b/src/test/resources/output/json/01638/HT016382441.json
@@ -389,7 +389,7 @@
     "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer",
     "label" : "Digitool"
   } ],
-  "subject" : [ {
+  "subject" : [ { }, {
     "id" : "https://w3id.org/lobid/rpb2#n820",
     "label" : "Informatik, Kybernetik",
     "source" : {
@@ -414,5 +414,5 @@
     "label" : "Digitool"
   } ],
   "title" : "Linux für Dummies",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/output/json/01655/HT016556189.json
+++ b/src/test/resources/output/json/01655/HT016556189.json
@@ -154,5 +154,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Jabberwocky",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/01893/HT018939763.json
+++ b/src/test/resources/output/json/01893/HT018939763.json
@@ -138,5 +138,5 @@
   "subjectAltLabel" : [ "Sprachenkontakt", "Iberoamerika", "Kontaktlinguistik", "Sprachbeziehungen", "Sprachberührung", "Portugiesische Sprache", "Lusophones Afrika" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6" ],
   "title" : "Dinâmicas Afro-Latinas",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/reverseTest/output/nt/00007/TT000075751.nt
+++ b/src/test/resources/reverseTest/output/nt/00007/TT000075751.nt
@@ -91,7 +91,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT000075751#!> <http://purl.org/lobid/lv#hbzID> "TT000075751"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000075751> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000075751> .
 <http://purl.org/ontology/bibo/AudioDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Audio-Dokument"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01509/HT015090208.nt
+++ b/src/test/resources/reverseTest/output/nt/01509/HT015090208.nt
@@ -337,7 +337,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:b16 .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015090208> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015090208> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Audio-Visuell"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
+++ b/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
@@ -1,21 +1,21 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/14320713X> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
-_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b2 <http://purl.org/lobid/lv#hasSuperordinate> _:b3 .
-_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
-_:b3 <http://www.w3.org/2000/01/rdf-schema#label> "... f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://schema.org/location> "Weinheim"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://schema.org/publishedBy> "Wiley-VCH"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4337730-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:b3 <http://purl.org/lobid/lv#hasSuperordinate> _:b4 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
+_:b4 <http://www.w3.org/2000/01/rdf-schema#label> "... f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://schema.org/location> "Weinheim"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://schema.org/publishedBy> "Wiley-VCH"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4337730-0> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4337730-0"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4337730-0> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/14320713X> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1962"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/14320713X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/14320713X> <http://www.w3.org/2000/01/rdf-schema#label> "Blum, Richard"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -219,7 +219,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT016382441> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016382441> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
+<http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/extent> "418 S. : zahlr. Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016382441:DE-1044:11%20=%20TWR5408#!> .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016382441:DE-1044:11%20=%20TWR5408%2B1#!> .
@@ -248,20 +248,20 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/subject> _:b1 .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/subject> _:b2 .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/subject> <https://w3id.org/lobid/rpb2#n820> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/tableOfContents> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027722&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/dc/terms/title> "Linux f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/14320713X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#hbzID> "HT016382441"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#isPartOf> _:b2 .
-<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#isPartOf> _:b3 .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/isbn> "9783527706495"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://rdaregistry.info/Elements/u/P60493> "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles f\u00FCr Ihr Rendezvous mit dem Pinguin]"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016382441#!> <http://schema.org/publication> _:b4 .
+<http://lobid.org/resources/HT016382441#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016382441> .

--- a/src/test/resources/reverseTest/output/nt/01655/HT016556189.nt
+++ b/src/test/resources/reverseTest/output/nt/01655/HT016556189.nt
@@ -143,7 +143,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/lobid/lv#hbzID> "HT016556189"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016556189> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016556189> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Audio-Visuell"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
+++ b/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
@@ -94,7 +94,6 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018939763#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.3726/978-3-653-05265-7> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018939763> .


### PR DESCRIPTION
As MAB field 551 holds the "VERLAGS-, PRODUKTIONS- UND BESTELLNUMMER VON MUSIKALIEN UND TONTRAEGERN" (see [MAB documentation](http://www.dnb.de/SharedDocs/Downloads/DE/DNB/standardisierung/mabTitelBibliographischeDaten2001.txt?__blob=publicationFile)) resources with content in this field can be either PublishedScores or AV documents and thus you shouldn't automatically add the publication type "PublishedScore". See also https://jira.hbz-nrw.de/browse/FRL-275.