### PR TITLE
Tweaks based on changes for NWBib

### DIFF
--- a/web/app/views/details.scala.html
+++ b/web/app/views/details.scala.html
@@ -27,7 +27,7 @@
       <h1>@((doc\\"title")(0).asOpt[String].getOrElse(q)) @for(subTitle <- (doc \ "otherTitleInformation").asOpt[Seq[String]]){<br/><small>@subTitle</small>}</h1>
       <div class="row" id="search-results">
       @defining(Lobid.items(doc.toString)) { items =>
-        @defining(!(doc\\"isPartOf").isEmpty && (doc\"type").toString.contains("Article")){superordination =>
+        @defining(!(doc\\"containedIn").isEmpty && (doc\"type").toString.contains("Article")){superordination =>
           <div class="col-md-@if(items.isEmpty && !doc.toString.contains("fulltextOnline") && !superordination){12} else {8}">
             <dl>
             @defining((doc\\"hbzId")(0).asOpt[String].getOrElse(q)){ id =>
@@ -64,7 +64,7 @@
                 <th style="width: 30%"></th>
                 <th style="width: 70%"></th>
               </tr>
-              @result_field("Zum Bestand siehe:", "hasSuperordinate", doc, TableRow.LINKS)
+              @result_field("Zum Bestand siehe:", "containedIn", doc, TableRow.LINKS)
             </table>
             </dd>
             }

--- a/web/app/views/details.scala.html
+++ b/web/app/views/details.scala.html
@@ -24,7 +24,7 @@
 } else {
   @defining(Json.parse(docJson)) { doc =>
     @main("", if( (doc\\"title").isEmpty) "lobid-resources - Vollanzeige" else (doc\\"title")(0).asOpt[String].getOrElse(q)) {
-      <h1>@((doc\\"title")(0).asOpt[String].getOrElse(q))</h1>
+      <h1>@((doc\\"title")(0).asOpt[String].getOrElse(q)) @for(subTitle <- (doc \ "otherTitleInformation").asOpt[Seq[String]]){<br/><small>@subTitle</small>}</h1>
       <div class="row" id="search-results">
       @defining(Lobid.items(doc.toString)) { items =>
         @defining(!(doc\\"isPartOf").isEmpty && (doc\"type").toString.contains("Article")){superordination =>


### PR DESCRIPTION
This adds two tweaks corresponding to the work in progress in https://github.com/hbz/nwbib/issues/163:

- Use `otherTitleInformation` as sub-header: http://stage.lobid.org/resources/HT019478500
- Fix display of superordinate links for articles: http://stage.lobid.org/resources/HT013829089

We have no issue, assigning this pull request for functional review.