### PR TITLE
Add raw keyword sub-field for subject.componentList.label

### DIFF
--- a/src/main/resources/index-config.json
+++ b/src/main/resources/index-config.json
@@ -473,8 +473,14 @@
                            "type" : "keyword"
                         },
                      "label": {
-                        "type": "text"
-                        },
+                        "type": "text",
+                        "fields": {
+                            "raw": {
+                                "type": "keyword",
+                                "index": "true"
+                            }
+                        }
+                     },
                      "type": {
                         "index" : "true",
                         "type": "keyword"


### PR DESCRIPTION
Required for scripted aggregation to implement NWBib topic search

See https://github.com/hbz/nwbib/issues/163

@dr0i This pull request is for the ES 5.6 code. It would be great if you could integrate this so that it is available in the ES 5.6 cluster after the Wednesday indexing, independent of our decision about merging the ES 5.6 code into master next week or not.

