### PR TITLE
Set up nested fields and nested queries

### DIFF
--- a/src/main/resources/index-config.json
+++ b/src/main/resources/index-config.json
@@ -379,6 +379,8 @@
                "type" : "text"
             },
             "contribution" : {
+               "type" : "nested",
+               "include_in_parent" : "true",
                "properties" : {
                   "agent" : {
                      "properties" : {
@@ -465,8 +467,12 @@
                }
             },
             "subject": {
+               "type" : "nested",
+               "include_in_parent" : "true",
                "properties": {
                   "componentList": {
+                     "type" : "nested",
+                     "include_in_parent" : "true",
                      "properties": {
                         "id": {
                            "index" : "true",

--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -91,6 +91,8 @@ public class Application extends Controller {
 	public static final String MEDIUM_FIELD = "medium.id";
 	/** The internal ES aggregation name for the owner facet. */
 	public static final String OWNER_AGGREGATION = "owner";
+	/** The internal ES aggregation name for the topics. */
+	public static final String TOPIC_AGGREGATION = "topic";
 	/** The internal ES field for subjects. */
 	public static final String SUBJECT_FIELD = "subject.componentList.id";
 	/** The internal ES field for contributing agents. */

--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -166,7 +166,7 @@ public class Application extends Controller {
 	 * @param format The response format (see {@code Accept.Format})
 	 * @param aggs The comma separated aggregation fields
 	 * @param location A single "lat,lon" point or space delimited points polygon
-	 * @param nested The nested object path. If non-empty, use q as nested query
+	 * @param nested A nested query, formatted as "<nested field>:<query string>"
 	 * @param filter A filter to apply to the query, supports query string syntax
 	 * @return The search results
 	 */

--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -168,13 +168,14 @@ public class Application extends Controller {
 	 * @param format The response format (see {@code Accept.Format})
 	 * @param aggs The comma separated aggregation fields
 	 * @param location A single "lat,lon" point or space delimited points polygon
+	 * @param nested The nested object path. If non-empty, use q as nested query
 	 * @return The search results
 	 */
 	public static Promise<Result> query(final String q, final String agent,
 			final String name, final String subject, final String id,
 			final String publisher, final String issued, final String medium,
 			final int from, final int size, final String owner, String t, String sort,
-			String set, String format, String aggs, String location) {
+			String set, String format, String aggs, String location, String nested) {
 		final String aggregations = aggs == null ? "" : aggs;
 		if (!aggregations.isEmpty() && !Index.SUPPORTED_AGGREGATIONS
 				.containsAll(Arrays.asList(aggregations.split(",")))) {
@@ -213,7 +214,7 @@ public class Application extends Controller {
 		} else {
 			result = Promise.promise(() -> {
 				Index queryResources = index.queryResources(queryString, from, size,
-						sort, owner, aggregations, location);
+						sort, owner, aggregations, location, nested);
 				boolean returnSuggestions = responseFormat.startsWith("json:");
 				JsonNode json = returnSuggestions
 						? toSuggestions(queryResources.getResult(), format.split(":")[1])
@@ -546,16 +547,17 @@ public class Application extends Controller {
 	 * @param sort Sorting order for results ("newest", "oldest", "" -> relevance)
 	 * @param set The set
 	 * @param location A single "lat,lon" point or space delimited points polygon
+	 * @param nested The nested object path. If non-empty, use q as nested query
 	 * @return The search results
 	 */
 	public static Promise<Result> facets(String q, String agent, String name,
 			String subject, String id, String publisher, String issued, String medium,
 			int from, int size, String owner, String t, String field, String sort,
-			String set, String location) {
+			String set, String location, String nested) {
 
-		String key =
-				String.format("facets.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s", field, q,
-						agent, name, id, publisher, set, subject, issued, medium, owner, t);
+		String key = String.format("facets.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
+				field, q, agent, name, id, publisher, set, subject, issued, medium,
+				owner, t, nested);
 		Result cachedResult = (Result) Cache.get(key);
 		if (cachedResult != null) {
 			return Promise.promise(() -> cachedResult);
@@ -623,12 +625,11 @@ public class Application extends Controller {
 			boolean current =
 					current(subject, agent, medium, owner, t, field, term, location);
 
-			String routeUrl =
-					routes.Application
-							.query(q, agentQuery, name, subjectQuery, id, publisher,
-									issuedQuery, mediumQuery, from, size, ownerQuery, typeQuery,
-									sort(sort, subjectQuery), set, null, field, locationQuery)
-							.url();
+			String routeUrl = routes.Application
+					.query(q, agentQuery, name, subjectQuery, id, publisher, issuedQuery,
+							mediumQuery, from, size, ownerQuery, typeQuery,
+							sort(sort, subjectQuery), set, null, field, locationQuery, nested)
+					.url();
 
 			String result = String.format(
 					"<li " + (current ? "class=\"active\"" : "")
@@ -643,28 +644,29 @@ public class Application extends Controller {
 
 		Promise<Result> promise =
 				query(q, agent, name, subject, id, publisher, issued, medium, from,
-						size, owner, t, sort, set, "json", field, location).map(result -> {
-							JsonNode json = Json.parse(Helpers.contentAsString(result))
-									.get("aggregation");
-							Stream<JsonNode> stream =
-									StreamSupport.stream(Spliterators.spliteratorUnknownSize(
-											json.get(field).elements(), 0), false);
-							String labelKey = String.format(
-									"facets-labels.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s", field, q,
-									agent, name, id, publisher, set, subject, issued, medium,
-									field.equals(OWNER_AGGREGATION) ? "" : owner, t);
-
-							@SuppressWarnings("unchecked")
-							List<Pair<JsonNode, String>> labelledFacets =
-									(List<Pair<JsonNode, String>>) Cache.get(labelKey);
-							if (labelledFacets == null) {
-								labelledFacets = stream.map(toLabel).filter(labelled)
-										.collect(Collectors.toList());
-								Cache.set(labelKey, labelledFacets, ONE_DAY);
-							}
-							return labelledFacets.stream().sorted(sorter).map(toHtml)
-									.collect(Collectors.toList());
-						}).map(lis -> ok(String.join("\n", lis)));
+						size, owner, t, sort, set, "json", field, location, nested)
+								.map(result -> {
+									JsonNode json = Json.parse(Helpers.contentAsString(result))
+											.get("aggregation");
+									Stream<JsonNode> stream =
+											StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+													json.get(field).elements(), 0), false);
+									String labelKey = String.format(
+											"facets-labels.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s.%s",
+											field, q, agent, name, id, publisher, set, subject,
+											issued, medium,
+											field.equals(OWNER_AGGREGATION) ? "" : owner, t);
+									@SuppressWarnings("unchecked")
+									List<Pair<JsonNode, String>> labelledFacets =
+											(List<Pair<JsonNode, String>>) Cache.get(labelKey);
+									if (labelledFacets == null) {
+										labelledFacets = stream.map(toLabel).filter(labelled)
+												.collect(Collectors.toList());
+										Cache.set(labelKey, labelledFacets, ONE_DAY);
+									}
+									return labelledFacets.stream().sorted(sorter).map(toHtml)
+											.collect(Collectors.toList());
+								}).map(lis -> ok(String.join("\n", lis)));
 		promise.onRedeem(r -> Cache.set(key, r, ONE_DAY));
 		return promise;
 	}

--- a/web/app/controllers/resources/Index.java
+++ b/web/app/controllers/resources/Index.java
@@ -198,6 +198,10 @@ public class Index {
 			if (!nested.isEmpty()) {
 				query = QueryBuilders.nestedQuery(nested, query, ScoreMode.Avg);
 			}
+			if (!filter.isEmpty()) {
+				query = QueryBuilders.boolQuery().must(query)
+						.filter(QueryBuilders.queryStringQuery(filter));
+			}
 			SearchRequestBuilder requestBuilder = client.prepareSearch(INDEX_NAME)
 					.setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
 					.setTypes(TYPE_RESOURCE).setQuery(query).setFrom(from).setSize(size);
@@ -208,9 +212,6 @@ public class Index {
 			if (!aggregations.isEmpty()) {
 				requestBuilder =
 						withAggregations(client, requestBuilder, aggregations.split(","));
-			}
-			if (!filter.isEmpty()) {
-				requestBuilder.setPostFilter(QueryBuilders.queryStringQuery(filter));
 			}
 			SearchResponse response = requestBuilder.execute().actionGet();
 			SearchHits hits = response.getHits();

--- a/web/app/controllers/resources/Index.java
+++ b/web/app/controllers/resources/Index.java
@@ -177,7 +177,7 @@ public class Index {
 	 * @param owner Owner institution
 	 * @param aggregations The comma separated aggregation fields
 	 * @param location A single "lat,lon" point or space delimited points polygon
-	 * @param nested The nested object path. If non-empty, use q as nested query
+	 * @param nested A nested query, formatted as "<nested field>:<query string>"
 	 * @param filter A filter to apply to the query, supports query string syntax
 	 * @return This index, get results via {@link #getResult()} and
 	 *         {@link #getTotal()}
@@ -196,7 +196,11 @@ public class Index {
 						QueryBuilders.boolQuery().must(query).must(polygonQuery(location));
 			}
 			if (!nested.isEmpty()) {
-				query = QueryBuilders.nestedQuery(nested, query, ScoreMode.Avg);
+				String nestedFieldName = nested.substring(0, nested.indexOf(':'));
+				String nestedQueryString = nested.substring(nested.indexOf(':') + 1);
+				QueryBuilder nestedQuery = QueryBuilders.nestedQuery(nestedFieldName,
+						QueryBuilders.queryStringQuery(nestedQueryString), ScoreMode.Avg);
+				query = QueryBuilders.boolQuery().must(query).must(nestedQuery);
 			}
 			if (!filter.isEmpty()) {
 				query = QueryBuilders.boolQuery().must(query)

--- a/web/app/controllers/resources/Index.java
+++ b/web/app/controllers/resources/Index.java
@@ -144,7 +144,7 @@ public class Index {
 			for (int j = 0; j < vals.length; j++) {
 				String v = vals[j];
 				q += f + ":"
-						+ (f.endsWith(".id") ? "\"" + Lobid.escapeUri(v) + "\"" : v);
+						+ (v.startsWith("http") ? "\"" + Lobid.escapeUri(v) + "\"" : v);
 				if (j < vals.length - 1)
 					q += " AND ";
 			}

--- a/web/app/controllers/resources/Index.java
+++ b/web/app/controllers/resources/Index.java
@@ -89,8 +89,8 @@ public class Index {
 	 * {@link #buildQueryString(String, String...)}
 	 */
 	public static final String[] QUERY_FIELDS =
-			new String[] { "contribution.agent.label", "title",
-					"subject.componentList.id|subject.componentList.label|subject.label",
+			new String[] { "contribution.agent.label", "title|otherTitleInformation",
+					"subject.componentList.id|subject.componentList.label|subject.label|subjectAltLabel",
 					"isbn|issn", "publication.publishedBy", "publication.startDate",
 					"medium.id", "type", "collectedBy.id" };
 

--- a/web/app/controllers/resources/LocalIndex.java
+++ b/web/app/controllers/resources/LocalIndex.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -98,7 +99,9 @@ public class LocalIndex {
 			BulkRequestBuilder bulkRequest) {
 		Arrays.asList(sampleDataRoot.listFiles()).forEach((file) -> {
 			try {
-				String data = Files.readAllLines(Paths.get(file.getAbsolutePath()))
+				String data = Files
+						.readAllLines(Paths.get(file.getAbsolutePath()),
+								StandardCharsets.UTF_8)
 						.stream().map(String::trim).collect(Collectors.joining());
 				boolean isItem = file.getName().contains(":");
 				String type = isItem ? "item" : "resource";

--- a/web/app/controllers/resources/LocalIndex.java
+++ b/web/app/controllers/resources/LocalIndex.java
@@ -48,8 +48,6 @@ public class LocalIndex {
 	private Node node;
 	private Client client;
 
-	private static final String TEST_INDEX = "resources";
-
 	/**
 	 * Create a new local index based on our test set
 	 */
@@ -87,7 +85,8 @@ public class LocalIndex {
 
 	/** Delete the index data and close the local node. */
 	public void shutdown() {
-		client.admin().indices().prepareDelete(TEST_INDEX).execute().actionGet();
+		client.admin().indices().prepareDelete(Index.INDEX_NAME).execute()
+				.actionGet();
 		try {
 			node.close();
 		} catch (IOException e) {
@@ -146,12 +145,13 @@ public class LocalIndex {
 	private IndexRequestBuilder createRequestBuilder(final String type, String id,
 			String parent, final Map<String, Object> map) {
 		final IndicesAdminClient admin = client.admin().indices();
-		if (!admin.prepareExists(TEST_INDEX).execute().actionGet().isExists()) {
-			admin.prepareCreate(TEST_INDEX).setSource(config(), XContentType.JSON)
-					.execute().actionGet();
+		if (!admin.prepareExists(Index.INDEX_NAME).execute().actionGet()
+				.isExists()) {
+			admin.prepareCreate(Index.INDEX_NAME)
+					.setSource(config(), XContentType.JSON).execute().actionGet();
 		}
 		final IndexRequestBuilder request =
-				client.prepareIndex(TEST_INDEX, type, id).setSource(map);
+				client.prepareIndex(Index.INDEX_NAME, type, id).setSource(map);
 		return parent.isEmpty() ? request : request.setParent(parent);
 	}
 

--- a/web/app/views/api.scala.html
+++ b/web/app/views/api.scala.html
@@ -51,7 +51,7 @@ $('input.search-resources').autocomplete({
 	<p>
 	@desc("Einfache Feldsuche: \"title\"", resources.routes.Application.query("title:ehrenfeld", format="json"))
 	@desc("Geschachtelte Feldsuche: \"contribution.agent.label\"", resources.routes.Application.query("contribution.agent.label:Melville", format="json"))
-	@desc("In eingebetteten Objekten suchen: \"nested\"", resources.routes.Application.query("contribution.agent.label:Melville AND contribution.role.label:Autor", format="json", nested="contribution"))
+	@desc("In eingebetteten Objekten suchen: \"nested\"", resources.routes.Application.query("", format="json", nested="contribution:contribution.agent.label:Melville AND contribution.role.label:Autor"))
 	@desc("Bereichssuche: \"publication.startDate:[* TO 1500]\"", resources.routes.Application.query("publication.startDate:[* TO 1500]", format="json"))
 	</p>
 	<p>Eine detaillierte Beschreibung der Abfragemöglichkeiten finden Sie in der Dokumentation der <a href="https://lucene.apache.org/core/5_5_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description">Lucene query string syntax</a>.</p>

--- a/web/app/views/api.scala.html
+++ b/web/app/views/api.scala.html
@@ -51,6 +51,7 @@ $('input.search-resources').autocomplete({
 	<p>
 	@desc("Einfache Feldsuche: \"title\"", resources.routes.Application.query("title:ehrenfeld", format="json"))
 	@desc("Geschachtelte Feldsuche: \"contribution.agent.label\"", resources.routes.Application.query("contribution.agent.label:Melville", format="json"))
+	@desc("In eingebetteten Objekten suchen: \"nested\"", resources.routes.Application.query("contribution.agent.label:Melville AND contribution.role.label:Autor", format="json", nested="contribution"))
 	@desc("Bereichssuche: \"publication.startDate:[* TO 1500]\"", resources.routes.Application.query("publication.startDate:[* TO 1500]", format="json"))
 	</p>
 	<p>Eine detaillierte Beschreibung der Abfragemöglichkeiten finden Sie in der Dokumentation der <a href="https://lucene.apache.org/core/5_5_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description">Lucene query string syntax</a>.</p>

--- a/web/conf/resources.conf
+++ b/web/conf/resources.conf
@@ -11,7 +11,7 @@ index = {
 	}
 	cluster = {
 		name = "weywot"
-		hosts = ["weywot5.hbz-nrw.de"]
+		hosts = ["weywot4.hbz-nrw.de", "weywot5.hbz-nrw.de"]
 		port = 9300
 	}
 }

--- a/web/conf/resources.conf
+++ b/web/conf/resources.conf
@@ -4,7 +4,7 @@ orgs.api="http://lobid.org/organisations/"
 isil2opac_hbzid = "https://raw.githubusercontent.com/hbz/link-templates/master/isil2opac_hbzid.json"
 
 index = {
-	name = "resources"
+	name = "resources-staging"
 	type = {
 		item = "item"
 		resource = "resource"
@@ -12,8 +12,8 @@ index = {
 	cluster = {
 		name = "weywot"
 		#hosts = ["weywot4.hbz-nrw.de", "weywot5.hbz-nrw.de"]
-		#hosts = ["10.9.0.13", "10.9.0.14"]
-		hosts = [] # use local index created from local test data
+		hosts = ["10.9.0.13", "10.9.0.14"]
+		#hosts = [] # use local index created from local test data
 		port = 9300
 	}
 }

--- a/web/conf/resources.conf
+++ b/web/conf/resources.conf
@@ -11,7 +11,8 @@ index = {
 	}
 	cluster = {
 		name = "weywot"
-		hosts = ["weywot4.hbz-nrw.de", "weywot5.hbz-nrw.de"]
+		#hosts = ["weywot4.hbz-nrw.de", "weywot5.hbz-nrw.de"]
+		hosts = ["10.9.0.13", "10.9.0.14"]
 		port = 9300
 	}
 }

--- a/web/conf/resources.routes
+++ b/web/conf/resources.routes
@@ -9,8 +9,8 @@ GET    /*path/                controllers.resources.Application.redirectTo(path:
 GET    /resources                       controllers.resources.Application.index()
 GET    /resources/api                   controllers.resources.Application.api()
 GET    /resources/advanced              controllers.resources.Application.advanced()
-GET    /resources/search                controllers.resources.Application.query(q?="", agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int?=0, size:Int?=15, owner?="", t?="", sort ?= "", set?="", format ?= null, aggregations ?= "", location ?= "")
-GET    /resources/facets                controllers.resources.Application.facets(q,agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int,size:Int,owner,t,field,sort,set?="", location ?= "")
+GET    /resources/search                controllers.resources.Application.query(q?="", agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int?=0, size:Int?=15, owner?="", t?="", sort ?= "", set?="", format ?= null, aggregations ?= "", location ?= "", nested ?= "")
+GET    /resources/facets                controllers.resources.Application.facets(q,agent?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int,size:Int,owner,t,field,sort,set?="", location ?= "", nested ?= "")
 
 GET    /resources/stars                 controllers.resources.Application.showStars(format?="", ids?="")
 GET    /resources/stars/clear           controllers.resources.Application.clearStars(ids ?= "")

--- a/web/conf/topic.painless
+++ b/web/conf/topic.painless
@@ -1,0 +1,17 @@
+// return doc['subject.componentList.id'].stream().collect(Collectors.joining(" | "))
+
+def result = new ArrayList();
+
+if(params._source.containsKey("subject")) {
+	for(subject in params._source.subject) {
+		if(subject.containsKey("componentList")) {
+			def current = new ArrayList();
+			for(item in subject.componentList) {
+				current.add(item.label);
+			}
+			result.add(current.stream().collect(Collectors.joining(" | ")));
+		}
+	}
+}
+
+return result

--- a/web/test/tests/IndexUnitTest.java
+++ b/web/test/tests/IndexUnitTest.java
@@ -41,5 +41,4 @@ public class IndexUnitTest {
 				.isEqualTo(
 						"* AND (contribution.agent.label:Melville) AND (isbn:123 AND isbn:456 OR (issn:123 AND issn:456))");
 	}
-
 }

--- a/web/test/tests/InputStringsTest.java
+++ b/web/test/tests/InputStringsTest.java
@@ -85,7 +85,7 @@ public class InputStringsTest extends LocalIndexSetup {
 	public void test() {
 		running(testServer(3333), () -> {
 			String uri = controllers.resources.Application.query(input, "", "", "",
-					"", "", "", "", 0, 10, "", "", "", "", "", "", "").toString();
+					"", "", "", "", 0, 10, "", "", "", "", "", "", "", "").toString();
 			try {
 				URLDecoder.decode(input, StandardCharsets.UTF_8.name());
 			} catch (IllegalArgumentException | UnsupportedEncodingException x) {

--- a/web/test/tests/IntegrationTests.java
+++ b/web/test/tests/IntegrationTests.java
@@ -58,7 +58,7 @@ public class IntegrationTests extends LocalIndexSetup {
 			String queryString =
 					index.buildQueryString("köln", "", "", "", "", "", "", "", "");
 			Index queryResources = index.queryResources(queryString, 0, 0, "", "",
-					Joiner.on(",").join(Index.SUPPORTED_AGGREGATIONS), "");
+					Joiner.on(",").join(Index.SUPPORTED_AGGREGATIONS), "", "");
 			Aggregations facets = queryResources.getAggregations();
 			Terms terms = facets.get("type");
 			Stream<String> values =
@@ -120,7 +120,7 @@ public class IntegrationTests extends LocalIndexSetup {
 	public void responseJsonFilterSearch() {
 		running(testServer(3333), () -> {
 			Index index = new Index();
-			index = index.queryResources("*", 0, 100, "", "", "", "");
+			index = index.queryResources("*", 0, 100, "", "", "", "", "");
 			assertThat(index.getTotal()).isGreaterThanOrEqualTo(100);
 			JsonNode hits = index.getResult();
 			assertThat(hits.isArray()).as("hits is an array").isTrue();

--- a/web/test/tests/NestedQueryTests.java
+++ b/web/test/tests/NestedQueryTests.java
@@ -1,0 +1,79 @@
+/* Copyright 2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package tests;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.test.Helpers.fakeApplication;
+import static play.test.Helpers.running;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import controllers.resources.Index;
+
+/**
+ * See http://www.playframework.com/documentation/2.4.x/JavaFunctionalTest
+ */
+@SuppressWarnings("javadoc")
+@RunWith(Parameterized.class)
+public class NestedQueryTests extends LocalIndexSetup {
+
+	// test data parameters, formatted as "input /*->*/ expected output"
+	@Parameters(name = "nested={0} q={1} -> {2}")
+	public static Collection<Object[]> data() {
+		// @formatter:off
+		return Arrays.asList(new Object[][] {
+			// Nested query: only return hits where query matches 1 nested pseudo-doc:
+			{ "contribution", "contribution.agent.label:SCHOLLE AND contribution.role.label:Mitwirkende", /*->*/ 1 },
+			// Nested query: don't match if query parts match different nested docs:
+			{ "contribution", "contribution.agent.label:SCHOLLE AND contribution.role.label:Autor", /*->*/ 0 },
+			// Normal query: return hits where query matches parent top-level doc:
+			{ "", "contribution.agent.label:SCHOLLE AND contribution.role.label:Autor", /*->*/ 1 },
+			// Same for 'subject' nested field:
+			{ "subject", "subject.label:Westfalen AND subject.source.label:Raumsystematik", /*->*/ 1 },
+			{ "subject", "subject.label:Westfalen AND subject.source.label:Sachsystematik", /*->*/ 0 },
+			{ "", "subject.label:Westfalen AND subject.source.label:Sachsystematik", /*->*/ 1 },
+			// Same for 'subject.componentList' nested field:
+			{ "subject.componentList", 
+				"subject.componentList.label:Freudenberg AND subject.componentList.type:PlaceOrGeographicName", /*->*/ 1 },
+			{ "subject.componentList", 
+				"subject.componentList.label:Freudenberg AND subject.componentList.type:SubjectHeading", /*->*/ 0 },
+			{ "", "subject.componentList.label:Freudenberg AND subject.componentList.type:SubjectHeading", /*->*/ 1 }
+		});
+	} // @formatter:on
+
+	private String nestedString;
+	private String queryString;
+	private int expectedResultCount;
+	private Index index;
+
+	public NestedQueryTests(String nestedString, String queryString,
+			int resultCount) {
+		this.nestedString = nestedString;
+		this.queryString = queryString;
+		this.expectedResultCount = resultCount;
+		this.index = new Index();
+	}
+
+	@Test
+	public void testResultCount() {
+		running(fakeApplication(), () -> {
+			if (expectedResultCount == 1)
+				assertThat(hitsForQuery()).isGreaterThanOrEqualTo(expectedResultCount);
+			else
+				assertThat(hitsForQuery()).isEqualTo(expectedResultCount);
+		});
+	}
+
+	private long hitsForQuery() {
+		return nestedString.isEmpty() ? index.totalHits(queryString)
+				: index.queryResources(queryString, 0, 1, "", "", "", "", nestedString)
+						.getTotal();
+	}
+
+}

--- a/web/test/tests/NestedQueryTests.java
+++ b/web/test/tests/NestedQueryTests.java
@@ -29,20 +29,20 @@ public class NestedQueryTests extends LocalIndexSetup {
 		// @formatter:off
 		return Arrays.asList(new Object[][] {
 			// Nested query: only return hits where query matches 1 nested pseudo-doc:
-			{ "contribution", "contribution.agent.label:SCHOLLE AND contribution.role.label:Mitwirkende", /*->*/ 1 },
+			{ "contribution:contribution.agent.label:SCHOLLE AND contribution.role.label:Mitwirkende", "", /*->*/ 1 },
 			// Nested query: don't match if query parts match different nested docs:
-			{ "contribution", "contribution.agent.label:SCHOLLE AND contribution.role.label:Autor", /*->*/ 0 },
+			{ "contribution:contribution.agent.label:SCHOLLE AND contribution.role.label:Autor", "", /*->*/ 0 },
 			// Normal query: return hits where query matches parent top-level doc:
 			{ "", "contribution.agent.label:SCHOLLE AND contribution.role.label:Autor", /*->*/ 1 },
 			// Same for 'subject' nested field:
-			{ "subject", "subject.label:Westfalen AND subject.source.label:Raumsystematik", /*->*/ 1 },
-			{ "subject", "subject.label:Westfalen AND subject.source.label:Sachsystematik", /*->*/ 0 },
+			{ "subject:subject.label:Westfalen AND subject.source.label:Raumsystematik", "", /*->*/ 1 },
+			{ "subject:subject.label:Westfalen AND subject.source.label:Sachsystematik", "", /*->*/ 0 },
 			{ "", "subject.label:Westfalen AND subject.source.label:Sachsystematik", /*->*/ 1 },
 			// Same for 'subject.componentList' nested field:
-			{ "subject.componentList", 
-				"subject.componentList.label:Freudenberg AND subject.componentList.type:PlaceOrGeographicName", /*->*/ 1 },
-			{ "subject.componentList", 
-				"subject.componentList.label:Freudenberg AND subject.componentList.type:SubjectHeading", /*->*/ 0 },
+			{ "subject.componentList:subject.componentList.label:Freudenberg AND subject.componentList.type:PlaceOrGeographicName", 
+				"", /*->*/ 1 },
+			{ "subject.componentList:subject.componentList.label:Freudenberg AND subject.componentList.type:SubjectHeading", 
+				"", /*->*/ 0 },
 			{ "", "subject.componentList.label:Freudenberg AND subject.componentList.type:SubjectHeading", /*->*/ 1 }
 		});
 	} // @formatter:on
@@ -72,8 +72,7 @@ public class NestedQueryTests extends LocalIndexSetup {
 
 	private long hitsForQuery() {
 		return nestedString.isEmpty() ? index.totalHits(queryString)
-				: index
-						.queryResources(queryString, 0, 1, "", "", "", "", nestedString, "")
+				: index.queryResources("*", 0, 1, "", "", "", "", nestedString, "")
 						.getTotal();
 	}
 


### PR DESCRIPTION
Interpret `q` param as nested query if `nested` param is not empty, using the value of the `nested` param as the nested field path (see [1]).

Required for https://github.com/hbz/lobid-resources/issues/532 and https://github.com/hbz/nwbib/issues/163

@dr0i:
- This is based on the ES 5.6 code base
- Contains index-config.json changes that should go into the next full staging index

[1]  https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-nested-query.html