### PR TITLE
Remove mapping of MAB 551 to "PublishedScore"

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -737,7 +737,7 @@
 		<data source="334-1.a" name="@rdftype">
 			<regexp match="Musikdruck" format="http://purl.org/ontology/mo/PublishedScore"/>
 		</data>
-		<data source="541[-ab]?.?|551??.?" name="@rdftype">
+		<data source="541[-ab]?.?" name="@rdftype">
 			<regexp match=".*" format="http://purl.org/ontology/mo/PublishedScore"/>
 		</data>
 		<!-- amtliche Druckschrift -->

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -7206,7 +7206,7 @@
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:Bb16 .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015090208> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015090208> .
@@ -7548,7 +7548,6 @@
 <http://lobid.org/resources/HT016382441#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
@@ -7594,7 +7593,7 @@
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/lobid/lv#hbzID> "HT016556189"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016556189> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016556189> .
@@ -9200,7 +9199,6 @@
 <http://lobid.org/resources/HT018939763#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.3726/978-3-653-05265-7> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
@@ -9497,7 +9495,7 @@
 <http://lobid.org/resources/TT000075751#!> <http://purl.org/lobid/lv#hbzID> "TT000075751"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000075751> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000075751> .

--- a/src/test/resources/jsonld/HT015090208
+++ b/src/test/resources/jsonld/HT015090208
@@ -252,5 +252,5 @@
   "subjectAltLabel" : [ "Goethe, Johann Wolfgang von (Faust et le second Faust)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4128140-8, DVD-Video" ],
   "title" : "Peter Stein inszeniert Faust",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/jsonld/HT016382441
+++ b/src/test/resources/jsonld/HT016382441
@@ -309,5 +309,5 @@
     "label" : "Digitool"
   } ],
   "title" : "Linux für Dummies",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/jsonld/HT016556189
+++ b/src/test/resources/jsonld/HT016556189
@@ -149,5 +149,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Jabberwocky",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/jsonld/HT018939763
+++ b/src/test/resources/jsonld/HT018939763
@@ -133,5 +133,5 @@
   "subjectAltLabel" : [ "Sprachenkontakt", "Iberoamerika", "Kontaktlinguistik", "Sprachbeziehungen", "Sprachberührung", "Portugiesische Sprache", "Lusophones Afrika" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6" ],
   "title" : "Dinâmicas Afro-Latinas",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/jsonld/TT000075751
+++ b/src/test/resources/jsonld/TT000075751
@@ -133,5 +133,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Complete folk song arrangements",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/00007/TT000075751.json
+++ b/src/test/resources/output/json/00007/TT000075751.json
@@ -138,5 +138,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Complete folk song arrangements",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/01509/HT015090208.json
+++ b/src/test/resources/output/json/01509/HT015090208.json
@@ -277,5 +277,5 @@
   "subjectAltLabel" : [ "Goethe, Johann Wolfgang von (Faust et le second Faust)" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4128140-8, DVD-Video" ],
   "title" : "Peter Stein inszeniert Faust",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/01638/HT016382441.json
+++ b/src/test/resources/output/json/01638/HT016382441.json
@@ -414,5 +414,5 @@
     "label" : "Digitool"
   } ],
   "title" : "Linux für Dummies",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/output/json/01655/HT016556189.json
+++ b/src/test/resources/output/json/01655/HT016556189.json
@@ -154,5 +154,5 @@
     "label" : "Culturegraph Ressource"
   } ],
   "title" : "Jabberwocky",
-  "type" : [ "BibliographicResource", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Miscellaneous" ]
 }

--- a/src/test/resources/output/json/01893/HT018939763.json
+++ b/src/test/resources/output/json/01893/HT018939763.json
@@ -138,5 +138,5 @@
   "subjectAltLabel" : [ "Sprachenkontakt", "Iberoamerika", "Kontaktlinguistik", "Sprachbeziehungen", "Sprachberührung", "Portugiesische Sprache", "Lusophones Afrika" ],
   "subjectOrder" : [ "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6" ],
   "title" : "Dinâmicas Afro-Latinas",
-  "type" : [ "BibliographicResource", "Book", "PublishedScore" ]
+  "type" : [ "BibliographicResource", "Book" ]
 }

--- a/src/test/resources/reverseTest/output/nt/00007/TT000075751.nt
+++ b/src/test/resources/reverseTest/output/nt/00007/TT000075751.nt
@@ -91,7 +91,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT000075751#!> <http://purl.org/lobid/lv#hbzID> "TT000075751"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000075751> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000075751> .
 <http://purl.org/ontology/bibo/AudioDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Audio-Dokument"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01509/HT015090208.nt
+++ b/src/test/resources/reverseTest/output/nt/01509/HT015090208.nt
@@ -337,7 +337,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:b16 .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015090208> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015090208> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Audio-Visuell"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
+++ b/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
@@ -262,7 +262,6 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016382441> .

--- a/src/test/resources/reverseTest/output/nt/01655/HT016556189.nt
+++ b/src/test/resources/reverseTest/output/nt/01655/HT016556189.nt
@@ -143,7 +143,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/lobid/lv#hbzID> "HT016556189"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
-<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
+<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016556189> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016556189> .
 <http://purl.org/ontology/bibo/AudioVisualDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Audio-Visuell"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
+++ b/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
@@ -94,7 +94,6 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018939763#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.3726/978-3-653-05265-7> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018939763> .


### PR DESCRIPTION
Here's the next PR for this as we had some problems in the first round (see https://github.com/hbz/lobid-resources/pull/571). This also doesn't have an issue associated with it but I think this is ok for this minor change.

As MAB field 551 holds the "VERLAGS-, PRODUKTIONS- UND BESTELLNUMMER VON MUSIKALIEN UND TONTRAEGERN" (see [MAB documentation](http://www.dnb.de/SharedDocs/Downloads/DE/DNB/standardisierung/mabTitelBibliographischeDaten2001.txt?__blob=publicationFile)) resources with content in this field can be either PublishedScores or AV documents and thus you shouldn't automatically add the publication type "PublishedScore". See also https://jira.hbz-nrw.de/browse/FRL-275. Includes an update of the test data.