### PR TITLE
Fix context definition of "contribution" to "list"

### DIFF
--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -222,7 +222,7 @@
       "multilangLabel" : {}
    },
    {
-      "container" : "@set",
+      "container" : "@list",
       "label" : "Mitwirkende",
       "multilangLabel" : {},
       "name" : "contribution",

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -5354,7 +5354,7 @@
 <http://lobid.org/organisations/ZDB-23-DGG#!> <http://www.w3.org/2000/01/rdf-schema#label> "eResource package"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/organisations/ZDB-30-PQE#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/organisations/ZDB-30-PQE#!> <http://www.w3.org/2000/01/rdf-schema#label> "eResource package"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/extent> "46 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Hrsg.: Stadt Freudenberg, Der Stadtdirektor]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/elements/1.1/coverage> "Freudenberg <Siegen-Wittgenstein>"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5373,7 +5373,7 @@
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadt Freudenberg S\u00FCdwestfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadt Freudenberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Zeitgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/BT000002852#!> <http://rdaregistry.info/Elements/u/P60493> "wechselvolle Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://schema.org/publication> _:Bb2 .
 <http://lobid.org/resources/BT000002852#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5421,9 +5421,7 @@
 <http://lobid.org/resources/BT000003404> <http://purl.org/dc/terms/modified> "20101004"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000003404> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000003404> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Heinrich Nettekoven ; Johannes Arnoldus Glessen. \u00DCbersetzung des lateinischen Textes durch Hans Kallhoff"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/dc/terms/bibliographicCitation> "Patrone und Heilige im kurk\u00F6lnischen Sauerland; Red.: Michael Senger. [Mitarb.: Christine Aka ...]; 1993; S. 113-114"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -5436,7 +5434,7 @@
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/174423993 | http://d-nb.info/gnd/174424019 | http://d-nb.info/gnd/174424000"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#hbzID> "BT000014215"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/BT000014215#!> <http://rdaregistry.info/Elements/u/P60493> "urkundliche Festlegung ... \u00FCber die 1794 erfolgte Translation der Reliquien der HLG. Drei K\u00F6nige vom 5. August 1808"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://schema.org/publication> _:Bb4 .
 <http://lobid.org/resources/BT000014215#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5448,7 +5446,7 @@
 <http://lobid.org/resources/BT000014215> <http://purl.org/dc/terms/modified> "20120613"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000014215> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000040377#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000040377#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/elements/1.1/coverage> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/bibliographicCitation> "Rheine gestern, heute, morgen. - 11 (1983), S. 26-38 : Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -5460,7 +5458,7 @@
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/105745944"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#hbzID> "BT000040377"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
+<http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/BT000040377#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
@@ -5471,7 +5469,7 @@
 <http://lobid.org/resources/BT000040377> <http://purl.org/dc/terms/modified> "19960814"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000040377> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000041593#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000041593#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/bibliographicCitation> "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -5493,7 +5491,7 @@
 <http://lobid.org/resources/BT000041593> <http://purl.org/dc/terms/modified> "19960814"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000041593> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000067443#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000067443#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/BT000067443#!> <http://id.loc.gov/ontologies/bibframe/note> "Anfang s. Jg. 5 (1985) S. 22-29"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/bibliographicCitation> "Kiebitz. - 6 (1986), S. 29-36, S. 63-67"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5518,7 +5516,7 @@
 <http://lobid.org/resources/BT000067443> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000067443> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000100437#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000103077#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000103077#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/BT000103077#!> <http://id.loc.gov/ontologies/bibframe/note> "Aus: Fabrik, Familie, Feierabend. Wuppertal 1978, S. 247-271"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/elements/1.1/coverage> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/bibliographicCitation> "Vom Kohlenpott zu Deutschlands \"starkem St\u00FCck\".; von J\u00FCrgen Reulecke; 1990; S. 49-76 ; graph. Darst., 1 Tab."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5531,7 +5529,7 @@
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118060872"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#hbzID> "BT000103077"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
 <http://lobid.org/resources/BT000103077#!> <http://rdaregistry.info/Elements/u/P60493> "Schulprobleme u. Schulalltag in e. \"jungen\" Industriestadt vor d. ersten Weltkrieg (Herne)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://schema.org/publication> _:Bb4 .
 <http://lobid.org/resources/BT000103077#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5543,7 +5541,7 @@
 <http://lobid.org/resources/BT000103077> <http://purl.org/dc/terms/modified> "20130424"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000103077> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/extent> "28 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/note> "Nicht im Sortimentsbuchh."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[hrsg. in Zsarb. mit d. Kommune]."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5556,7 +5554,7 @@
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#contributorOrder> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#hbzID> "BT000110055"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
 <http://lobid.org/resources/BT000110055#!> <http://rdaregistry.info/Elements/u/P60493> "wir sch\u00FCtzen unsere Umwelt"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/BT000110055#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5568,7 +5566,7 @@
 <http://lobid.org/resources/BT000110055> <http://purl.org/dc/terms/modified> "19960817"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000110055> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000128754#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000128754#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/elements/1.1/coverage> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/elements/1.1/coverage> "M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/abstract> "Erinnerungen an d. 1. FC K\u00F6ln u. Borussia M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5592,7 +5590,7 @@
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "Erster Fu\u00DFball-Club K\u00F6ln 01/07"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "Erster Fu\u00DFball-Klub K\u00F6ln 01/07"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "VfL Borussia M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
+<http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/BT000128754#!> <http://rdaregistry.info/Elements/u/P60493> "Jugend zwischen zwei Magnetpolen ; nur Animosit\u00E4t gebiert gro\u00DFe Spiele"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/BT000128754#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5604,7 +5602,7 @@
 <http://lobid.org/resources/BT000128754> <http://purl.org/dc/terms/modified> "20090401"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/BT000128754> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/extent> "42 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Fraktion B\u00FCndnis 90, Die Gr\u00FCnen im Landschaftsverband Westfalen-Lippe"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -5627,7 +5625,7 @@
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "North Rhine-Westphalia"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Weib"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Weibliche Erwachsene"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/BT000168595#!> <http://rdaregistry.info/Elements/u/P60493> "frauenpolitische Konzeptionen im Kulturbetrieb ; Dokumentation einer Anh\u00F6rung vom 16. Mai 1998"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/BT000168595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5639,7 +5637,7 @@
 <http://lobid.org/resources/BT000168595> <http://purl.org/dc/terms/modified> "20020909"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000168595> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/extent> "176 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/CT001004829:DE-929:#!> .
 <http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Johann Josef Reiff"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5657,7 +5655,7 @@
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#fulltextOnline> <http://nbn-resolving.de/urn:nbn:de:0128-1-37874> .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#hbzID> "CT001004829"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheineck, Otto von (-1150)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:0128-1-37874"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://rdaregistry.info/Elements/u/P60493> "Trauerspiel in 5 Akten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://schema.org/publication> _:Bb5 .
@@ -5673,19 +5671,7 @@
 <http://lobid.org/resources/CT001004829> <http://purl.org/dc/terms/modified> "20141002"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/CT001004829> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb10 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb11 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb12 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
+<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb16 .
 <http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Plakat : sw ; 33 x 29 cm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "die Musik ist von dem ber\u00C3\u00BChmten Kapellmeister Winter, Compositeur der Oper: Das unterbrochene Opferfest. [Textverf.: Alessandro Ercole Pepoli. \u00C3\u009Cbers. und arrang. von Carl Ludwig von Giesecke]. Personen: Madam Bilau, Herr Fuchs, Madam B\u00C3\u00B6hm d.j., Madam B\u00C3\u00B6hm d.\u00C3\u00A4., Herr Kellermann, Herr Dardenne, Herr Krug, Madam Annoni, Herr B\u00C3\u00B6hm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/alternative> "<<La>> Belisa Ossia La Fedelt\u00C3\u00A1 Riconosciuta"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5709,7 +5695,7 @@
 <http://lobid.org/resources/CT003012479> <http://purl.org/dc/terms/created> "20150420"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/CT003012479> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000009600:DE-260:Z%201009#!> .
 <http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000009600:DE-294-17:BX-7#!> .
 <http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000009600:DE-38:Haa1455#!> .
@@ -5784,7 +5770,7 @@
 <http://lobid.org/resources/HT000009600> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT000009600> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT000009600> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/extent> "X, 99 S. : GRAPH. DARST."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000290078:DE-290:Jc%20F%2016826#!> .
 <http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000290078:DE-467:11DCX1513%2B1#!> .
@@ -5806,7 +5792,7 @@
 <http://lobid.org/resources/HT000290078> <http://purl.org/dc/terms/modified> "20070718"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT000290078> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/extent> "226 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001039253:DE-131:MAS#!> .
 <http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001039253:DE-294:WFA228-29:2#!> .
@@ -5828,7 +5814,7 @@
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#isPartOf> _:Bb2 .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectAltLabel> "Metallfeder"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectAltLabel> "Normschrift (Norm)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/edition> "2., ge\u00E4nd. Aufl., Stand d.abgedr. Normen: Januar 1974"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/isbn> "3410104356"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/isbn> "9783410104353"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5846,8 +5832,7 @@
 <http://lobid.org/resources/HT001039253> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001245500#!> <http://www.w3.org/2000/01/rdf-schema#label> "Stuttgarter Berichte zur Siedlungswasserwirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001252640#!> <http://www.w3.org/2000/01/rdf-schema#label> "Strafrechtliche Abhandlungen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001310215:DE-294:ZMC134#!> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/title> "JOURNAL"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -5868,8 +5853,7 @@
 <http://lobid.org/resources/HT001375579#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001381485#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001387918#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/extent> "XVIII, 1306 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001898812:DE-294:LLB3272-2#!> .
 <http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001898812:DE-361:NP701.35%20G8D4P%5B2,2#!> .
@@ -5903,7 +5887,7 @@
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Hochdeutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuhochdeutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Polnische Sprache"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT001898812#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
@@ -5920,7 +5904,7 @@
 <http://lobid.org/resources/HT002152208#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT002156174#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT002156469#!> <http://www.w3.org/2000/01/rdf-schema#label> "DIN-Taschenbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT002619538:DE-294:ZRC%20828#!> .
 <http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT002619538:DE-38-121:Sh13#!> .
 <http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT002619538:DE-38:Sh13#!> .
@@ -5960,7 +5944,7 @@
 <http://lobid.org/resources/HT002619538> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT002808565#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT002864207> <http://www.w3.org/2000/01/rdf-schema#label> "Die Angestellten"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003160768:DE-385:ONG%2Fg52127#!> .
 <http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003160768:DE-465:ONG%2Fg52127#!> .
 <http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003160768:DE-6-007:ONG%2Fg52127#!> .
@@ -5981,7 +5965,7 @@
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "Handwerkskammerbezirk M\u00FCnster (Westf)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "Landesentwicklungsplanung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FCnster (Westf) (Bezirk)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/HT003160768#!> <http://rdaregistry.info/Elements/u/P60327> "Regierungsbezirk M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://schema.org/publication> _:Bb2 .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -5996,7 +5980,7 @@
 <http://lobid.org/resources/HT003160768> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-464#!> .
 <http://lobid.org/resources/HT003160768> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003422154#!> <http://www.w3.org/2000/01/rdf-schema#label> "Sport Gala"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/extent> "[8] Bl., 306 S., [1] gef. Bl. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003536695:DE-38:N5%2F26#!> .
 <http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003536695:DE-5:13%20a%20R%20337#!> .
@@ -6061,7 +6045,7 @@
 <http://lobid.org/resources/HT003651380> <http://purl.org/dc/terms/modified> "20070127"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003651380> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-385#!> .
 <http://lobid.org/resources/HT003651380> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003654516#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT003654516#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb11 .
 <http://lobid.org/resources/HT003654516#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003654516:DE-294:ZRC458-1988%2F89#!> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/dc/terms/medium> <http://purl.org/lobid/lv#Miscellaneous> .
@@ -6081,7 +6065,7 @@
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectAltLabel> "Berichtswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectAltLabel> "Jahresbericht (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectAltLabel> "T\u00E4tigkeitsbericht (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb11 .
+<http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb12 .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/ontology/bibo/oclcnum> "224546401"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/ontology/bibo/oclcnum> "84927101"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://schema.org/publication> _:Bb10 .
@@ -6096,7 +6080,7 @@
 <http://lobid.org/resources/HT003654516> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT003654516> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003759287#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/extent> "117 S. : zahlr. Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5#!> .
 <http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D#!> .
@@ -6121,7 +6105,7 @@
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regierungsbezirk M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalentwicklungsplan"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionaler Raumordnungsplan"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
 <http://lobid.org/resources/HT004381366#!> <http://schema.org/publication> _:Bb4 .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
@@ -6135,7 +6119,7 @@
 <http://lobid.org/resources/HT004381366> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004394800#!> <http://www.w3.org/2000/01/rdf-schema#label> "Forum Musikp\u00E4dagogik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004520034#!> <http://www.w3.org/2000/01/rdf-schema#label> "Discussion paper / Zentrum f\u00FCr Europ\u00E4ische Wirtschaftsforschung ; 03,49 : Labour economics, human resources and social policy"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT004944075:DE-294:ZRC828-43#!> .
 <http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Economic Commission for Europe, Transport Division, United Nations"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004944075#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .
@@ -6162,7 +6146,7 @@
 <http://lobid.org/resources/HT004984061#!> <http://www.w3.org/2000/01/rdf-schema#label> "The Cambridge edition of the works of F. Scott Fitzgerald"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005016197#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005077038#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT005944358#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT005944358#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb13 .
 <http://lobid.org/resources/HT005944358#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT005944358:DE-361:NA000%20Z540%5B95#!> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/dc/terms/medium> <http://purl.org/lobid/lv#Miscellaneous> .
@@ -6184,7 +6168,7 @@
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sch\u00F6ne Literatur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachkunst"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wortkunst"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb13 .
+<http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb14 .
 <http://lobid.org/resources/HT005944358#!> <http://schema.org/publication> _:Bb12 .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
@@ -6194,12 +6178,7 @@
 <http://lobid.org/resources/HT005944358> <http://purl.org/dc/terms/created> "19931226"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005944358> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-361#!> .
 <http://lobid.org/resources/HT005944358> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
+<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
 <http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Videokassette (VHS, 93 Min.) : farb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006266886:DE-467:Medienzentrum#!> .
 <http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Regia: Vittorio DeSica. Interpreti: Dominique Sanda ; Lino Capolicchio ; Fabio Testi ; Helmut Berger"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6223,7 +6202,7 @@
 <http://lobid.org/resources/HT006266886> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT006266886> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006514951#!> <http://www.w3.org/2000/01/rdf-schema#label> "Schriftenreihe des NS-Dokumentationszentrums der Stadt K\u00C3\u00B6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/extent> "XIV, 464 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006698544:DE-5:57%2F6471#!> .
 <http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006698544:DE-6:1E%2018283#!> .
@@ -6235,7 +6214,7 @@
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#fulltextOnline> <http://resolver.sub.uni-goettingen.de/purl?PPN236434969> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#hbzID> "HT006698544"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalkunde"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/HT006698544#!> <http://rdaregistry.info/Elements/u/P60493> "mit besonderer R\u00FCcksicht auf deutsche Auswanderung und die physischen Verh\u00E4ltnisse des Landes ; mit einem naturwissenschaftlichen Anhange und einer topographisch-geognostisschen Karte von Texas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://schema.org/publication> _:Bb2 .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -6252,7 +6231,7 @@
 <http://lobid.org/resources/HT006886477#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006886478#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006886479#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006987933:DE-Kn28:#!> .
 <http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006987933:DE-Kn28:5%20A#!> .
 <http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006987933:DE-Kn28:CDR%200638%20(2005,Juli%2F2009,Juni)#!> .
@@ -6289,9 +6268,7 @@
 <http://lobid.org/resources/HT007138775#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007527436#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007751353#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/extent> "93 S. ; 8-o"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT007847893:DE-5-21:A%20607%205%2F10#!> .
 <http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT007847893:DE-5:65%2F7293#!> .
@@ -6309,7 +6286,7 @@
 <http://lobid.org/resources/HT007847893> <http://purl.org/dc/terms/created> "19980105"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007847893> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT007847893> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT008733617:DE-290:SDC%205000%2F4#!> .
 <http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT008733617:DE-294:YMB92313#!> .
 <http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT008733617:DE-361:ZN140%20A#!> .
@@ -6338,9 +6315,7 @@
 <http://lobid.org/resources/HT008733617> <http://purl.org/dc/terms/created> "19980716"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT008733617> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-292#!> .
 <http://lobid.org/resources/HT008733617> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT009719670:DE-467:#!> .
 <http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "s\u00E9lectionn\u00E9s par Janine Courtillon et Genevi\u00E8ve-Dominique de Salins"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .
@@ -6363,8 +6338,7 @@
 <http://lobid.org/resources/HT009719670> <http://purl.org/dc/terms/modified> "20050117"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT009719670> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/extent> "56 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT009993506:DE-38:1K4304#!> .
 <http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT009993506:DE-Sol1:KA%206169#!> .
@@ -6387,7 +6361,7 @@
 <http://lobid.org/resources/HT009993506> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010095606#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010627685#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/extent> "23 p."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT010662586:DE-380:#!> .
 <http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "by C[icely] V[eronica] Wedgwood"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6478,7 +6452,7 @@
 <http://lobid.org/resources/HT010726584> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT010726584> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT010726584> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012237361#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT012237361#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT012237361#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012237361:DE-107:Per.%205157#!> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -6506,7 +6480,7 @@
 <http://lobid.org/resources/HT012299746#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012670837#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012848847#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/extent> "76 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012895751:DE-929:C2001A%2F13#!> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -6520,7 +6494,7 @@
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#hbzID> "HT012895751"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectAltLabel> "Heimatforschung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectAltLabel> "Heimatgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT012895751#!> <http://rdaregistry.info/Elements/u/P60493> "Informationen f\u00FCr B\u00FCrger, Neub\u00FCrger & G\u00E4ste"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -6533,7 +6507,7 @@
 <http://lobid.org/resources/HT012895751> <http://purl.org/dc/terms/modified> "20010312"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT012895751> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/extent> "XIV, 514 S. : graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012926727:DE-1010:01PUM23(2)#!> .
 <http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl.#!> .
@@ -6607,7 +6581,7 @@
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheinbund"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stromwirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u01E6umh\u016Br\u012Byat Alm\u0101niy\u0101 al-Itti\u1E25\u0101d\u012Bya"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/edition> "2. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/isbn> "3540676376"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/isbn> "9783540676379"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6707,7 +6681,7 @@
 <http://lobid.org/resources/HT012996101> <http://purl.org/dc/terms/created> "20010504"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012996101> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT012996101> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb12 .
 <http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013056453:DE-107:Per.%2014635#!> .
 <http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013056453:DE-294:ZGB%203152#!> .
 <http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013056453:DE-294:ZGB%203152-YID#!> .
@@ -6729,7 +6703,7 @@
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb2 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb5 .
-<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb7 .
+<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb6 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb9 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/title> "Homo ludens"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6740,7 +6714,7 @@
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spiele"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spielen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spielerziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb12 .
+<http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb13 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#zdbID> "1125458-0"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/ontology/bibo/oclcnum> "183350230"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://rdaregistry.info/Elements/u/P60278> <http://lobid.org/resources/HT016084461> .
@@ -6760,9 +6734,7 @@
 <http://lobid.org/resources/HT013056453> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT013056453> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT013056453> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
 <http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/extent> "VII, 119 S. : Ill., graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013077595:DE-6-290:Y%20401%20-%2036#!> .
 <http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013077595:DE-6:2J%201468#!> .
@@ -6804,7 +6776,7 @@
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pressestelle (Coesfeld)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadt Coesfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtdirektor (Coesfeld)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
+<http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb12 .
 <http://lobid.org/resources/HT013077595#!> <http://rdaregistry.info/Elements/u/P60493> "Kirsten Balke. [Hrsg.: Kreisheimatverein Coesfeld e.V. Red.: Hans-Peter Boer ...]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://schema.org/publication> _:Bb8 .
 <http://lobid.org/resources/HT013077595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -6860,8 +6832,7 @@
 <http://lobid.org/resources/HT013304885#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013370531#!> <http://www.w3.org/2000/01/rdf-schema#label> "Buchners Kollege Themen Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013384949#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/extent> "XVIII, 635 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013480902:DE-1010:01TWP864#!> .
 <http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013480902:DE-466:TWP16169#!> .
@@ -6877,7 +6848,7 @@
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#hbzID> "HT013480902"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#isPartOf> _:Bb4 .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#subjectAltLabel> "Hypertext Transfer Protocol"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/edition> "1. ed."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/isbn> "1565925092"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/isbn> "9781565925090"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6897,7 +6868,7 @@
 <http://lobid.org/resources/HT013494180#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT013494180#!> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland-Pf\u00E4lzische Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013538692#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013577568#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT013577568#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT013577568#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Johannes Heinrichs"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/bibliographicCitation> "Kontinuit\u00E4t und Diskontinuit\u00E4t / hrsg. von Thomas Gr\u00FCnewald ... - Berlin [u.a.], 2003. - (Reallexikon der germanischen Altertumskunde : Erg\u00E4nzungsb\u00E4nde ; 35). - S. [266]-344 : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -6919,7 +6890,7 @@
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "Metallgeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "R\u00F6mische Zeit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheinlande (im engeren Sinn)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT013577568#!> <http://rdaregistry.info/Elements/u/P60493> "Mittel- und Niederrhein ca. 70 - 71 v. Chr. anhand germanischer M\u00FCnzen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://schema.org/publication> _:Bb6 .
 <http://lobid.org/resources/HT013577568#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -6931,7 +6902,7 @@
 <http://lobid.org/resources/HT013577568> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013668741#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013668747#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/extent> "56 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013798403:DE-294-18:B%201324%20%2F%201%20:2003H.49#!> .
 <http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Tobias Hagen"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -6983,7 +6954,7 @@
 <http://lobid.org/resources/HT013911008> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-361#!> .
 <http://lobid.org/resources/HT013911008> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013911051#!> <http://www.w3.org/2000/01/rdf-schema#label> "Eutropia-CD"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013925945#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT013925945#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT013925945#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Karl-Josef von Ketteler"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/elements/1.1/coverage> "B\u00F6kenf\u00F6rde"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/elements/1.1/coverage> "Schwarzenraben"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7003,7 +6974,7 @@
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Konservierung (Restaurierung)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kunstwerk / Restaurierung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Restauration (Bestandserhaltung)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT013925945#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
@@ -7012,8 +6983,7 @@
 <http://lobid.org/resources/HT013925945> <http://purl.org/dc/terms/created> "20040216"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT013925945> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/extent> "324 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014015351:DE-294:IFB9657#!> .
 <http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014015351:DE-361:OH058%20S7L5#!> .
@@ -7032,7 +7002,7 @@
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/title> "Spuren, Lekt\u00FCren"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/129016713 | http://d-nb.info/gnd/136788548"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#hbzID> "HT014015351"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/ontology/bibo/isbn> "3770538471"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/ontology/bibo/isbn> "9783770538478"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://rdaregistry.info/Elements/u/P60493> "Praktiken des Symbolischen ; [Festschrift f\u00FCr Ludwig J\u00E4ger zum 60. Geburtstag]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7050,9 +7020,7 @@
 <http://lobid.org/resources/HT014015351> <http://schema.org/provider> <http://lobid.org/organisations/DE-292#!> .
 <http://lobid.org/resources/HT014015351> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT014015351> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Spiel (Inhalt: 1 Spielanleitung, 100 Situationskarten: 60 f\u00FCr Frauen, 40 f\u00FCr M\u00E4dchen (ab 12 J.). 90 Brave-Karten, 90 B\u00F6se-Karten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014046679:DE-Bi10:ICE%20Brav#!> .
 <http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/note> "Lizenziert f\u00FCr das Amt f\u00FCr Jugendarbeit der Evangelischen Kirche von Westfalen, Haus Villigast"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7078,7 +7046,7 @@
 <http://lobid.org/resources/HT014168843#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westf\u00E4lische Bibliographie (NWBib)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014215912#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT014215912#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT014215912#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Sven L\u00FCken"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/bibliographicCitation> "Karl der Gro\u00DFe und Europa / hrsg. von der Schweizerischen Botschaft in der Bundesrepublik Deutschland ... - Frankfurt am Main [u.a.], 2004. - S. 67-86 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -7109,7 +7077,7 @@
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "der Gro\u00DFe (747-814)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "le Grand (747-814)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "the Great (747-814)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT014215912#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
@@ -7118,8 +7086,7 @@
 <http://lobid.org/resources/HT014215912> <http://purl.org/dc/terms/created> "20041208"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT014215912> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/extent> "183 S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014319164:DE-38:17B2432#!> .
 <http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014319164:DE-929:2005%2F1952#!> .
@@ -7144,7 +7111,7 @@
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Plastiken"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Skulptur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Skulpturen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT014319164#!> <http://rdaregistry.info/Elements/u/P60493> "Bildhauer"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://schema.org/publication> _:Bb6 .
 <http://lobid.org/resources/HT014319164#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -7158,14 +7125,7 @@
 <http://lobid.org/resources/HT014319164> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT014319164> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014419735> <http://www.w3.org/2000/01/rdf-schema#label> "Annual bulletin of transport statistics for Europe and North America"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
+<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
 <http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/extent> "2 Schallpl. : 33 UpM, stereo ; 30 cm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014525099:DE-1156:AR%20ba%2071#!> .
 <http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Johann Sebastian Bach"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7215,8 +7175,7 @@
 <http://lobid.org/resources/HT014555885> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-12#!> .
 <http://lobid.org/resources/HT014555885> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014679525#!> <http://www.w3.org/2000/01/rdf-schema#label> "Sediment"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/extent> "[ca. 50 Bl.] : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014681992:DE-61-90:za%2F4269(2005)#!> .
 <http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Cornelius-Gesellschaft Neuss-Selikum e.V."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7232,7 +7191,7 @@
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuss (Neuss)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuss-Selikum (Neuss-Selikum)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
 <http://lobid.org/resources/HT014681992#!> <http://rdaregistry.info/Elements/u/P60493> "vom 3. bis 4. September"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -7248,9 +7207,7 @@
 <http://lobid.org/resources/HT014681992> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/2000/01/rdf-schema#label> "Zeitschriftendatenbank (ZDB)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/extent> "15, [14] S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Arbeitskreis Stra\u00DFenbauabf\u00E4lle Rheinland-Pfalz; Landesamt f\u00FCr Umweltschutz und Gewerbeaufsicht; Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer> .
@@ -7298,16 +7255,7 @@
 <http://lobid.org/resources/HT015082724> <http://purl.org/dc/terms/created> "20070508"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015082724> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-361#!> .
 <http://lobid.org/resources/HT015082724> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
+<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb17 .
 <http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015090208:DE-465:CMAF1063-CD#!> .
 <http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015090208:DE-467:70KNLS3136-DVD#!> .
 <http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015090208:DE-5-13:DVD%202007%2F1#!> .
@@ -7327,7 +7275,7 @@
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#isPartOf> _:Bb12 .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#isPartOf> _:Bb14 .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectAltLabel> "Goethe, Johann Wolfgang von (Faust et le second Faust)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb17 .
+<http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb27 .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:Bb16 .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -7340,8 +7288,7 @@
 <http://lobid.org/resources/HT015090208> <http://purl.org/dc/terms/modified> "20100702"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT015090208> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/extent> "LV, 225 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015183529:DE-5:2007%2F4575#!> .
 <http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "F. Scott Fitzgerald. Ed. by Matthew J. Bruccoli"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7363,9 +7310,7 @@
 <http://lobid.org/resources/HT015183529> <http://purl.org/dc/terms/created> "20070618"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT015183529> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015414894:DE-6:#!> .
 <http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Sascha Werthes ; Richard Kim ; Christoph Conrad"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/bibliographicCitation> "Medien und Terrorismus; Christian Schicha ... (Hg.); 2002; S. 80 - 93"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7385,7 +7330,7 @@
 <http://lobid.org/resources/HT015414894> <http://purl.org/dc/terms/created> "20080125"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT015414894> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/extent> "181, VIII S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015440386:DE-385-AN:C%2Fld487#!> .
 <http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Ralf K\u00F6nig"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7419,7 +7364,7 @@
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectAltLabel> "King, Ralph (1960-)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectAltLabel> "Konig, Ralf (1960-)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photographien-Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/edition> "Orig.-Ausg., 31. - 40. Tsd."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/isbn> "3499223929"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/isbn> "9783499223921"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7433,7 +7378,7 @@
 <http://lobid.org/resources/HT015440386> <http://purl.org/dc/terms/created> "20080220"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-385#!> .
 <http://lobid.org/resources/HT015440386> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb15 .
 <http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/extent> "291 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015455455:DE-107:208-316#!> .
 <http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015455455:DE-82:(1)043776#!> .
@@ -7463,7 +7408,7 @@
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectAltLabel> "SDP AG"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectAltLabel> "Steyr-Daimler-Puch-AG"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u00D6sterreichische Daimler-Motoren-Commanditgesellschaft Bierenz, Fischer und Co. (Wiener Neustadt)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb15 .
+<http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb16 .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/ontology/bibo/isbn> "3205776399"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/ontology/bibo/isbn> "9783205776390"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://rdaregistry.info/Elements/u/P60493> "Rivalen bis zur Fusion ; die fr\u00FChen Jahre des Ferdinand Porsche"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7481,7 +7426,7 @@
 <http://lobid.org/resources/HT015455455> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015550020#!> <http://www.w3.org/2000/01/rdf-schema#label> "Forschung und Praxis der Gesundheitsf\u00C3\u00B6rderung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015845132#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015865114:DE-294-11:#!> .
 <http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015865114:DE-6-290:#!> .
 <http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015865114:DE-929:#!> .
@@ -7501,7 +7446,7 @@
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectAltLabel> "Geschichte / Didaktik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectAltLabel> "Geschichte / Unterricht"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectAltLabel> "Geschichtsdidaktik"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#titleKeyword> "Schulbuch Buchner"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://rdaregistry.info/Elements/u/P60493> "die Welt nach 1945"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://schema.org/publication> _:Bb6 .
@@ -7517,8 +7462,7 @@
 <http://lobid.org/resources/HT015865114> <http://purl.org/dc/terms/modified> "20090318"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT015865114> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/extent> "670 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015891797:DE-107:9.1191%2F10,2#!> .
 <http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015891797:DE-121:09%20A%20756#!> .
@@ -7544,7 +7488,7 @@
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#isPartOf> _:Bb6 .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectAltLabel> "Adenauer, ... (1876-1967)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectAltLabel> "Adenauer, Konrad Hermann Joseph (1876-1967)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
+<http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb10 .
 <http://lobid.org/resources/HT015891797#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
@@ -7556,7 +7500,7 @@
 <http://lobid.org/resources/HT015891797> <http://purl.org/dc/terms/modified> "20090817"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT015891797> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/extent> "88 p."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015894164:DE-1044:#!> .
 <http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015894164:DE-1383:#!> .
@@ -7606,7 +7550,7 @@
 <http://lobid.org/resources/HT015894164> <http://purl.org/dc/terms/modified> "20120815"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016084461> <http://www.w3.org/2000/01/rdf-schema#label> "Ludographie - Spiel und Spiele"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/extent> "32 gez. S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016135351:DE-6:2C%208876#!> .
 <http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Hemut Buchmann"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7622,7 +7566,7 @@
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kornm\u00FChle Roberg (Harsewinkel)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "Lutter-Wasserm\u00FChle Roberg (Harsewinkel-Marienfeld)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FChle Roberg (Harsewinkel)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT016135351#!> <http://rdaregistry.info/Elements/u/P60493> "Zeitzeuge und Kleinod in Harsewinkel"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/HT016135351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -7635,7 +7579,7 @@
 <http://lobid.org/resources/HT016135351> <http://purl.org/dc/terms/modified> "20091210"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016135351> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/extent> "418 S. : zahlr. Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016382441:DE-1044:11%20=%20TWR5408#!> .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016382441:DE-1044:11%20=%20TWR5408%2B1#!> .
@@ -7671,7 +7615,7 @@
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/14320713X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#hbzID> "HT016382441"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#isPartOf> _:Bb3 .
-<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/isbn> "9783527706495"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://rdaregistry.info/Elements/u/P60493> "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles f\u00FCr Ihr Rendezvous mit dem Pinguin]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7709,13 +7653,7 @@
 <http://lobid.org/resources/HT016545462> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT016545462> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016545462> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
+<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016556189:DE-61:nc%2F12926#!> .
 <http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Michael Palin mit Harry H. Corbett ; John LeMesurier... Drehbuch: Charles Alverson ... Nach der Geschichte von Lewis Caroll. Regie: Terry Gilliam"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -7738,8 +7676,7 @@
 <http://lobid.org/resources/HT016556189> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT016556189> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016593925#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016604323:DE-6:XB%203534#!> .
 <http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hrsg.: Landschaftsverband Westfalen-Lippe, LWL-Abteilung f\u00FCr Krankenh\u00E4user und Gesundheitswesen, LWL-PsychiatrieVerbund Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -7754,7 +7691,7 @@
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#hbzID> "HT016604323"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014846970#!> .
-<http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#zdbID> "2581964-1"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://rdaregistry.info/Elements/u/P60493> "f\u00FCr das Jahr ..."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://schema.org/publication> _:Bb6 .
@@ -7772,10 +7709,7 @@
 <http://lobid.org/resources/HT016604323> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016604323> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016607985#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
+<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016608165:DE-575:#!> .
 <http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Claude Debussy. [Text:] (Th\u00E9odore de Banville)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016608165#!> <http://purl.org/dc/terms/bibliographicCitation> "M\u00E9lodies; Claude Debussy; 1980"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7795,7 +7729,7 @@
 <http://lobid.org/resources/HT016608165> <http://purl.org/dc/terms/created> "20101130"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016608165> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-575#!> .
 <http://lobid.org/resources/HT016608165> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/extent> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016618741:DE-61:#!> .
 <http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Christiane Rasch"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7821,11 +7755,7 @@
 <http://lobid.org/resources/HT016618741> <http://purl.org/dc/terms/modified> "20110330"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT016618741> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
+<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb11 .
 <http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/extent> "349 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016675714:DE-1116:DS%207200%200141#!> .
 <http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/note> "\u0411\u0438\u0431\u043B\u0438\u043E\u0433\u0440. \u0432 \u0442\u0435\u043A\u0441\u0442\u0435"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7849,7 +7779,7 @@
 <http://lobid.org/resources/HT016675714> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-1116#!> .
 <http://lobid.org/resources/HT016675714> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016777884#!> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsche Literatur - Studien und Quellen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/extent> "312 S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016791198:DE-Kn41:2012%2F1#!> .
 <http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016791198:DE-Kn41:49618#!> .
@@ -7875,7 +7805,7 @@
 <http://lobid.org/resources/HT016791198> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/2000/01/rdf-schema#label> "Edoweb Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/extent> "97 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016987148:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "vorgelegt von Sebastian Friedrich Teschers"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7921,7 +7851,7 @@
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectAltLabel> "North-Rhine/Westphalia"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectAltLabel> "Qualit\u00E4tspr\u00FCfung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectAltLabel> "Quality control"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:38m-0000004639"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/ontology/bibo/doi> "10.4126/38m-000000463"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://rdaregistry.info/Elements/u/P60489> "K\u00F6ln, Univ., Diss., 2011"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -7960,7 +7890,7 @@
 <http://lobid.org/resources/HT017028573> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT017028573> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9#!> .
 <http://lobid.org/resources/HT017028573> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017066705:DE-107:DVD%20886#!> .
 <http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/note> "Imagefilm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -7986,7 +7916,7 @@
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokolade / Industrie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokolade / S\u00FC\u00DFwarenindustrie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokoladeindustrie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
 <http://lobid.org/resources/HT017066705#!> <http://rdaregistry.info/Elements/u/P60493> "Schokok\u00FCsse aus Herxheim"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/HT017066705#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -7999,7 +7929,7 @@
 <http://lobid.org/resources/HT017066705> <http://purl.org/dc/terms/modified> "20120106"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT017066705> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017150239#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017150239#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT017150239#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Borgmann, Richard"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/elements/1.1/coverage> "M\u00FCnster <Westfalen>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/bibliographicCitation> "Westfalen; 88. 2010 (2012), S. 175-179"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8015,7 +7945,7 @@
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FCnster (Westf) / Fachbereich Praktische Denkmalpflege und Baukultur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen-Lippe. Fachbereich Praktische Denkmalpflege"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/HT017150239#!> <http://schema.org/publication> _:Bb2 .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
@@ -8027,7 +7957,7 @@
 <http://lobid.org/resources/HT017150239> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017150239> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017290519#!> <http://www.w3.org/2000/01/rdf-schema#label> "Mit gn\u00C3\u00A4digster Erlaubnis ... wird aufgef\u00C3\u00BChrt"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb14 .
 <http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017411546:DE-385:#!> .
 <http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017411546:DE-38:#!> .
 <http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017411546:DE-466:#!> .
@@ -8062,7 +7992,7 @@
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen (Volk, Neuzeit)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westphalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westphalie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb14 .
+<http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb15 .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:6-85659520092"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#zdbID> "2685248-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://schema.org/publication> _:Bb12 .
@@ -8080,7 +8010,7 @@
 <http://lobid.org/resources/HT017411546> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT017411546> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017411546> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017437638:DE-836:#!> .
 <http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Adrian Pewestorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/hasVersion> <http://beck-online.beck.de/Default.aspx?vpath=bibdata%5Ckomm%5Cpewkokagbefrvo_1%5Ccont%5Cpewkokagbefrvo.htm&pos=0&hlwords=pewestorf%C3%90adrian%C3%90+adrian+%C3%90+pewestorf+#xhlhit> .
@@ -8101,7 +8031,7 @@
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Datenbank (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Dokument"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
+<http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -8137,7 +8067,7 @@
 <http://lobid.org/resources/HT017451384> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT017451384> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-1241#!> .
 <http://lobid.org/resources/HT017451384> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Kt. : grenzkolor., fl\u00E4chenkolor., Kupferst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017468042:DE-6:RK%2013#!> .
 <http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/note> "Titelkartusche mit Ma\u00DFstab geschm\u00FC. mit 1 Wappen links Mitte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8159,7 +8089,7 @@
 <http://lobid.org/resources/HT017468042> <http://purl.org/dc/terms/modified> "20130220"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017468042> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017468042> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017472134#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017472134#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT017472134#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Friedhelm Treckmann]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/elements/1.1/coverage> "Dortmund-Nette"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/bibliographicCitation> "Nachrichten aus der Netter Geschichte; 2 (2011), S. 18-35 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8174,7 +8104,7 @@
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#hbzID> "HT017472134"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectAltLabel> "Familie (Familie)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT017472134#!> <http://schema.org/publication> _:Bb6 .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
@@ -8185,7 +8115,7 @@
 <http://lobid.org/resources/HT017472134> <http://purl.org/dc/terms/modified> "20121203"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017472134> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/extent> "59 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017480009:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "vorgelegt von Anna Laura Fett"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8217,9 +8147,7 @@
 <http://lobid.org/resources/HT017480009> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT017480009> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017500108#!> <http://www.w3.org/2000/01/rdf-schema#label> "Biografien & Materialien / NSDOK; NS-Dokumentationszentrum der Stadt K\u00C3\u00B6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/extent> "XXXVII, 265 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017529028:DE-1032:PHBB%2018%2F22%2FXVIII#!> .
 <http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017529028:DE-Kn28:PHBB%2018%2F22%2FXVIII#!> .
@@ -8258,7 +8186,7 @@
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectAltLabel> "vom Cre\u00FCtz (1542-1591)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectAltLabel> "vom Creutz (1542-1591)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectAltLabel> "vom Kreuz (1542-1591)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/ontology/bibo/edition> "4., durchges. und korr. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/ontology/bibo/isbn> "9783451273889"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://rdaregistry.info/Elements/u/P60493> "Studie \u00FCber Johannes vom Kreuz"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8307,7 +8235,7 @@
 <http://lobid.org/resources/HT017894012> <http://purl.org/dc/terms/created> "20131119"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017894012> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-468#!> .
 <http://lobid.org/resources/HT017894012> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018131501#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018131501#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT018131501#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Manfred Engelhardt"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/elements/1.1/coverage> "D\u00FCsseldorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/bibliographicCitation> "Der Gie\u00DFerjunge; 34 (2014),1, S. 14-15"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8351,7 +8279,7 @@
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtgemeinde D\u00FCsseldorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverordnetenversammlung (D\u00FCsseldorf)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (D\u00FCsseldorf)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT018131501#!> <http://schema.org/publication> _:Bb3 .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
@@ -8395,7 +8323,7 @@
 <http://lobid.org/resources/HT018138676> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018138676> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT018138676> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018147158#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018147158#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/dc/terms/subject> _:Bb1 .
@@ -8436,7 +8364,7 @@
 <http://lobid.org/resources/HT018187026> <http://purl.org/dc/terms/modified> "20140610"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018187026> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-836#!> .
 <http://lobid.org/resources/HT018187026> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/extent> "517 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018239864:DE-107:115-289#!> .
 <http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018239864:DE-294:IFB10325-17#!> .
@@ -8468,7 +8396,7 @@
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectAltLabel> "Narratologie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u05E7\u05D5\u05D9\u05DF, \u05D0\u05D9\u05E8\u05DE\u05D2\u05E8\u05D3 (1905-1982)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u1E32oyn, Irmgard (1905-1982)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/ontology/bibo/isbn> "3050064641"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/ontology/bibo/isbn> "9783050064642"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/ontology/bibo/isbn> "9783050103020"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8488,7 +8416,7 @@
 <http://lobid.org/resources/HT018239864> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018239864> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018239864> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/extent> "544 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018290299:DE-38:17B5040#!> .
 <http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018290299:DE-5-39:Gb%209130%2F650%20(19)#!> .
@@ -8554,7 +8482,7 @@
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverordneten-Versammlung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectAltLabel> "Verwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/ontology/bibo/isbn> "9783954513673"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://rdaregistry.info/Elements/u/P60493> "Ausz\u00C3\u00BCge aus 500 Interviews mit ehemaligen Zwangsarbeiterinnen und Zwangsarbeitern"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://schema.org/publication> _:Bb6 .
@@ -8570,8 +8498,7 @@
 <http://lobid.org/resources/HT018290299> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018290299> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018290299> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb10 .
 <http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/extent> "596 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018295975:DE-5-39:C%2060%2F145%2F10#!> .
 <http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018295975:DE-6:3K%2051779#!> .
@@ -8598,7 +8525,7 @@
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectAltLabel> "Th\u00FCringer Land"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectAltLabel> "Thuringia"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectAltLabel> "Vereinigte Th\u00FCringische Staaten"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb10 .
+<http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb12 .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/ontology/bibo/isbn> "9783943539233"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://rdaregistry.info/Elements/u/P60493> "Bonn - Koblenz - Weimar - Meiningen ; Festschrift f\u00FCr Johannes M\u00F6tsch zum 65. Geburtstag"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8616,7 +8543,7 @@
 <http://lobid.org/resources/HT018295975> <http://purl.org/dc/terms/modified> "20141105"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018295975> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018312899#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018312899#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT018312899#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Sientje Maes"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/elements/1.1/coverage> "Detmold"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/bibliographicCitation> "Grabbe-Jahrbuch ...; 32. 2013 (2014), S. 80-95"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8635,7 +8562,7 @@
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Nachleben"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Nachwirkung (Rezeption)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wirkungsgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/HT018312899#!> <http://rdaregistry.info/Elements/u/P60493> "der Cid als Zeit- und Gattungskritik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://schema.org/publication> _:Bb2 .
 <http://lobid.org/resources/HT018312899#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -8645,9 +8572,7 @@
 <http://lobid.org/resources/HT018312899> <http://purl.org/dc/terms/created> "20140702"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018312899> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/extent> "122 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018454638:DE-5-39:Gb%207470%2F201#!> .
 <http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018454638:DE-Kn28:Fc%206601#!> .
@@ -8669,7 +8594,7 @@
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrei St. Antonius Abbas Herkenrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrgemeinderat (Pfarrei Sankt Antonius Abbas Herkenrath)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrgemeinderat Sankt Antonius Abbas Herkenrath"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT018454638#!> <http://rdaregistry.info/Elements/u/P60493> "Festschrift zum Jubil\u00E4um 2014 in St. Antonius Abbas, Herkenrath ; Ausstellungsbegleiter"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/HT018454638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -8682,8 +8607,7 @@
 <http://lobid.org/resources/HT018454638> <http://purl.org/dc/terms/modified> "20150303"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT018454638> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/extent> "394 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018468645:DE-466:#!> .
 <http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hrsg. von Fritsche, Christiane ; Paulmann, Johannes"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8733,7 +8657,7 @@
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sammelwerk (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectAltLabel> "Zeitgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u00C7\u00A6umh\u00C5\u00ABr\u00C4\u00AByat Alm\u00C4\u0081niy\u00C4\u0081 al-Itti\u00E1\u00B8\u00A5\u00C4\u0081d\u00C4\u00ABya"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/ontology/bibo/doi> "10.7788/boehlau.9783412216689"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/ontology/bibo/isbn> "9783412216689"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://schema.org/publication> _:Bb5 .
@@ -8747,9 +8671,7 @@
 <http://lobid.org/resources/HT018468645> <http://purl.org/dc/terms/created> "20141125"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-466#!> .
 <http://lobid.org/resources/HT018468645> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/extent> "45 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018585406:DE-107:#!> .
 <http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Deutsch-Franz\u00F6sisch-Schweizerische Oberrheinkonferenz, AG Raumordnung. Hrsg.: Entwicklungsagentur Rheinland-Pfalz e.V. Red.: Hans-G\u00FCnther Clev ..."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8773,7 +8695,7 @@
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinebene"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinische Tiefebene"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinlande"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/HT018585406#!> <http://schema.org/publication> _:Bb5 .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
@@ -8783,9 +8705,7 @@
 <http://lobid.org/resources/HT018585406> <http://purl.org/dc/terms/created> "20150319"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT018585406> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb14 .
 <http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/extent> "173 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018612706:DE-465:KFG1163-26%2F26#!> .
 <http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018612706:DE-5-7:kund960.h582#!> .
@@ -8903,7 +8823,7 @@
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectAltLabel> "Verwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westdeutschland (Bundesrepublik, 1949-1990)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb14 .
+<http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb17 .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/ontology/bibo/isbn> "9783903004108"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://rdaregistry.info/Elements/u/P60493> "[... anl\u00C3\u00A4sslich der gleichnamigen Ausstellung auf der ART COLOGNE 16. - 19.4.2015, und im ZADIK, 4.5. - 28.8.2015]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://schema.org/publication> _:Bb13 .
@@ -8920,7 +8840,7 @@
 <http://lobid.org/resources/HT018612706> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT018612706> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018615288#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/extent> "55 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018617137:DE-5:#!> .
 <http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Text: Eva Maria Helm]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8947,11 +8867,7 @@
 <http://lobid.org/resources/HT018617137> <http://purl.org/dc/terms/created> "20150424"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT018617137> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
+<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
 <http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/extent> "239 S. : zahlr. graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018700720:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/note> "Literaturangaben"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -8982,10 +8898,7 @@
 <http://lobid.org/resources/HT018700720> <http://purl.org/dc/terms/modified> "20150720"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018700720> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
+<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018703339:DE-38M:#!> .
 <http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Klaus Kayser ; Stephan Borkenfeld ; Amina Djenouni ; Gian Kayser"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018703339#!> <http://purl.org/dc/terms/bibliographicCitation> "Diagnostic pathology; 1 (2015), 14, S. 1 - 18 : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9013,7 +8926,7 @@
 <http://lobid.org/resources/HT018703339> <http://purl.org/dc/terms/modified> "20170915"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018703339> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018703339> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018722247#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018722247#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT018722247#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018722247:DE-38M:#!> .
 <http://lobid.org/resources/HT018722247#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018722247#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .
@@ -9032,7 +8945,7 @@
 <http://lobid.org/resources/HT018722247> <http://purl.org/dc/terms/created> "20150810"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018722247> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018722247> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018726005#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018726005#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT018726005#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Text: Hans Hoff"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/elements/1.1/coverage> "Bielefeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/bibliographicCitation> "K.West; 2006,1, S. 12-14 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9047,7 +8960,7 @@
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#fulltextOnline> <http://www.bibliothek.uni-regensburg.de/ezeit/?2655603> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#hbzID> "HT018726005"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb3 .
+<http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
 <http://lobid.org/resources/HT018726005#!> <http://rdaregistry.info/Elements/u/P60493> "die Parallelwelten des Ingolf L\u00FCck"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://schema.org/publication> _:Bb2 .
 <http://lobid.org/resources/HT018726005#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -9057,7 +8970,7 @@
 <http://lobid.org/resources/HT018726005> <http://purl.org/dc/terms/created> "20150813"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018726005> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/extent> "276 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018770176:DE-294-39:123%2FY%2F3264#!> .
 <http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018770176:DE-6-228:StrR%20XIV%2023%2F246#!> .
@@ -9087,8 +9000,7 @@
 <http://lobid.org/resources/HT018770176> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018770176> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6-228#!> .
 <http://lobid.org/resources/HT018770176> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/extent> "42 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Text Anya R\u00F6sgen ; Hans-Joachim Wiehager]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/elements/1.1/coverage> "Bergisch Gladbach- Bensberg"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9104,7 +9016,7 @@
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#isPartOf> _:Bb5 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectAltLabel> "7. Schloss Bensberg Classics"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
+<http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb10 .
 <http://lobid.org/resources/HT018771475#!> <http://rdaregistry.info/Elements/u/P60493> "17. bis 19. Juli 2015"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://schema.org/publication> _:Bb7 .
 <http://lobid.org/resources/HT018771475#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
@@ -9115,7 +9027,7 @@
 <http://lobid.org/resources/HT018771475> <http://purl.org/dc/terms/created> "20151005"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018771475> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/extent> "264 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018779822:DE-Kob7:#!> .
 <http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Julie Cross"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9134,7 +9046,7 @@
 <http://lobid.org/resources/HT018779822> <http://purl.org/dc/terms/created> "20151014"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kob7#!> .
 <http://lobid.org/resources/HT018779822> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Partitur (12 Seiten), 2 Stimmen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018781534:DE-Kn38:Fb%203533#!> .
 <http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hermann Schroeder, 1904-1984"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9158,8 +9070,7 @@
 <http://lobid.org/resources/HT018781534> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018781534> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn38#!> .
 <http://lobid.org/resources/HT018781534> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/extent> "circa 32 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018782520:DE-Kn28:Faf%209816#!> .
 <http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018782520:DE-Kn28:Faf%209816,01#!> .
@@ -9179,7 +9090,7 @@
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectAltLabel> "of Myra (270-340)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Bari (270-340)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Myra (270-340)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/ontology/bibo/isbn> "3522304144"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/ontology/bibo/isbn> "9783522304146"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://rdaregistry.info/Elements/u/P60584> <http://d-nb.info/gnd/4006604-6> .
@@ -9195,7 +9106,7 @@
 <http://lobid.org/resources/HT018782520> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018782520> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT018782520> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/extent> "353 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018786244:DE-1156:Sbh%2010%20%2F%20For%201%20%2F%20133#!> .
 <http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018786244:DE-1156:Sbh%2010%20%2F%20For%201%20%2F%20133%20%2F%20a#!> .
@@ -9228,10 +9139,7 @@
 <http://lobid.org/resources/HT018786244> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018786244> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018786244> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
+<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (1 Videodatei)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018801101:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Konzeption und Redaktion: Ursula Arning, Bettina Kullmer, Elke Roesner ; Mitarbeit: Jasmin Schmitz]"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9293,7 +9201,7 @@
 <http://lobid.org/resources/HT018839495> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018839495> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-8#!> .
 <http://lobid.org/resources/HT018839495> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/extent> "7 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018895767:DE-107:#!> .
 <http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018895767:DE-929:#!> .
@@ -9329,12 +9237,7 @@
 <http://lobid.org/resources/HT018895767> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT018895767> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907246#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
+<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (1 Videodatei)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018907266:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "created by: Simone Haas, Bettina Kullmer, Birte Lindst\u00E4dt, Katja Pletsch ; with the assistance of: Ursula Arning, Jasmin Schmitz"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9356,7 +9259,7 @@
 <http://lobid.org/resources/HT018907266> <http://purl.org/dc/terms/created> "20160307"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018907266> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/extent> "108 ungez\u00E4hlte Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018924091:DE-61:pfl%2Fe6097#!> .
 <http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Poverino Peppino"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9372,7 +9275,7 @@
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#hbzID> "HT018924091"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kartoon"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/ontology/bibo/edition> "1. Auflage"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/ontology/bibo/isbn> "3981189337"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/ontology/bibo/isbn> "9783981189339"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9390,8 +9293,7 @@
 <http://lobid.org/resources/HT018924091> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018924091> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018924091> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (265 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018939763:DE-38:#!> .
 <http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Juanito Ornelas de Avelar / Laura \u00C1lvarez L\u00F3pez (eds.)"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9410,7 +9312,7 @@
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachber\u00FChrung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachbeziehungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachenkontakt"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb4 .
+<http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/doi> "10.3726/978-3-653-05265-7"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/isbn> "9783631660249"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/isbn> "9783653052657"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9429,7 +9331,7 @@
 <http://lobid.org/resources/HT018939763> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT018939763> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998832#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/extent> "[10], 232 Bl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018998891:DE-Zw1:#!> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -9454,7 +9356,7 @@
 <http://lobid.org/resources/HT018998891> <http://purl.org/dc/terms/modified> "20160620"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT018998891> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (x, 284 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019011249:DE-38:#!> .
 <http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Derek Bickerton"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9478,13 +9380,7 @@
 <http://lobid.org/resources/HT019011249> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT019011249> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019054663#!> <http://www.w3.org/2000/01/rdf-schema#label> "BAWBildatlas"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
+<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb9 .
 <http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (VIII, 192 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019054687:DE-B23:E-Publikation#!> .
 <http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Bearbeiter: F. Hesser, R. Seiffert, A. B\u00FCscher, I. Holzwarth, E. Rudolph, A. Sehili, N. Winkel"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9507,10 +9403,7 @@
 <http://lobid.org/resources/HT019054687> <http://purl.org/dc/terms/created> "20160805"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019054687> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-B23#!> .
 <http://lobid.org/resources/HT019054687> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
+<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
 <http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/extent> "[96] S. : zahlr. Ill., \u00FCberw. farb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019093814:DE-465:JZH43391#!> .
 <http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019093814:DE-6:LC%201017#!> .
@@ -9554,7 +9447,7 @@
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photographieren"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photographische Aufnahme"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photokunst"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb6 .
+<http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb10 .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/ontology/bibo/edition> "[1. Auflage]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/ontology/bibo/isbn> "9783954761586"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://rdaregistry.info/Elements/u/P60493> "junge Fotografie, Ruhrtriennale 2016 : Meisterkurse Daniel Josefson und Julian R\u00F6mer; Louisa Boeszoermeny, Jakob Ganslmeier, Gregro Schmidt, Julian Slagman"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9570,8 +9463,7 @@
 <http://lobid.org/resources/HT019093814> <http://purl.org/dc/terms/modified> "20161111"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn3#!> .
 <http://lobid.org/resources/HT019093814> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (35 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019149667:DE-929:#!> .
 <http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Herausgeber: Landesamt f\u00FCr Soziales, Jugend und Versorgung ; Text und Redaktion: Horst B\u00F6ning (KV Mayen-Koblenz), Elke Gr\u00FCn (LSJV - LJA), Peter Krauthausen (LSJV - LJA), Katharina Rothenbacher-Dostert (StV Kaiserslautern), Anne Scherr-Schmitt (SkF Trier)"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9600,7 +9492,7 @@
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rh\u00E9nanie-Palatinat"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheinland Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rhineland-Palatinate"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb8 .
+<http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb10 .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:02-edoweb:70052615"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/ontology/bibo/edition> "2. Auflage"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://rdaregistry.info/Elements/u/P60493> "eine Brosch\u00FCre f\u00FCr Pflegeeltern und solche, die es werden m\u00F6chten : ... damit Kinder die Gewinner sind"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9618,7 +9510,7 @@
 <http://lobid.org/resources/HT019149667> <http://purl.org/dc/terms/modified> "20161222"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019149667> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
 <http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019248596:DE-107:#!> .
 <http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019248596:DE-929:#!> .
 <http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019248596:DE-Zw1:#!> .
@@ -9655,8 +9547,7 @@
 <http://lobid.org/resources/HT019248596> <http://purl.org/dc/terms/modified> "20170426"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019248596> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019248596> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (376 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019322941:DE-B23:Link#!> .
 <http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Katharina Habermann, Klaus-Dieter Herbst (Hg.)"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9678,8 +9569,7 @@
 <http://lobid.org/resources/HT019322941> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-B23#!> .
 <http://lobid.org/resources/HT019322941> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019378259#!> <http://www.w3.org/2000/01/rdf-schema#label> "Schriftenreihe des Landtags Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb11 .
 <http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (89 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019440025:DE-929:#!> .
 <http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Herausgeber: Der Pr\u00E4sident des Landtags Rheinland-Pfalz ; verantwortlich: Hans-Peter Hexemer, Leiter Kommunikation und neue Medien"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9717,10 +9607,7 @@
 <http://lobid.org/resources/HT019440025> <http://purl.org/dc/terms/created> "20170905"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019440025> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019440025> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
+<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (ix, 335 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019474284:DE-38M:#!> .
 <http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Connie M. Weaver, Robin M. Daly, Heike A. Bischoff-Ferrari editors"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9753,13 +9640,7 @@
 <http://lobid.org/resources/HT019474284> <http://purl.org/dc/terms/modified> "20171019"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019474284> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT019474284> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
+<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
 <http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/extent> "2 CD : DDD + Beih."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT000075751:DE-Kn38:CD%202410%20-%20CD%202411#!> .
 <http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Benjamin Britten. Lorna Anderson, soprano ; Regina Nathan, soprano ; Jamie MacDougall, tenor ; Malcolm Martineau, piano ; Bryn Lewis, harp ; Craig Ogden, guitar"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9780,7 +9661,7 @@
 <http://lobid.org/resources/TT000075751> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn38#!> .
 <http://lobid.org/resources/TT000075751> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001197763#!> <http://www.w3.org/2000/01/rdf-schema#label> "Bibliotheca Palatina"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001210514:DE-107:#!> .
 <http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Adolf Hitler"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -9803,9 +9684,7 @@
 <http://lobid.org/resources/TT001210514> <http://schema.org/provider> <http://lobid.org/organisations/DE-576#!> .
 <http://lobid.org/resources/TT001210514> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/TT001210514> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/extent> "[8] Bl., 414, [1] S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001230001:DE-107:MF%20275%2FF2001%2FF2003#!> .
 <http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/note> "Vorlageform des Erscheinungsvermerks: Avgvstae Vindelicorvm ... Apud Ioannem Praetorium, Anno M.D.XCVI ... - Mikrofiche. M\u00FCnchen : Saur, 1991. Mikrofiche-Nr. F2001-F2003 : 23x"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9828,8 +9707,7 @@
 <http://lobid.org/resources/TT001230001> <http://schema.org/provider> <http://lobid.org/organisations/DE-576#!> .
 <http://lobid.org/resources/TT001230001> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/TT001230001> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/extent> "[2] Bl. : graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001671747:DE-290:GOA%207%2F62-3,5,1#!> .
 <http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001671747:DE-386:GOA%207%2F62-3,5,1#!> .
@@ -9854,7 +9732,7 @@
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalkunde"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen (Provinzialverband)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen (Volk, Neuzeit)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/ontology/bibo/isbn> "3402061740"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/ontology/bibo/isbn> "9783402061749"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://schema.org/publication> _:Bb6 .
@@ -9869,7 +9747,7 @@
 <http://lobid.org/resources/TT001671747> <http://schema.org/provider> <http://lobid.org/organisations/DE-386#!> .
 <http://lobid.org/resources/TT001671747> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-386#!> .
 <http://lobid.org/resources/TT001671747> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/extent> "[2] Bl., 116 S. : Ill. (Kupfert.)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001726537:DE-Kn28:2%20in:%20Aa%201801#!> .
 <http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001726537:DE-Kn28:2%20in:%20Aa%202422#!> .
@@ -9892,7 +9770,7 @@
 <http://lobid.org/resources/TT001726537> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001726537> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001726537> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001966831#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/TT001966831#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/TT001966831#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001966831:DE-Kn28:Zd%200159%20(1999,2)#!> .
 <http://lobid.org/resources/TT001966831#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/spa> .
 <http://lobid.org/resources/TT001966831#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -9912,8 +9790,7 @@
 <http://lobid.org/resources/TT001966831> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001966831> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001966831> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/extent> "XVI, 323 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002001274:DE-Kn28:Dc%204364#!> .
 <http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Hans Lietzmann"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9937,7 +9814,7 @@
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "di Laodicea (310-390)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Laodicea (310-390)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Laodikeia (310-390)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb5 .
+<http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
 <http://lobid.org/resources/TT002001274#!> <http://schema.org/publication> _:Bb4 .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
@@ -9948,7 +9825,7 @@
 <http://lobid.org/resources/TT002001274> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT002001274> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT002001274> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
 <http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/extent> "S. 77"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002165019:DE-6-139a:G%20m%2038#!> .
 <http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hrsg.: Stadt Paderborn. Verantwortl.: A. Erich Boskamp"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9967,7 +9844,7 @@
 <http://lobid.org/resources/TT002165019> <http://schema.org/provider> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/TT002165019> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/TT002165019> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/TT002234042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
 <http://lobid.org/resources/TT002234042#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002234042:DE-929:#!> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638077&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -9996,10 +9873,7 @@
 <http://lobid.org/resources/TT002234042> <http://purl.org/dc/terms/modified> "20160609"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234042> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234042> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
+<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb12 .
 <http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002234459:DE-929:#!> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -10019,7 +9893,7 @@
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rhein-Lahn-Kreis / Landratsamt"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sternenweg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wandern, Diez, Lahnstein, Rhein-Lahn-Info, Rhein, Lahn, Wirtschaftsf\u00F6rderung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb12 .
+<http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb16 .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:01-2079"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#webPageArchived> <http://www.rhein-lahn-info.de/jakobsweg/> .
 <http://lobid.org/resources/TT002234459#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079> .
@@ -10033,7 +9907,7 @@
 <http://lobid.org/resources/TT002234459> <http://purl.org/dc/terms/modified> "20081017"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234459> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
+<http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002234858:DE-929:#!> .
 <http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/note> "Siehe: http://www.stk.rlp.de"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6267588&custom_att_2=simple_viewer> .
@@ -10062,8 +9936,7 @@
 <http://lobid.org/resources/TT002234858> <http://purl.org/dc/terms/modified> "20160523"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234858> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234858> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT003059252:DE-5-58:9%2F041#!> .
 <http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/note> "Engl. Original mit dt. Untertiteln"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10086,8 +9959,7 @@
 <http://lobid.org/resources/TT003059252> <http://schema.org/provider> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT003059252_contAndCrea:DE-5-58:9%2F041#!> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/note> "Engl. Original mit dt. Untertiteln"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10110,15 +9982,7 @@
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://schema.org/provider> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb1 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb3 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb4 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb5 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb6 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb8 .
+<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb10 .
 <http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/extent> "3 CDs : stereo ; ADD"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT003060418:DE-5-58:7%2F441#!> .
 <http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/note> "AD: 9+10/1958"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10158,8 +10022,7 @@
 <http://lobid.org/resources/TT003280170> <http://schema.org/provider> <http://lobid.org/organisations/DE-82#!> .
 <http://lobid.org/resources/TT003280170> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-82#!> .
 <http://lobid.org/resources/TT003280170> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb0 .
-<http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb2 .
+<http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:Bb7 .
 <http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "herausgegeben von Holger Siekmann, Lars Irlenbusch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.1007/978-3-642-20784-6> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -10171,7 +10034,7 @@
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#hbzID> "TT050409948"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/organisations/ZDB-2-SMD#!> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#subjectAltLabel> "Operation / Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb7 .
+<http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#subjectOrder> _:Bb9 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/ontology/bibo/doi> "10.1007/978-3-642-20784-6"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/ontology/bibo/isbn> "9783642207846"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://schema.org/publication> _:Bb6 .
@@ -10670,8 +10533,8 @@ _:Bb1 <http://schema.org/startDate> "2008"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb1 <http://schema.org/startDate> "2010"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb1 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb10 .
-_:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
-_:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb4 .
+_:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb11 .
+_:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb18 .
 _:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb5 .
 _:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb6 .
 _:Bb1 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb7 .
@@ -10732,23 +10595,40 @@ _:Bb10 <http://schema.org/publishedBy> "Landtag Rheinland-Pfalz"^^<http://www.w3
 _:Bb10 <http://schema.org/publishedBy> "\u041D\u0430\u0443\u043A\u0430"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb10 <http://schema.org/startDate> "2010"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb10 <http://schema.org/startDate> "2017"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb10 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb18 .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12174793X, Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010356-0, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb28 .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1063656419, http://d-nb.info/gnd/4045895-7"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1074109953, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/11850066X, Geschichte 1963-1967, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2041907-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049795-1, http://d-nb.info/gnd/4045612-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4058216-4, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2041907-7> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4002641-3> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045612-2> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4047968-7> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4126078-8, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1060772442> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118640038> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/133595935> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/16090142-X> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020533-2> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4061694-0> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4067488-5> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4074032-8> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4075561-7> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076388-2> .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115393-5> .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4246263-0> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4139439-2> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4142176-0> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4152975-3> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219952-9> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4479982-2> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4511937-5> .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
-_:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb11 .
 _:Bb10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
@@ -10771,15 +10651,26 @@ _:Bb11 <http://schema.org/endDate> "2000"^^<http://www.w3.org/2001/XMLSchema#gYe
 _:Bb11 <http://schema.org/location> "M\u00FCnchen ; Salzburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb11 <http://schema.org/publishedBy> "Katzbichler"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb11 <http://schema.org/startDate> "1991"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb11 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb31 .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059979-6, Geschichte, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb11 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb32 .
 _:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4061778-6, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128022-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010355-9> .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4126078-8> .
-_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4143413-4> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1063656419> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1074109953> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/11850066X> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2041907-7> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2175350-7> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4002641-3> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4046277-8> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4047968-7> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049795-1> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4077723-6> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113292-0> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4136959-2> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4227766-8> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4246263-0> .
+_:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
 _:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
@@ -10813,15 +10704,21 @@ _:Bb12 <http://schema.org/publishedBy> "Neomarius"^^<http://www.w3.org/2001/XMLS
 _:Bb12 <http://schema.org/publishedBy> "Niemeyer"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb12 <http://schema.org/publishedBy> "de Gruyter"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb12 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049787-2, http://d-nb.info/gnd/4114067-9, Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4056218-9, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12174793X, Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010355-9, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4072560-1, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2050419-6> .
-_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4024116-6> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128022-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
 _:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
-_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059979-6> .
-_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128022-2> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045612-2> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045895-7> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4126078-8> .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
+_:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
 _:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
 _:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
 _:Bb12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
@@ -10846,15 +10743,18 @@ _:Bb13 <http://schema.org/publishedBy> "Verl. f\u00C3\u00BCr moderne Kunst"^^<ht
 _:Bb13 <http://schema.org/publishedBy> "Zentralarchiv des Internationalen Kunsthandels e.V., ZADIK"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb13 <http://schema.org/startDate> "1951"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb13 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4182273-0, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049787-2> .
-_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049788-4> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010356-0, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4056218-9, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059979-6, Geschichte, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2050419-6> .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4072560-1> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128022-2> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4143413-4> .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
-_:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb14 .
 _:Bb13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
@@ -10869,15 +10769,16 @@ _:Bb14 <http://schema.org/location> "Wien ; K\u00F6ln ; Weimar"^^<http://www.w3.
 _:Bb14 <http://schema.org/publishedBy> "Universit\u00C3\u00A4ts- und Landesbibliothek"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb14 <http://schema.org/startDate> "2007"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb14 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011889-7, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, http://d-nb.info/gnd/4035964-5, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4122362-7, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010356-0> .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4182273-0, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010355-9> .
 _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049788-4> .
-_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4114067-9> .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059979-6> .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
 _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
 _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
+_:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
 _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb15 .
 _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
@@ -10886,16 +10787,18 @@ _:Bb14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Publ
 _:Bb15 <http://schema.org/location> "D\u00C3\u00BCsseldorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb15 <http://schema.org/publishedBy> "B\u00C3\u00B6gemann"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb15 <http://schema.org/startDate> "1805"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/118595881, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4050484-0, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4078937-8, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12174793X> .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, http://d-nb.info/gnd/4035964-5, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4122362-7, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4024116-6> .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049788-4> .
 _:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4061778-6> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4122362-7> .
-_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
+_:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb8 .
 _:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb16 .
 _:Bb15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
@@ -10903,42 +10806,59 @@ _:Bb15 <http://www.w3.org/2000/01/rdf-schema#label> "<<Die>> Theater-Edition"^^<
 _:Bb16 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb16 <http://schema.org/publishedBy> "Bel Air Ed. [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb16 <http://schema.org/startDate> "2007"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/4003988-2, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, Geschichte, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
-_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020378-5> .
-_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/118595881, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049787-2, http://d-nb.info/gnd/4114067-9, Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4050484-0, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4078937-8, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4122362-7> .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
-_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
+_:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
 _:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
 _:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb17 .
 _:Bb16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128140-8, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4443675-0, http://d-nb.info/gnd/4073757-3, Geschichte 1918-1940, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4035964-5> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040629-5> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/4003988-2, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011889-7, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, Geschichte, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12174793X> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010356-0> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020378-5> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049787-2> .
 _:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4058216-4> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4182273-0> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
+_:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
 _:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb18 .
-_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4576855-9, http://d-nb.info/gnd/4073757-3, Geschichte 1920-1945, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
-_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4078937-8> .
-_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128140-8> .
-_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
-_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4443675-0, http://d-nb.info/gnd/4073757-3, Geschichte 1918-1940, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4024116-6> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4035964-5> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040629-5> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4114067-9> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4182273-0> .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
+_:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb8 .
 _:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb19 .
-_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
-_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4050484-0> .
-_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4056218-9> .
-_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb11 .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4576855-9, http://d-nb.info/gnd/4073757-3, Geschichte 1920-1945, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4078937-8> .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb20 .
 _:Bb2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1049793021> .
@@ -11058,15 +10978,17 @@ _:Bb2 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb2 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb2 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb2 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
+_:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb10 .
 _:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb12 .
 _:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb15 .
-_:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb16 .
-_:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb19 .
-_:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb5 .
+_:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
+_:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb20 .
 _:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb6 .
 _:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb7 .
 _:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb8 .
 _:Bb2 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb9 .
+_:Bb2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 _:Bb2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:Bb2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -11111,51 +11033,73 @@ _:Bb2 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2
 _:Bb2 <http://www.w3.org/2004/02/skos/core#notation> "700"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://www.w3.org/2004/02/skos/core#notation> "796"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://www.w3.org/2004/02/skos/core#notation> "914.3"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4003988-2> .
-_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
+_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
+_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4050484-0> .
+_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4056218-9> .
+_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
-_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
-_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
-_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
 _:Bb20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb21 .
-_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
-_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
-_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
+_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4003988-2> .
+_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
+_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
+_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
+_:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
 _:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb22 .
-_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011889-7> .
-_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
-_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
+_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
+_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
+_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
 _:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
-_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
 _:Bb22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb23 .
-_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
-_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4576855-9> .
+_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
+_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
 _:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
+_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
+_:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb24 .
-_:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
+_:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4576855-9> .
+_:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
 _:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
-_:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
+_:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb8 .
 _:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb25 .
-_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
-_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
+_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011889-7> .
+_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
+_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
+_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb8 .
+_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
+_:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb26 .
-_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
-_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb11 .
-_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
+_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
+_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
+_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
+_:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
 _:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb27 .
-_:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4443675-0> .
+_:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128140-8, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
+_:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb11 .
+_:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
 _:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
+_:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb28 .
-_:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
+_:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128140-8> .
+_:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4443675-0> .
 _:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb12 .
+_:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
 _:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb29 .
-_:Bb29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
+_:Bb29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
+_:Bb29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb11 .
+_:Bb29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb30 .
 _:Bb3 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1067217789> .
 _:Bb3 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1080064435> .
@@ -11262,21 +11206,13 @@ _:Bb3 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb10 .
 _:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb11 .
 _:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb12 .
-_:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb13 .
-_:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb15 .
-_:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb6 .
-_:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb7 .
+_:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb14 .
+_:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb16 .
 _:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb8 .
 _:Bb3 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb9 .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/128989459"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4014228-0"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4018466-3, http://d-nb.info/gnd/4020517-4"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4046259-6, http://d-nb.info/gnd/4067488-5, http://d-nb.info/gnd/4511937-5"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059594-8, http://d-nb.info/gnd/4073972-7"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4077513-6, http://d-nb.info/gnd/4143413-4"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7683386-0, http://d-nb.info/gnd/4124796-6, http://d-nb.info/gnd/4049716-1"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7856688-5"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
 _:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb4 .
 _:Bb3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
@@ -11325,16 +11261,18 @@ _:Bb3 <http://www.w3.org/2004/02/skos/core#notation> "700"^^<http://www.w3.org/2
 _:Bb3 <http://www.w3.org/2004/02/skos/core#notation> "900"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://www.w3.org/2004/02/skos/core#notation> "943"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://www.w3.org/2004/02/skos/core#notation> "rpbr_99_o31500000_"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
-_:Bb30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:Bb31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
-_:Bb31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb32 .
-_:Bb32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118595881> .
+_:Bb30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb9 .
+_:Bb30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb31 .
+_:Bb31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
+_:Bb31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:Bb32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
 _:Bb32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb33 .
-_:Bb33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
+_:Bb33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118595881> .
 _:Bb33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb34 .
-_:Bb34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb12 .
-_:Bb34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:Bb34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
+_:Bb34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb35 .
+_:Bb35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb12 .
+_:Bb35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb4 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/10518151X> .
 _:Bb4 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1072011352> .
 _:Bb4 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/120113562> .
@@ -11400,37 +11338,29 @@ _:Bb4 <http://schema.org/startDate> "2005"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb4 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb4 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb4 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
+_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb10 .
 _:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb11 .
-_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb12 .
+_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb13 .
 _:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb14 .
-_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb16 .
+_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb15 .
 _:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb19 .
-_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb21 .
-_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb7 .
-_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb8 .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1093886471, http://d-nb.info/gnd/4147365-6"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118560034, http://d-nb.info/gnd/4159648-1, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/119411970, http://d-nb.info/gnd/4010427-8, http://d-nb.info/gnd/4145395-5"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4137215-3, Geschichte 1288-1815"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4016583-8, http://d-nb.info/gnd/4419668-4"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4037117-7, http://d-nb.info/gnd/4127794-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb20 .
+_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb22 .
+_:Bb4 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb9 .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/128989459"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4014228-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4018466-3, http://d-nb.info/gnd/4020517-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042552-6, http://d-nb.info/gnd/4156127-2, http://d-nb.info/gnd/4151183-9, Geschichte 1805-2000, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4246263-0, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4050698-8, CD-ROM"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4055876-9, http://d-nb.info/gnd/4130470-6, Montr\u00E9al <1983>"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059594-8, http://d-nb.info/gnd/4073972-7"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4077513-6, http://d-nb.info/gnd/4067488-5"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/6509781-6"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7684863-2, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7764102-4, http://d-nb.info/gnd/4049600-4, Geschichte 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/128989459> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018466-3> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7683386-0, http://d-nb.info/gnd/4124796-6, http://d-nb.info/gnd/4049716-1"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7856688-5"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4046259-6> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059594-8> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7683386-0> .
-_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7856688-5> .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb5 .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
@@ -11441,6 +11371,7 @@ _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/l
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "... f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Augsburger Schriften"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11460,12 +11391,11 @@ _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Ottovay, Kathrin"^^<http://w
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Schulbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Darbietungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "020"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "330"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "380"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "791"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "rpbr_99_11100000_"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1082286788> .
 _:Bb5 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/108376990> .
@@ -11529,37 +11459,32 @@ _:Bb5 <http://schema.org/startDate> "2013"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb5 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb5 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb5 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb12 .
+_:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb13 .
 _:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
-_:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb23 .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118649817"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12918814X"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040619-2, http://d-nb.info/gnd/4306876-5, http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4033581-1, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4113303-1, http://d-nb.info/gnd/4006617-4, http://d-nb.info/gnd/4142176-0, http://d-nb.info/gnd/4047968-7, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb24 .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1093886471, http://d-nb.info/gnd/4147365-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118560034, http://d-nb.info/gnd/4159648-1, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/119411970, http://d-nb.info/gnd/4010427-8, http://d-nb.info/gnd/4145395-5"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4137215-3, Geschichte 1288-1815"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4016583-8, http://d-nb.info/gnd/4419668-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4037117-7, http://d-nb.info/gnd/4127794-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4246263-0, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4055876-9, http://d-nb.info/gnd/4143413-4"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4219055-1"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4604932-0, http://d-nb.info/gnd/4184194-3, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1093886471> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118560034> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/119411970> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4014228-0> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4016583-8> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4037117-7> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7684863-2, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7764102-4, http://d-nb.info/gnd/4049600-4, Geschichte 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/128989459> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018466-3> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042552-6> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4050698-8> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059594-8> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4067488-5> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4077513-6> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120316-1> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4124796-6> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/6509781-6> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7684863-2> .
-_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7764102-4> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7683386-0> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7856688-5> .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb6 .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
@@ -11570,10 +11495,10 @@ _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/l
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#SecondaryPublicationEvent> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Chemische Verfahrenstechnik und verwandte Technologien"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1959-1972"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11588,11 +11513,13 @@ _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http:/
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Understanding Web internals"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Darbietungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "\u0418\u043D-\u0442 \u0441\u043E\u0446\u0438\u0430\u043B\u044C\u043D\u043E\u0433\u043E \u043E\u0431\u0440\u0430\u0437\u043E\u0432\u0430\u043D\u0438\u044F (\u0444\u0438\u043B.) \u0420\u0413\u0421\u0423 \u0432 \u0433. \u0421\u0430\u0440\u0430\u0442\u043E\u0432\u0435"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "320"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "610"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "660"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "791"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/114975760> .
 _:Bb6 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118500546> .
 _:Bb6 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/11851928X> .
@@ -11655,38 +11582,34 @@ _:Bb6 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb6 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb6 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb6 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb14 .
-_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb15 .
-_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb9 .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1060772442, http://d-nb.info/gnd/2175350-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1063656419, http://d-nb.info/gnd/4045895-7"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118640038"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4219952-9, http://d-nb.info/gnd/4136959-2, http://d-nb.info/gnd/4020517-4, http://d-nb.info/gnd/4143413-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb11 .
+_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
+_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb18 .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040619-2, http://d-nb.info/gnd/4306876-5, http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042203-3, Geschichte, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4075561-7, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120314-8, W\u00F6rterbuch, http://d-nb.info/gnd/4113292-0"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4337730-0"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4362856-4, http://d-nb.info/gnd/4507427-6, http://d-nb.info/gnd/4076388-2, Geschichte 1911-2011, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118649817> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12918814X> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010427-8> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040619-2> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049600-4> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049716-1> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4033581-1, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4113303-1, http://d-nb.info/gnd/4006617-4, http://d-nb.info/gnd/4142176-0, http://d-nb.info/gnd/4047968-7, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/6509781-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1093886471> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118560034> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/119411970> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4014228-0> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4016583-8> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4037117-7> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4055876-9> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120108-5> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4127794-6> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4137215-3> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4124796-6> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4143413-4> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4147365-6> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4156127-2> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4159648-1> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219055-1> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4419668-4> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4511937-5> .
-_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4604932-0> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7684863-2> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7764102-4> .
+_:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
@@ -11696,7 +11619,6 @@ _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontol
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Ausstellung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Classic cars"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11756,39 +11678,33 @@ _:Bb7 <http://schema.org/startDate> "2009"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb7 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb7 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb7 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Geschichte 1945-2003, http://d-nb.info/gnd/4020533-2, Schulbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118722123, http://d-nb.info/gnd/4152975-3"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/133595935, http://d-nb.info/gnd/4046277-8, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/138460604, Theaterst\u00FCck, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/16090142-X, Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118649817"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12918814X"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/35439-9, http://d-nb.info/gnd/4057399-0, http://d-nb.info/gnd/4067488-5"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4139439-2, http://d-nb.info/gnd/4002641-3, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4, http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4020378-5, http://d-nb.info/gnd/4040629-5, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4052945-9, http://d-nb.info/gnd/4067488-5"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4061694-0, http://d-nb.info/gnd/4227766-8, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4479982-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1060772442> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1063656419> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118640038> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4033581-1> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4337730-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4362856-4, http://d-nb.info/gnd/4507427-6, http://d-nb.info/gnd/4076388-2, Geschichte 1911-2011, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4604932-0, http://d-nb.info/gnd/4184194-3, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010427-8> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040619-2> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042203-3> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4075561-7> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049600-4> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049716-1> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4077513-6> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113303-1> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120314-8> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120316-1> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4127794-6> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4137215-3> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4143413-4> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4145395-5> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4147365-6> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4151183-9> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4184194-3> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4306876-5> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4327015-3> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4337730-0> .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4362856-4> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4159648-1> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4419668-4> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/6509781-6> .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
-_:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb8 .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -11797,8 +11713,8 @@ _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standa
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Dokumentarische Medien, publizistische Medien, Unterrichtsmedien; Journalismus; Verlagswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Handel, Kommunikation, Verkehr"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Il grande cinema"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11811,7 +11727,6 @@ _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http:/
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "\u0410\u043D\u0434\u0440\u0435\u0435\u0432\u0430, \u0413. \u0424."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "070"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "380"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "860"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb8 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1041277814> .
@@ -11838,42 +11753,37 @@ _:Bb8 <http://schema.org/startDate> "1981"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb8 <http://schema.org/startDate> "1992"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb8 <http://schema.org/startDate> "2000"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb8 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb8 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb22 .
 _:Bb8 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb25 .
-_:Bb8 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb27 .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1074109953, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/11850066X, Geschichte 1963-1967, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2050419-6, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb26 .
+_:Bb8 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb28 .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Geschichte 1945-2003, http://d-nb.info/gnd/4020533-2, Schulbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118722123, http://d-nb.info/gnd/4152975-3"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/138460604, Theaterst\u00FCck, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4219952-9, http://d-nb.info/gnd/4136959-2, http://d-nb.info/gnd/4020517-4, http://d-nb.info/gnd/4143413-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4139439-2, http://d-nb.info/gnd/4002641-3, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049795-1, http://d-nb.info/gnd/4045612-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4511937-5, Kommentar"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118722123> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/133595935> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/138460604> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/16090142-X> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2175350-7> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4, http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4020378-5, http://d-nb.info/gnd/4040629-5, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120314-8, W\u00F6rterbuch, http://d-nb.info/gnd/4113292-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4219055-1"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118649817> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12918814X> .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/35439-9> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4006617-4> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045895-7> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4033581-1> .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4052945-9> .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4055876-9> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4061694-0> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4067488-5> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4074032-8> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219952-9> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4479982-2> .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4507427-6> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113303-1> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120108-5> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4145395-5> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4306876-5> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4337730-0> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4362856-4> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4604932-0> .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
+_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
-_:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb9 .
 _:Bb8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -11908,39 +11818,43 @@ _:Bb9 <http://schema.org/publishedBy> "Spiegel-Verl. Augstein"^^<http://www.w3.o
 _:Bb9 <http://schema.org/startDate> "1994"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb9 <http://schema.org/startDate> "2000"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb9 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb9 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb13 .
-_:Bb9 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb19 .
-_:Bb9 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb21 .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2041907-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010355-9, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4126078-8, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
+_:Bb9 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb20 .
+_:Bb9 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb22 .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1060772442, http://d-nb.info/gnd/2175350-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118640038"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/133595935, http://d-nb.info/gnd/4046277-8, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/16090142-X, Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2050419-6, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4061694-0, http://d-nb.info/gnd/4227766-8, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4075561-7, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115393-5, Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1074109953> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/11850066X> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020533-2> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4046277-8> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049795-1> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4479982-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4511937-5, Kommentar"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118722123> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/138460604> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4006617-4> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4057399-0> .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4067488-5> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076388-2> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4077723-6> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113292-0> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120314-8> .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4130470-6> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4136959-2> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4139439-2> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4142176-0> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4152975-3> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4227766-8> .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4511937-5> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4184194-3> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219055-1> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4327015-3> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4507427-6> .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb0 .
+_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb1 .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb4 .
-_:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb10 .
 _:Bb9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .

--- a/src/test/resources/reverseTest/output/nt/00000/BT000002852.nt
+++ b/src/test/resources/reverseTest/output/nt/00000/BT000002852.nt
@@ -1,17 +1,19 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/4018466-3> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "Freudenberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1989"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4018466-3, http://d-nb.info/gnd/4020517-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018466-3> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4018466-3, http://d-nb.info/gnd/4020517-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018466-3> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/4018466-3> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/4018466-3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName> .
 <http://d-nb.info/gnd/4018466-3> <http://www.w3.org/2000/01/rdf-schema#label> "Freudenberg, Kreis Siegen-Wittgenstein"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -27,7 +29,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000002852> <http://purl.org/dc/terms/modified> "19960513"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000002852> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/extent> "46 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Hrsg.: Stadt Freudenberg, Der Stadtdirektor]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/dc/elements/1.1/coverage> "Freudenberg <Siegen-Wittgenstein>"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -46,7 +48,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadt Freudenberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadt Freudenberg S\u00FCdwestfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Zeitgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/BT000002852#!> <http://rdaregistry.info/Elements/u/P60493> "wechselvolle Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000002852#!> <http://schema.org/publication> _:b2 .
 <http://lobid.org/resources/BT000002852#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00000/HT000009600.nt
+++ b/src/test/resources/reverseTest/output/nt/00000/HT000009600.nt
@@ -13,6 +13,8 @@ _:b3 <http://schema.org/location> "Hamburg"^^<http://www.w3.org/2001/XMLSchema#s
 _:b3 <http://schema.org/publishedBy> "DAG"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1948"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/37043-5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/37043-5> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsche Angestellten-Gewerkschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/37043-5> <http://www.w3.org/2004/02/skos/core#altLabel> "Angestellten-Gewerkschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -352,7 +354,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT000009600> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT000009600> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT000009600> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000009600:DE-260:Z%201009#!> .
 <http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000009600:DE-294-17:BX-7#!> .
 <http://lobid.org/resources/HT000009600#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000009600:DE-38:Haa1455#!> .

--- a/src/test/resources/reverseTest/output/nt/00001/BT000014215.nt
+++ b/src/test/resources/reverseTest/output/nt/00001/BT000014215.nt
@@ -7,15 +7,21 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/174424000> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/trl> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://schema.org/location> "Schmallenberg-Holthausen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1993"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4219055-1"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219055-1> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4219055-1"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219055-1> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/174423993> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/174423993> <http://www.w3.org/2000/01/rdf-schema#label> "Nettekoven, Heinrich"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/174423993> <http://www.w3.org/2004/02/skos/core#altLabel> "Nettekoven, Henricus"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -37,9 +43,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000014215> <http://purl.org/dc/terms/modified> "20120613"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000014215> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/BT000014215#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Heinrich Nettekoven ; Johannes Arnoldus Glessen. \u00DCbersetzung des lateinischen Textes durch Hans Kallhoff"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/dc/terms/bibliographicCitation> "Patrone und Heilige im kurk\u00F6lnischen Sauerland; Red.: Michael Senger. [Mitarb.: Christine Aka ...]; 1993; S. 113-114"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -52,7 +56,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/174423993 | http://d-nb.info/gnd/174424019 | http://d-nb.info/gnd/174424000"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#hbzID> "BT000014215"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/BT000014215#!> <http://rdaregistry.info/Elements/u/P60493> "urkundliche Festlegung ... \u00FCber die 1794 erfolgte Translation der Reliquien der HLG. Drei K\u00F6nige vom 5. August 1808"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000014215#!> <http://schema.org/publication> _:b4 .
 <http://lobid.org/resources/BT000014215#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00004/BT000040377.nt
+++ b/src/test/resources/reverseTest/output/nt/00004/BT000040377.nt
@@ -1,21 +1,23 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/105745944> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b12 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b13 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -23,10 +25,10 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standar
 _:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "1983"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/105745944> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/105745944> <http://www.w3.org/2000/01/rdf-schema#label> "Schmidt, Eckhard"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-BT000040377> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -37,7 +39,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000040377> <http://purl.org/dc/terms/modified> "19960814"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000040377> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000040377#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000040377#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/elements/1.1/coverage> "Rheine"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/bibliographicCitation> "Rheine gestern, heute, morgen. - 11 (1983), S. 26-38 : Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -49,7 +51,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/105745944"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#hbzID> "BT000040377"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
+<http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/BT000040377#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .

--- a/src/test/resources/reverseTest/output/nt/00004/BT000041593.nt
+++ b/src/test/resources/reverseTest/output/nt/00004/BT000041593.nt
@@ -3,6 +3,8 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://schema.org/startDate> "1983"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/10880724X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/10880724X> <http://www.w3.org/2000/01/rdf-schema#label> "Altekamp, Heinrich"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-BT000041593> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -13,7 +15,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/BT000041593> <http://purl.org/dc/terms/modified> "19960814"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000041593> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000041593#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000041593#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/bibliographicCitation> "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .

--- a/src/test/resources/reverseTest/output/nt/00006/BT000067443.nt
+++ b/src/test/resources/reverseTest/output/nt/00006/BT000067443.nt
@@ -3,6 +3,8 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://schema.org/startDate> "1986"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118033948> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/118033948> <http://www.w3.org/2000/01/rdf-schema#label> "Meier, Elmar"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-BT000067443> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -13,7 +15,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/BT000067443> <http://purl.org/dc/terms/modified> "19960816"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000067443> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000067443#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000067443#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/BT000067443#!> <http://id.loc.gov/ontologies/bibframe/note> "Anfang s. Jg. 5 (1985) S. 22-29"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/elements/1.1/coverage> "Coesfeld (Kreis)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/dc/terms/bibliographicCitation> "Kiebitz. - 6 (1986), S. 29-36, S. 63-67"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00007/TT000075751.nt
+++ b/src/test/resources/reverseTest/output/nt/00007/TT000075751.nt
@@ -4,6 +4,16 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/13482167X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/sng> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/134926285> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/sng> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -23,6 +33,10 @@ _:b7 <http://schema.org/location> "London"^^<http://www.w3.org/2001/XMLSchema#st
 _:b7 <http://schema.org/publishedBy> "Hyperion"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "1994"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/118515527> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1913"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118515527> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1976"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118515527> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -67,13 +81,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT000075751> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn38#!> .
 <http://lobid.org/resources/TT000075751> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn38#!> .
 <http://lobid.org/resources/TT000075751> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
+<http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/extent> "2 CD : DDD + Beih."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT000075751:DE-Kn38:CD%202410%20-%20CD%202411#!> .
 <http://lobid.org/resources/TT000075751#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Benjamin Britten. Lorna Anderson, soprano ; Regina Nathan, soprano ; Jamie MacDougall, tenor ; Malcolm Martineau, piano ; Bryn Lewis, harp ; Craig Ogden, guitar"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00010/BT000103077.nt
+++ b/src/test/resources/reverseTest/output/nt/00010/BT000103077.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118060872> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Schulgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10,12 +10,14 @@ _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Herne"^^<http://www.w3.org/20
 _:b4 <http://schema.org/location> "Bonn"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1990"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118060872> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1940"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118060872> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/118060872> <http://www.w3.org/2000/01/rdf-schema#label> "Reulecke, J\u00FCrgen"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -29,7 +31,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000103077> <http://purl.org/dc/terms/modified> "20130424"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000103077> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000103077#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000103077#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/BT000103077#!> <http://id.loc.gov/ontologies/bibframe/note> "Aus: Fabrik, Familie, Feierabend. Wuppertal 1978, S. 247-271"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/elements/1.1/coverage> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/dc/terms/bibliographicCitation> "Vom Kohlenpott zu Deutschlands \"starkem St\u00FCck\".; von J\u00FCrgen Reulecke; 1990; S. 49-76 ; graph. Darst., 1 Tab."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -42,7 +44,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/118060872"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#hbzID> "BT000103077"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
 <http://lobid.org/resources/BT000103077#!> <http://rdaregistry.info/Elements/u/P60493> "Schulprobleme u. Schulalltag in e. \"jungen\" Industriestadt vor d. ersten Weltkrieg (Herne)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000103077#!> <http://schema.org/publication> _:b4 .
 <http://lobid.org/resources/BT000103077#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00011/BT000110055.nt
+++ b/src/test/resources/reverseTest/output/nt/00011/BT000110055.nt
@@ -4,7 +4,7 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b1 <http://www.w3.org/2000/01/rdf-schema#label> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Umweltschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -15,12 +15,14 @@ _:b5 <http://schema.org/location> "Kissing"^^<http://www.w3.org/2001/XMLSchema#s
 _:b5 <http://schema.org/publishedBy> "WEKA, Informationsschr.- u. Werbefachverl."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "1991"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://hub.culturegraph.org/resource/HBZ-BT000110055> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#label> "Mitwirkende"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/organisations/DE-605#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Organisation"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -29,7 +31,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000110055> <http://purl.org/dc/terms/modified> "19960817"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000110055> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/extent> "28 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/note> "Nicht im Sortimentsbuchh."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[hrsg. in Zsarb. mit d. Kommune]."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -42,7 +44,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#contributorOrder> "Kall"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#hbzID> "BT000110055"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/BT000110055#!> <http://rdaregistry.info/Elements/u/P60493> "wir sch\u00FCtzen unsere Umwelt"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000110055#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/BT000110055#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00012/BT000128754.nt
+++ b/src/test/resources/reverseTest/output/nt/00012/BT000128754.nt
@@ -1,29 +1,31 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/174423330> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2050419-6> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2050419-6> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/location> "Reinbek bei Hamburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "1996"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2050419-6, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2041907-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2041907-7> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2050419-6, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2041907-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2041907-7> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/174423330> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/174423330> <http://www.w3.org/2000/01/rdf-schema#label> "Job, Bertram"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2041907-7> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -42,7 +44,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000128754> <http://purl.org/dc/terms/modified> "20090401"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/BT000128754> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000128754#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000128754#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/elements/1.1/coverage> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/elements/1.1/coverage> "M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/dc/terms/abstract> "Erinnerungen an d. 1. FC K\u00F6ln u. Borussia M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -64,7 +66,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "Erster Fu\u00DFball-Club K\u00F6ln 01/07"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "Erster Fu\u00DFball-Klub K\u00F6ln 01/07"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "VfL Borussia M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/BT000128754#!> <http://rdaregistry.info/Elements/u/P60493> "Jugend zwischen zwei Magnetpolen ; nur Animosit\u00E4t gebiert gro\u00DFe Spiele"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000128754#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/BT000128754#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00016/BT000168595.nt
+++ b/src/test/resources/reverseTest/output/nt/00016/BT000168595.nt
@@ -1,29 +1,31 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/5265186-1> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4246263-0> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4246263-0> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1998"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4246263-0, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4033581-1, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4033581-1> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4246263-0, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4033581-1, http://d-nb.info/gnd/4018202-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4033581-1> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4018202-2> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/4018202-2> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/4018202-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 <http://d-nb.info/gnd/4018202-2> <http://www.w3.org/2000/01/rdf-schema#label> "Frau"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -52,7 +54,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/BT000168595> <http://purl.org/dc/terms/modified> "20020909"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000168595> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/extent> "42 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Fraktion B\u00FCndnis 90, Die Gr\u00FCnen im Landschaftsverband Westfalen-Lippe"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
@@ -75,7 +77,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "North Rhine-Westphalia"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Weib"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Weibliche Erwachsene"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/BT000168595#!> <http://rdaregistry.info/Elements/u/P60493> "frauenpolitische Konzeptionen im Kulturbetrieb ; Dokumentation einer Anh\u00F6rung vom 16. Mai 1998"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/BT000168595#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/BT000168595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00029/HT000290078.nt
+++ b/src/test/resources/reverseTest/output/nt/00029/HT000290078.nt
@@ -7,6 +7,8 @@ _:b1 <http://schema.org/publishedBy> "HOELDER-PICHLER-TEMPSKY"^^<http://www.w3.o
 _:b1 <http://schema.org/publishedBy> "LEYKAM"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1976"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/174737203> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/174737203> <http://www.w3.org/2000/01/rdf-schema#label> "Aigner, Johann"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT000290078> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -36,7 +38,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT000290078> <http://purl.org/dc/terms/modified> "20070718"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT000290078> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/extent> "X, 99 S. : GRAPH. DARST."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000290078:DE-290:Jc%20F%2016826#!> .
 <http://lobid.org/resources/HT000290078#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT000290078:DE-467:11DCX1513%2B1#!> .

--- a/src/test/resources/reverseTest/output/nt/00100/CT001004829.nt
+++ b/src/test/resources/reverseTest/output/nt/00100/CT001004829.nt
@@ -1,9 +1,11 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/101423748> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Theaterst\u00FCck"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -18,11 +20,11 @@ _:b6 <http://schema.org/location> "Coblenz"^^<http://www.w3.org/2001/XMLSchema#s
 _:b6 <http://schema.org/publishedBy> "H\u00F6lscher"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "1828"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/138460604, Theaterst\u00FCck, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/138460604> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/138460604, Theaterst\u00FCck, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/138460604> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/101423748> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1793"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/101423748> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1864"^^<http://www.w3.org/2001/XMLSchema#gYear> .
@@ -52,7 +54,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/CT001004829> <http://purl.org/dc/terms/modified> "20141002"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/CT001004829> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/extent> "176 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/CT001004829:DE-929:#!> .
 <http://lobid.org/resources/CT001004829#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Johann Josef Reiff"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -70,7 +72,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#fulltextOnline> <http://nbn-resolving.de/urn:nbn:de:0128-1-37874> .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#hbzID> "CT001004829"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheineck, Otto von (-1150)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:0128-1-37874"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://rdaregistry.info/Elements/u/P60493> "Trauerspiel in 5 Akten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT001004829#!> <http://schema.org/publication> _:b5 .

--- a/src/test/resources/reverseTest/output/nt/00103/HT001039253.nt
+++ b/src/test/resources/reverseTest/output/nt/00103/HT001039253.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/41115-2> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://purl.org/lobid/lv#hasSuperordinate> <http://lobid.org/resources/HT002156469#!> .
 _:b2 <http://purl.org/lobid/lv#numbering> "29"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10,12 +10,14 @@ _:b3 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSc
 _:b3 <http://schema.org/publishedBy> "Beuth"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1974"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4016583-8, http://d-nb.info/gnd/4419668-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4016583-8> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4419668-4> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4016583-8, http://d-nb.info/gnd/4419668-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4016583-8> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4419668-4> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/4016583-8> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/4016583-8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 <http://d-nb.info/gnd/4016583-8> <http://www.w3.org/2000/01/rdf-schema#label> "Feder"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -118,7 +120,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001039253> <http://purl.org/dc/terms/modified> "20090220"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-832#!> .
 <http://lobid.org/resources/HT001039253> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/extent> "226 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001039253:DE-131:MAS#!> .
 <http://lobid.org/resources/HT001039253#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001039253:DE-294:WFA228-29:2#!> .
@@ -140,7 +142,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#isPartOf> _:b2 .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectAltLabel> "Metallfeder"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectAltLabel> "Normschrift (Norm)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT001039253#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/edition> "2., ge\u00E4nd. Aufl., Stand d.abgedr. Normen: Januar 1974"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/isbn> "3410104356"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/isbn> "9783410104353"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00121/TT001210514.nt
+++ b/src/test/resources/reverseTest/output/nt/00121/TT001210514.nt
@@ -4,6 +4,8 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://schema.org/location> "Marburg/Lahn"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/publishedBy> "Blindenhochschulb\u00FCcherei"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118551655> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1889"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118551655> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1945"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118551655> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -40,7 +42,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT001210514> <http://schema.org/provider> <http://lobid.org/organisations/DE-576#!> .
 <http://lobid.org/resources/TT001210514> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/TT001210514> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001210514:DE-107:#!> .
 <http://lobid.org/resources/TT001210514#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Adolf Hitler"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .

--- a/src/test/resources/reverseTest/output/nt/00123/TT001230001.nt
+++ b/src/test/resources/reverseTest/output/nt/00123/TT001230001.nt
@@ -14,6 +14,12 @@ _:b4 <http://schema.org/location> "Avgvstae Vindelicorvm"^^<http://www.w3.org/20
 _:b4 <http://schema.org/publishedBy> "Praetorius"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1596"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118535765> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1194"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118535765> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1250"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118535765> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -104,9 +110,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT001230001> <http://schema.org/provider> <http://lobid.org/organisations/DE-576#!> .
 <http://lobid.org/resources/TT001230001> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/TT001230001> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/extent> "[8] Bl., 414, [1] S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001230001:DE-107:MF%20275%2FF2001%2FF2003#!> .
 <http://lobid.org/resources/TT001230001#!> <http://id.loc.gov/ontologies/bibframe/note> "Vorlageform des Erscheinungsvermerks: Avgvstae Vindelicorvm ... Apud Ioannem Praetorium, Anno M.D.XCVI ... - Mikrofiche. M\u00FCnchen : Saur, 1991. Mikrofiche-Nr. F2001-F2003 : 23x"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00131/HT001310215.nt
+++ b/src/test/resources/reverseTest/output/nt/00131/HT001310215.nt
@@ -8,6 +8,10 @@ _:b2 <http://schema.org/location> "CHICAGO, ILL."^^<http://www.w3.org/2001/XMLSc
 _:b2 <http://schema.org/publishedBy> "AMERICAN DENTAL ASSOCIATION"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1980"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b4 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/177572388> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/177572388> <http://www.w3.org/2000/01/rdf-schema#label> "SCHOLLE, ROGER H."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/37460-X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
@@ -30,8 +34,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT001310215> <http://purl.org/dc/terms/created> "19950206"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001310215> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT001310215> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT001310215#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001310215:DE-294:ZMC134#!> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/dc/terms/title> "JOURNAL"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00167/TT001671747.nt
+++ b/src/test/resources/reverseTest/output/nt/00167/TT001671747.nt
@@ -4,9 +4,13 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/137082479> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/red> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -17,12 +21,12 @@ _:b6 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSch
 _:b6 <http://schema.org/publishedBy> "Aschendorff"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "1990"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/137082479> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1938"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/137082479> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/137082479> <http://www.w3.org/2000/01/rdf-schema#label> "Mayr, Alois"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -107,8 +111,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT001671747> <http://schema.org/provider> <http://lobid.org/organisations/DE-386#!> .
 <http://lobid.org/resources/TT001671747> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-386#!> .
 <http://lobid.org/resources/TT001671747> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/extent> "[2] Bl. : graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001671747:DE-290:GOA%207%2F62-3,5,1#!> .
 <http://lobid.org/resources/TT001671747#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001671747:DE-386:GOA%207%2F62-3,5,1#!> .
@@ -133,7 +136,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalkunde"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen (Provinzialverband)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen (Volk, Neuzeit)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/TT001671747#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/ontology/bibo/isbn> "3402061740"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/ontology/bibo/isbn> "9783402061749"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001671747#!> <http://schema.org/publication> _:b6 .

--- a/src/test/resources/reverseTest/output/nt/00172/TT001726537.nt
+++ b/src/test/resources/reverseTest/output/nt/00172/TT001726537.nt
@@ -5,6 +5,8 @@ _:b1 <http://schema.org/location> "Cologne [i.e.] Amsterdam"^^<http://www.w3.org
 _:b1 <http://schema.org/publishedBy> "Delpeuck"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1683"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/115541802> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1610"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/115541802> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1686"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/115541802> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -43,7 +45,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT001726537> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001726537> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001726537> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/extent> "[2] Bl., 116 S. : Ill. (Kupfert.)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001726537:DE-Kn28:2%20in:%20Aa%201801#!> .
 <http://lobid.org/resources/TT001726537#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001726537:DE-Kn28:2%20in:%20Aa%202422#!> .

--- a/src/test/resources/reverseTest/output/nt/00189/HT001898812.nt
+++ b/src/test/resources/reverseTest/output/nt/00189/HT001898812.nt
@@ -4,7 +4,11 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/124515312> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113292-0> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "W\u00F6rterbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -15,14 +19,14 @@ _:b5 <http://schema.org/location> "Leipzig"^^<http://www.w3.org/2001/XMLSchema#s
 _:b5 <http://schema.org/publishedBy> "Verl. Enzyklop\u00E4die [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "1974"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120314-8, W\u00F6rterbuch, http://d-nb.info/gnd/4113292-0"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120314-8> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113292-0> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120314-8, W\u00F6rterbuch, http://d-nb.info/gnd/4113292-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120314-8> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/124515312> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1867"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/124515312> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1960"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/124515312> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -205,8 +209,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001898812> <http://purl.org/dc/terms/modified> "20030610"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT001898812> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/extent> "XVIII, 1306 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001898812:DE-294:LLB3272-2#!> .
 <http://lobid.org/resources/HT001898812#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT001898812:DE-361:NP701.35%20G8D4P%5B2,2#!> .
@@ -240,7 +243,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Hochdeutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuhochdeutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Polnische Sprache"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT001898812#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .

--- a/src/test/resources/reverseTest/output/nt/00196/TT001966831.nt
+++ b/src/test/resources/reverseTest/output/nt/00196/TT001966831.nt
@@ -13,6 +13,8 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 _:b4 <http://schema.org/location> "Madrid"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1999"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/219515-X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/219515-X> <http://www.w3.org/2000/01/rdf-schema#label> "Acci\u00F3n Cat\u00F3lica Espa\u00F1ola"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/219515-X> <http://www.w3.org/2004/02/skos/core#altLabel> "Acci\u00F3n Cat\u00F3lica Espan\u0304ola"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -36,7 +38,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT001966831> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001966831> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001966831> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT001966831#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/TT001966831#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/TT001966831#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT001966831:DE-Kn28:Zd%200159%20(1999,2)#!> .
 <http://lobid.org/resources/TT001966831#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/spa> .
 <http://lobid.org/resources/TT001966831#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .

--- a/src/test/resources/reverseTest/output/nt/00200/TT002001274.nt
+++ b/src/test/resources/reverseTest/output/nt/00200/TT002001274.nt
@@ -4,7 +4,7 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/171952448> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://purl.org/lobid/lv#hasSuperordinate> <http://lobid.org/resources/HT001375579#!> .
 _:b3 <http://purl.org/lobid/lv#numbering> "1"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -13,10 +13,14 @@ _:b4 <http://schema.org/location> "T\u00FCbingen"^^<http://www.w3.org/2001/XMLSc
 _:b4 <http://schema.org/publishedBy> "Mohr"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1904"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118649817"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118649817> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118649817"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118649817> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118572865> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1875"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118572865> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1942"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118572865> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -61,8 +65,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT002001274> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT002001274> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT002001274> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/extent> "XVI, 323 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002001274:DE-Kn28:Dc%204364#!> .
 <http://lobid.org/resources/TT002001274#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Hans Lietzmann"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -86,7 +89,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "di Laodicea (310-390)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Laodicea (310-390)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Laodikeia (310-390)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/TT002001274#!> <http://schema.org/publication> _:b4 .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .

--- a/src/test/resources/reverseTest/output/nt/00216/TT002165019.nt
+++ b/src/test/resources/reverseTest/output/nt/00216/TT002165019.nt
@@ -4,6 +4,8 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://schema.org/location> "Paderborn"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1964"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/104698489> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/104698489> <http://www.w3.org/2000/01/rdf-schema#label> "Boskamp, Aloys Erich"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-TT002165019> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -22,7 +24,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT002165019> <http://schema.org/provider> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/TT002165019> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/TT002165019> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/extent> "S. 77"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002165019:DE-6-139a:G%20m%2038#!> .
 <http://lobid.org/resources/TT002165019#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hrsg.: Stadt Paderborn. Verantwortl.: A. Erich Boskamp"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234042.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234042.nt
@@ -8,6 +8,8 @@ _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Verwaltung u
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "350"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "2001"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/4149423-4> <http://www.w3.org/2000/01/rdf-schema#label> "Dewey-Dezimalklassifikation"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638077&custom_att_2=simple_viewer> <http://www.w3.org/2000/01/rdf-schema#label> "Digitool"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://edoweb-rlp.de/resource/edoweb:1638076> <http://www.w3.org/2000/01/rdf-schema#label> "Edoweb"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -26,7 +28,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT002234042> <http://purl.org/dc/terms/modified> "20160609"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234042> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234042> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/TT002234042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/TT002234042#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002234042:DE-929:#!> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638077&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234459.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234459.nt
@@ -8,14 +8,22 @@ _:b10 <http://www.w3.org/2000/01/rdf-schema#label> "Karte"^^<http://www.w3.org/2
 _:b11 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b11 <http://www.w3.org/2000/01/rdf-schema#label> "Geografie Mitteleuropas und Reisen in Mitteleuropa\u00A0\u00A0\u00A0\u00A0Geografie Deutschlands und Reisen in Deutschland"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b11 <http://www.w3.org/2004/02/skos/core#notation> "914.3"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049787-2, http://d-nb.info/gnd/4114067-9, Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049787-2> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
 _:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4114067-9> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
 _:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049787-2, http://d-nb.info/gnd/4114067-9, Karte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049787-2> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4114067-9> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> _:b3 .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -31,7 +39,7 @@ _:b6 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 _:b7 <http://www.w3.org/2000/01/rdf-schema#label> "M\u00FCller, Guntram"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b9 <http://www.loc.gov/mads/rdf/v1#componentList> _:b13 .
+_:b9 <http://www.loc.gov/mads/rdf/v1#componentList> _:b17 .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 <http://d-nb.info/gnd/4049787-2> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/4049787-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName> .
@@ -58,10 +66,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/TT002234459> <http://purl.org/dc/terms/modified> "20081017"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234459> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
+<http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b12 .
 <http://lobid.org/resources/TT002234459#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002234459:DE-929:#!> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1638893&custom_att_2=simple_viewer> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -81,7 +86,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rhein-Lahn-Kreis / Landratsamt"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sternenweg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wandern, Diez, Lahnstein, Rhein-Lahn-Info, Rhein, Lahn, Wirtschaftsf\u00F6rderung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectOrder> _:b12 .
+<http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectOrder> _:b16 .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:01-2079"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#webPageArchived> <http://www.rhein-lahn-info.de/jakobsweg/> .
 <http://lobid.org/resources/TT002234459#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079> .

--- a/src/test/resources/reverseTest/output/nt/00223/TT002234858.nt
+++ b/src/test/resources/reverseTest/output/nt/00223/TT002234858.nt
@@ -4,6 +4,8 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Verwaltung und Milit\u00E4rwissenschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://www.w3.org/2004/02/skos/core#notation> "350"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://cmswebserver10.icteam.net/stk/> <http://www.w3.org/2000/01/rdf-schema#label> "http://cmswebserver10.icteam.net/stk"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2029758-0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/2029758-0> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -32,7 +34,7 @@ _:b2 <http://www.w3.org/2004/02/skos/core#notation> "350"^^<http://www.w3.org/20
 <http://lobid.org/resources/TT002234858> <http://purl.org/dc/terms/modified> "20160523"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234858> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234858> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT002234858:DE-929:#!> .
 <http://lobid.org/resources/TT002234858#!> <http://id.loc.gov/ontologies/bibframe/note> "Siehe: http://www.stk.rlp.de"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6267588&custom_att_2=simple_viewer> .

--- a/src/test/resources/reverseTest/output/nt/00261/HT002619538.nt
+++ b/src/test/resources/reverseTest/output/nt/00261/HT002619538.nt
@@ -12,6 +12,8 @@ _:b3 <http://schema.org/location> "Gen\u00E8ve [u.a.]"^^<http://www.w3.org/2001/
 _:b3 <http://schema.org/publishedBy> "UN"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1955"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2023669-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/2023669-4> <http://www.w3.org/2000/01/rdf-schema#label> "Vereinte Nationen. Economic Commission for Europe"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2023669-4> <http://www.w3.org/2004/02/skos/core#altLabel> "CEE"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -82,7 +84,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT002619538> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT002619538> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT002619538> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT002619538:DE-294:ZRC%20828#!> .
 <http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT002619538:DE-38-121:Sh13#!> .
 <http://lobid.org/resources/HT002619538#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT002619538:DE-38:Sh13#!> .

--- a/src/test/resources/reverseTest/output/nt/00301/CT003012479.nt
+++ b/src/test/resources/reverseTest/output/nt/00301/CT003012479.nt
@@ -25,9 +25,35 @@ _:b15 <http://schema.org/location> "D\u00C3\u00BCsseldorf"^^<http://www.w3.org/2
 _:b15 <http://schema.org/publishedBy> "B\u00C3\u00B6gemann"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b15 <http://schema.org/startDate> "1805"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/123633206> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b22 .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b23 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b24 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b8 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b25 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b26 .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b27 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b11 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b28 .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b12 .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/116620153> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -141,19 +167,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 <http://lobid.org/resources/CT003012479> <http://purl.org/dc/terms/created> "20150420"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/CT003012479> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b10 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b12 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
-<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9 .
+<http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b16 .
 <http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Plakat : sw ; 33 x 29 cm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "die Musik ist von dem ber\u00C3\u00BChmten Kapellmeister Winter, Compositeur der Oper: Das unterbrochene Opferfest. [Textverf.: Alessandro Ercole Pepoli. \u00C3\u009Cbers. und arrang. von Carl Ludwig von Giesecke]. Personen: Madam Bilau, Herr Fuchs, Madam B\u00C3\u00B6hm d.j., Madam B\u00C3\u00B6hm d.\u00C3\u00A4., Herr Kellermann, Herr Dardenne, Herr Krug, Madam Annoni, Herr B\u00C3\u00B6hm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/dc/terms/alternative> "<<La>> Belisa Ossia La Fedelt\u00C3\u00A1 Riconosciuta"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00305/TT003059252.nt
+++ b/src/test/resources/reverseTest/output/nt/00305/TT003059252.nt
@@ -8,6 +8,10 @@ _:b2 <http://schema.org/location> "s.l."^^<http://www.w3.org/2001/XMLSchema#stri
 _:b2 <http://schema.org/publishedBy> "Apple Films"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1967"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b4 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/2000/01/rdf-schema#label> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/2004/02/skos/core#altLabel> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -28,8 +32,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT003059252> <http://schema.org/provider> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT003059252:DE-5-58:9%2F041#!> .
 <http://lobid.org/resources/TT003059252#!> <http://id.loc.gov/ontologies/bibframe/note> "Engl. Original mit dt. Untertiteln"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00305/TT003059252_contAndCrea.nt
+++ b/src/test/resources/reverseTest/output/nt/00305/TT003059252_contAndCrea.nt
@@ -8,6 +8,10 @@ _:b2 <http://schema.org/location> "s.l."^^<http://www.w3.org/2001/XMLSchema#stri
 _:b2 <http://schema.org/publishedBy> "Apple Films"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1967"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b4 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/2000/01/rdf-schema#label> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2005535-3> <http://www.w3.org/2004/02/skos/core#altLabel> "The Beatles"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -29,8 +33,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://schema.org/provider> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Video (VHS, 55 min.) : farb.; stereo"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT003059252_contAndCrea:DE-5-58:9%2F041#!> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://id.loc.gov/ontologies/bibframe/note> "Engl. Original mit dt. Untertiteln"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00306/TT003060418.nt
+++ b/src/test/resources/reverseTest/output/nt/00306/TT003060418.nt
@@ -4,6 +4,24 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118718312> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cmp> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b8 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/119309998> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/lbt> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -107,15 +125,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/TT003060418> <http://schema.org/provider> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003060418> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT003060418> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
-<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
+<http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b10 .
 <http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/extent> "3 CDs : stereo ; ADD"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/TT003060418:DE-5-58:7%2F441#!> .
 <http://lobid.org/resources/TT003060418#!> <http://id.loc.gov/ontologies/bibframe/note> "AD: 9+10/1958"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00316/HT003160768.nt
+++ b/src/test/resources/reverseTest/output/nt/00316/HT003160768.nt
@@ -1,18 +1,20 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2019209-5> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/publishedBy> "Der Regierungspr\u00E4sident"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1980"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2019209-5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName> .
 <http://d-nb.info/gnd/2019209-5> <http://www.w3.org/2000/01/rdf-schema#label> "Regierungsbezirk M\u00FCnster, Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4034268-2> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -76,7 +78,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT003160768> <http://purl.org/dc/terms/modified> "20031104"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-464#!> .
 <http://lobid.org/resources/HT003160768> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003160768:DE-385:ONG%2Fg52127#!> .
 <http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003160768:DE-465:ONG%2Fg52127#!> .
 <http://lobid.org/resources/HT003160768#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003160768:DE-6-007:ONG%2Fg52127#!> .
@@ -97,7 +99,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "Handwerkskammerbezirk M\u00FCnster (Westf)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "Landesentwicklungsplanung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FCnster (Westf) (Bezirk)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/HT003160768#!> <http://rdaregistry.info/Elements/u/P60327> "Regierungsbezirk M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003160768#!> <http://schema.org/publication> _:b2 .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00353/HT003536695.nt
+++ b/src/test/resources/reverseTest/output/nt/00353/HT003536695.nt
@@ -5,6 +5,8 @@ _:b1 <http://schema.org/location> "Amstelodami"^^<http://www.w3.org/2001/XMLSche
 _:b1 <http://schema.org/publishedBy> "Elzevir"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1646"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/119026074> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1598"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/119026074> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1679"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/119026074> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -63,7 +65,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT003536695> <http://purl.org/dc/terms/modified> "20140220"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT003536695> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/extent> "[8] Bl., 306 S., [1] gef. Bl. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003536695:DE-38:N5%2F26#!> .
 <http://lobid.org/resources/HT003536695#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003536695:DE-5:13%20a%20R%20337#!> .

--- a/src/test/resources/reverseTest/output/nt/00365/HT003654516.nt
+++ b/src/test/resources/reverseTest/output/nt/00365/HT003654516.nt
@@ -7,17 +7,19 @@ _:b1 <http://www.w3.org/2004/02/skos/core#notation> "360"^^<http://www.w3.org/20
 _:b10 <http://schema.org/location> "Bochum"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b10 <http://schema.org/publishedBy> "Bergbau-Berufsgenossenschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128022-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128022-2> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128022-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128022-2> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://www.w3.org/2004/02/skos/core#notation> "330"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Ingenieurwissenschaften und zugeordnete T\u00E4tigkeiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "620"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b12 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b13 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Chemische Verfahrenstechnik und verwandte Technologien"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -60,7 +62,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 <http://lobid.org/resources/HT003654516> <http://purl.org/dc/terms/created> "19901130"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT003654516> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003654516#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT003654516#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11 .
 <http://lobid.org/resources/HT003654516#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT003654516:DE-294:ZRC458-1988%2F89#!> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/dc/terms/medium> <http://purl.org/lobid/lv#Miscellaneous> .
@@ -80,7 +82,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectAltLabel> "Berichtswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectAltLabel> "Jahresbericht (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectAltLabel> "T\u00E4tigkeitsbericht (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectOrder> _:b11 .
+<http://lobid.org/resources/HT003654516#!> <http://purl.org/lobid/lv#subjectOrder> _:b12 .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/ontology/bibo/oclcnum> "224546401"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/ontology/bibo/oclcnum> "84927101"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT003654516#!> <http://schema.org/publication> _:b10 .

--- a/src/test/resources/reverseTest/output/nt/00438/HT004381366.nt
+++ b/src/test/resources/reverseTest/output/nt/00438/HT004381366.nt
@@ -1,9 +1,11 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2019209-5> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://purl.org/lobid/lv#hasSuperordinate> <http://lobid.org/resources/HT003160768#!> .
 _:b3 <http://purl.org/lobid/lv#numbering> "Tezemu"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -12,16 +14,16 @@ _:b4 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSch
 _:b4 <http://schema.org/publishedBy> "Der Regierungspr\u00E4sident"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1986"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040619-2, http://d-nb.info/gnd/4306876-5, http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040619-2> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4306876-5> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040619-2, http://d-nb.info/gnd/4306876-5, http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040619-2> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4306876-5> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040613-1> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/2019209-5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName> .
 <http://d-nb.info/gnd/2019209-5> <http://www.w3.org/2000/01/rdf-schema#label> "Regierungsbezirk M\u00FCnster, Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4034268-2> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -83,7 +85,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT004381366> <http://purl.org/dc/terms/modified> "20010605"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT004381366> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/extent> "117 S. : zahlr. Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT004381366:DE-6-007:Sep.%2010.04.01%2F55,5#!> .
 <http://lobid.org/resources/HT004381366#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT004381366:DE-6-210:Boe%2070%20-%20%5B2%5D#!> .
@@ -108,7 +110,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regierungsbezirk M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalentwicklungsplan"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionaler Raumordnungsplan"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
 <http://lobid.org/resources/HT004381366#!> <http://schema.org/publication> _:b4 .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .

--- a/src/test/resources/reverseTest/output/nt/00494/HT004944075.nt
+++ b/src/test/resources/reverseTest/output/nt/00494/HT004944075.nt
@@ -14,6 +14,8 @@ _:b4 <http://schema.org/location> "Gen\u00E8ve [u.a.]"^^<http://www.w3.org/2001/
 _:b4 <http://schema.org/publishedBy> "UN"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1993"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2023669-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/2023669-4> <http://www.w3.org/2000/01/rdf-schema#label> "United Nations. Economic Commission for Europe"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2023669-4> <http://www.w3.org/2004/02/skos/core#altLabel> "CEE"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -49,7 +51,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT004944075> <http://purl.org/dc/terms/created> "19930816"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004944075> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT004944075> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT004944075:DE-294:ZRC828-43#!> .
 <http://lobid.org/resources/HT004944075#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Economic Commission for Europe, Transport Division, United Nations"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT004944075#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/eng> .

--- a/src/test/resources/reverseTest/output/nt/00594/HT005944358.nt
+++ b/src/test/resources/reverseTest/output/nt/00594/HT005944358.nt
@@ -16,31 +16,33 @@ _:b12 <http://schema.org/publishedBy> "Neomarius"^^<http://www.w3.org/2001/XMLSc
 _:b12 <http://schema.org/publishedBy> "Niemeyer"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b12 <http://schema.org/publishedBy> "de Gruyter"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, http://d-nb.info/gnd/4035964-5, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4050484-0, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4035964-5> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4115788-6, http://d-nb.info/gnd/4035964-5, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4050484-0, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
 _:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4050484-0> .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b16 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4035964-5> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b17 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b22 .
-_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
-_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4050484-0> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4115788-6> .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b23 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b19 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b20 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -53,7 +55,7 @@ _:b7 <http://www.w3.org/2004/02/skos/core#notation> "860"^^<http://www.w3.org/20
 _:b8 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b8 <http://www.w3.org/2000/01/rdf-schema#label> "Franz\u00F6sisch und verwandte romanische Sprachen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://www.w3.org/2004/02/skos/core#notation> "440"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b9 <http://www.loc.gov/mads/rdf/v1#componentList> _:b21 .
+_:b9 <http://www.loc.gov/mads/rdf/v1#componentList> _:b22 .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 <http://d-nb.info/gnd/119126796> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1844"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/119126796> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1911"^^<http://www.w3.org/2001/XMLSchema#gYear> .
@@ -91,7 +93,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/HT005944358> <http://purl.org/dc/terms/created> "19931226"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005944358> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-361#!> .
 <http://lobid.org/resources/HT005944358> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT005944358#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT005944358#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b13 .
 <http://lobid.org/resources/HT005944358#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT005944358:DE-361:NA000%20Z540%5B95#!> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/dc/terms/medium> <http://purl.org/lobid/lv#Miscellaneous> .
@@ -113,7 +115,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sch\u00F6ne Literatur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachkunst"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wortkunst"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectOrder> _:b13 .
+<http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectOrder> _:b14 .
 <http://lobid.org/resources/HT005944358#!> <http://schema.org/publication> _:b12 .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .

--- a/src/test/resources/reverseTest/output/nt/00626/HT006266886.nt
+++ b/src/test/resources/reverseTest/output/nt/00626/HT006266886.nt
@@ -4,6 +4,16 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118657496> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/143102893> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/act> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -23,6 +33,8 @@ _:b8 <http://schema.org/location> "Segrate (Milano)"^^<http://www.w3.org/2001/XM
 _:b8 <http://schema.org/publishedBy> "Mondadori Video"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://schema.org/startDate> "1992"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/118657496> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1916"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118657496> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "2000"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118657496> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -68,12 +80,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT006266886> <http://purl.org/dc/terms/modified> "20021108"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT006266886> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
+<http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9 .
 <http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Videokassette (VHS, 93 Min.) : farb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006266886:DE-467:Medienzentrum#!> .
 <http://lobid.org/resources/HT006266886#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Regia: Vittorio DeSica. Interpreti: Dominique Sanda ; Lino Capolicchio ; Fabio Testi ; Helmut Berger"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/00669/HT006698544.nt
+++ b/src/test/resources/reverseTest/output/nt/00669/HT006698544.nt
@@ -1,18 +1,20 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/116583053> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "Bonn"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/publishedBy> "Marcus"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1849"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059594-8, http://d-nb.info/gnd/4073972-7"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059594-8> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059594-8, http://d-nb.info/gnd/4073972-7"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059594-8> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/116583053> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1818"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/116583053> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1891"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/116583053> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -61,7 +63,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT006698544> <http://purl.org/dc/terms/modified> "20150217"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT006698544> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/extent> "XIV, 464 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006698544:DE-5:57%2F6471#!> .
 <http://lobid.org/resources/HT006698544#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006698544:DE-6:1E%2018283#!> .
@@ -73,7 +75,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#fulltextOnline> <http://resolver.sub.uni-goettingen.de/purl?PPN236434969> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#hbzID> "HT006698544"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalkunde"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/HT006698544#!> <http://rdaregistry.info/Elements/u/P60493> "mit besonderer R\u00FCcksicht auf deutsche Auswanderung und die physischen Verh\u00E4ltnisse des Landes ; mit einem naturwissenschaftlichen Anhange und einer topographisch-geognostisschen Karte von Texas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT006698544#!> <http://schema.org/publication> _:b2 .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/00698/HT006987933.nt
+++ b/src/test/resources/reverseTest/output/nt/00698/HT006987933.nt
@@ -12,6 +12,8 @@ _:b3 <http://id.loc.gov/ontologies/bibframe/note> "Periodizit\u00E4t: w\u00F6che
 _:b3 <http://schema.org/location> "Madrid"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1940"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/219515-X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/219515-X> <http://www.w3.org/2000/01/rdf-schema#label> "Acci\u00F3n Cat\u00F3lica Espa\u00F1ola"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/219515-X> <http://www.w3.org/2004/02/skos/core#altLabel> "Acci\u00F3n Cat\u00F3lica Espan\u0304ola"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -70,7 +72,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT006987933> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT006987933> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT006987933> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006987933:DE-Kn28:#!> .
 <http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006987933:DE-Kn28:5%20A#!> .
 <http://lobid.org/resources/HT006987933#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT006987933:DE-Kn28:CDR%200638%20(2005,Juli%2F2009,Juni)#!> .

--- a/src/test/resources/reverseTest/output/nt/00784/HT007847893.nt
+++ b/src/test/resources/reverseTest/output/nt/00784/HT007847893.nt
@@ -11,6 +11,12 @@ _:b3 <http://schema.org/location> "Napoli"^^<http://www.w3.org/2001/XMLSchema#st
 _:b3 <http://schema.org/publishedBy> "Libreria scientif. ed."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1964"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118506080> <http://d-nb.info/standards/elementset/gnd#dateOfBirthAndDeath> "ca. 1. H\u00E4lfte v5. Jh."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/118506080> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/118506080> <http://www.w3.org/2000/01/rdf-schema#label> "Bacchylides"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -77,9 +83,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT007847893> <http://purl.org/dc/terms/created> "19980105"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007847893> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT007847893> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/extent> "93 S. ; 8-o"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT007847893:DE-5-21:A%20607%205%2F10#!> .
 <http://lobid.org/resources/HT007847893#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT007847893:DE-5:65%2F7293#!> .

--- a/src/test/resources/reverseTest/output/nt/00873/HT008733617.nt
+++ b/src/test/resources/reverseTest/output/nt/00873/HT008733617.nt
@@ -10,6 +10,8 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 _:b3 <http://schema.org/location> "Strassburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1624"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118590111> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1597"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118590111> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1639"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118590111> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -143,7 +145,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT008733617> <http://purl.org/dc/terms/created> "19980716"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT008733617> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-292#!> .
 <http://lobid.org/resources/HT008733617> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT008733617:DE-290:SDC%205000%2F4#!> .
 <http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT008733617:DE-294:YMB92313#!> .
 <http://lobid.org/resources/HT008733617#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT008733617:DE-361:ZN140%20A#!> .

--- a/src/test/resources/reverseTest/output/nt/00971/HT009719670.nt
+++ b/src/test/resources/reverseTest/output/nt/00971/HT009719670.nt
@@ -4,6 +4,8 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/133991210> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/11860225X> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -17,6 +19,10 @@ _:b7 <http://id.loc.gov/ontologies/bibframe/note> "Erschienen: 1 - 2, jeweils Vi
 _:b7 <http://schema.org/location> "Paris"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/publishedBy> "Hatier/Didier"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/11860225X> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1920"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/11860225X> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "2010"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/11860225X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -52,9 +58,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT009719670> <http://purl.org/dc/terms/modified> "20050117"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT009719670> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT009719670:DE-467:#!> .
 <http://lobid.org/resources/HT009719670#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "s\u00E9lectionn\u00E9s par Janine Courtillon et Genevi\u00E8ve-Dominique de Salins"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/fra> .

--- a/src/test/resources/reverseTest/output/nt/00999/HT009993506.nt
+++ b/src/test/resources/reverseTest/output/nt/00999/HT009993506.nt
@@ -12,6 +12,10 @@ _:b4 <http://schema.org/location> "Opladen"^^<http://www.w3.org/2001/XMLSchema#s
 _:b4 <http://schema.org/publishedBy> "Leweke"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1968"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://hub.culturegraph.org/resource/HBZ-HT009993506> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/ctb> <http://www.w3.org/2000/01/rdf-schema#label> "Mitwirkende"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -39,8 +43,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT009993506> <http://purl.org/dc/terms/modified> "20041230"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT009993506> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/extent> "56 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT009993506:DE-38:1K4304#!> .
 <http://lobid.org/resources/HT009993506#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT009993506:DE-Sol1:KA%206169#!> .

--- a/src/test/resources/reverseTest/output/nt/01066/HT010662586.nt
+++ b/src/test/resources/reverseTest/output/nt/01066/HT010662586.nt
@@ -4,6 +4,8 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://schema.org/publishedBy> "Leicester Univ. Pr."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1957"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118839055> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1910"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118839055> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1997"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118839055> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -25,7 +27,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT010662586> <http://purl.org/dc/terms/created> "19990818"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT010662586> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/extent> "23 p."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT010662586:DE-380:#!> .
 <http://lobid.org/resources/HT010662586#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "by C[icely] V[eronica] Wedgwood"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01223/HT012237361.nt
+++ b/src/test/resources/reverseTest/output/nt/01223/HT012237361.nt
@@ -6,6 +6,8 @@ _:b1 <http://schema.org/location> "Bad Ems"^^<http://www.w3.org/2001/XMLSchema#s
 _:b1 <http://schema.org/publishedBy> "Statist. Landesamt"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1975"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/36467-8> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/36467-8> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/36467-8> <http://www.w3.org/2004/02/skos/core#altLabel> "Statistisches Landesamt"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -30,7 +32,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT012237361> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT012237361> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT012237361> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012237361#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT012237361#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT012237361#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012237361:DE-107:Per.%205157#!> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT012237361#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .

--- a/src/test/resources/reverseTest/output/nt/01289/HT012895751.nt
+++ b/src/test/resources/reverseTest/output/nt/01289/HT012895751.nt
@@ -1,18 +1,20 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2037247-4> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://schema.org/location> "Bad Kreuznach"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/publishedBy> "FORM-Medien-Verl.-Ges."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2000"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4037117-7, http://d-nb.info/gnd/4127794-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4037117-7> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4127794-6> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4037117-7, http://d-nb.info/gnd/4127794-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4037117-7> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4127794-6> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2037247-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName> .
 <http://d-nb.info/gnd/2037247-4> <http://www.w3.org/2000/01/rdf-schema#label> "Main-Kinzig-Kreis"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4037117-7> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -40,7 +42,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012895751> <http://purl.org/dc/terms/modified> "20010312"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT012895751> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/extent> "76 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012895751:DE-929:C2001A%2F13#!> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -54,7 +56,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#hbzID> "HT012895751"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectAltLabel> "Heimatforschung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectAltLabel> "Heimatgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT012895751#!> <http://rdaregistry.info/Elements/u/P60493> "Informationen f\u00FCr B\u00FCrger, Neub\u00FCrger & G\u00E4ste"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012895751#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01292/HT012926727.nt
+++ b/src/test/resources/reverseTest/output/nt/01292/HT012926727.nt
@@ -1,18 +1,20 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1031919368> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/publishedBy> "Springer"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2001"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4014228-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4014228-0> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4014228-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4014228-0> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1031919368> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1929"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/1031919368> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1031919368> <http://www.w3.org/2000/01/rdf-schema#label> "M\u00FCller, Leonhard"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -353,7 +355,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012926727> <http://purl.org/dc/terms/modified> "20130305"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT012926727> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/extent> "XIV, 514 S. : graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012926727:DE-1010:01PUM23(2)#!> .
 <http://lobid.org/resources/HT012926727#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT012926727:DE-1042:etech%20A%20002%202.%20Aufl.#!> .
@@ -427,7 +429,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectAltLabel> "R\u00E9publique F\u00E9d\u00E9rale d'Allemagne (Deutschland)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stromwirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u01E6umh\u016Br\u012Byat Alm\u0101niy\u0101 al-Itti\u1E25\u0101d\u012Bya"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/HT012926727#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/edition> "2. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/isbn> "3540676376"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/isbn> "9783540676379"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01305/HT013056453.nt
+++ b/src/test/resources/reverseTest/output/nt/01305/HT013056453.nt
@@ -13,39 +13,41 @@ _:b11 <http://schema.org/location> "M\u00FCnchen ; Salzburg"^^<http://www.w3.org
 _:b11 <http://schema.org/publishedBy> "Katzbichler"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b11 <http://schema.org/startDate> "1991"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4056218-9, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4182273-0, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4056218-9, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4122362-7, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4122362-7> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4182273-0> .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4056218-9> .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b15 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4182273-0, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4122362-7, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4122362-7> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4182273-0> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4056218-9> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b16 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
-_:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.loc.gov/mads/rdf/v1#componentList> _:b17 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
-_:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.loc.gov/mads/rdf/v1#componentList> _:b18 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
+_:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
+_:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b8 <http://www.w3.org/2000/01/rdf-schema#label> "Spiele und Freizeitaktivit\u00E4ten f\u00FCr drinnen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://www.w3.org/2004/02/skos/core#notation> "793"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b9 <http://www.loc.gov/mads/rdf/v1#componentList> _:b19 .
+_:b9 <http://www.loc.gov/mads/rdf/v1#componentList> _:b20 .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 <http://d-nb.info/gnd/4056218-9> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/4056218-9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
@@ -175,7 +177,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/HT013056453> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT013056453> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT013056453> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b12 .
 <http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013056453:DE-107:Per.%2014635#!> .
 <http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013056453:DE-294:ZGB%203152#!> .
 <http://lobid.org/resources/HT013056453#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013056453:DE-294:ZGB%203152-YID#!> .
@@ -196,7 +198,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b2 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b5 .
-<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b6 .
+<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b7 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b9 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> <https://w3id.org/lobid/rpb2#n990> .
@@ -208,7 +210,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spiele"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spielen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spielerziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectOrder> _:b12 .
+<http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#subjectOrder> _:b13 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/lobid/lv#zdbID> "1125458-0"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/ontology/bibo/oclcnum> "183350230"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013056453#!> <http://rdaregistry.info/Elements/u/P60278> <http://lobid.org/resources/HT016084461> .

--- a/src/test/resources/reverseTest/output/nt/01307/HT013077595.nt
+++ b/src/test/resources/reverseTest/output/nt/01307/HT013077595.nt
@@ -4,36 +4,42 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/11079267X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010355-9> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4024116-6> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010355-9, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010356-0, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010356-0> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010355-9> .
 _:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4024116-6> .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
 _:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010356-0> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4024116-6> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/109490312> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/red> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b13 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.loc.gov/mads/rdf/v1#componentList> _:b13 .
+_:b5 <http://www.loc.gov/mads/rdf/v1#componentList> _:b16 .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/location> "Coesfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2000"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010355-9, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4010356-0, http://d-nb.info/gnd/4024116-6, Lehrmittel"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/109490312> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1949"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/109490312> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/109490312> <http://www.w3.org/2000/01/rdf-schema#label> "Boer, Hans-Peter"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -88,9 +94,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013077595> <http://purl.org/dc/terms/modified> "20011113"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT013077595> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/extent> "VII, 119 S. : Ill., graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013077595:DE-6-290:Y%20401%20-%2036#!> .
 <http://lobid.org/resources/HT013077595#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013077595:DE-6:2J%201468#!> .
@@ -131,7 +135,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pressestelle (Coesfeld)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadt Coesfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtdirektor (Coesfeld)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
+<http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectOrder> _:b11 .
 <http://lobid.org/resources/HT013077595#!> <http://rdaregistry.info/Elements/u/P60493> "Kirsten Balke. [Hrsg.: Kreisheimatverein Coesfeld e.V. Red.: Hans-Peter Boer ...]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013077595#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/HT013077595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01330/HT013304490.nt
+++ b/src/test/resources/reverseTest/output/nt/01330/HT013304490.nt
@@ -4,11 +4,11 @@ _:b0 <http://www.w3.org/2004/02/skos/core#notation> "620"^^<http://www.w3.org/20
 _:b1 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b1 <http://www.w3.org/2000/01/rdf-schema#label> "Freizeitgestaltung, darstellende K\u00FCnste, Sport"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://www.w3.org/2004/02/skos/core#notation> "790"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
-_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
-_:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Dokumentarische Medien, publizistische Medien, Unterrichtsmedien; Journalismus; Verlagswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.w3.org/2004/02/skos/core#notation> "070"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
+_:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Dokumentarische Medien, publizistische Medien, Unterrichtsmedien; Journalismus; Verlagswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b2 <http://www.w3.org/2004/02/skos/core#notation> "070"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01348/HT013480902.nt
+++ b/src/test/resources/reverseTest/output/nt/01348/HT013480902.nt
@@ -4,7 +4,9 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/184293960> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4479982-2> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Kopplungs- und Kommunikationsprotokolle"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -16,10 +18,12 @@ _:b6 <http://schema.org/location> "Beijing [u.a.]"^^<http://www.w3.org/2001/XMLS
 _:b6 <http://schema.org/publishedBy> "O'Reilly"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2002"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4479982-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4479982-2> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4479982-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/124162061> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/124162061> <http://www.w3.org/2000/01/rdf-schema#label> "Gourley, David"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/184293960> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -77,8 +81,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013480902> <http://schema.org/provider> <http://lobid.org/organisations/DE-292#!> .
 <http://lobid.org/resources/HT013480902> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT013480902> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/extent> "XVIII, 635 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013480902:DE-1010:01TWP864#!> .
 <http://lobid.org/resources/HT013480902#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013480902:DE-466:TWP16169#!> .
@@ -94,7 +97,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#hbzID> "HT013480902"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#isPartOf> _:b4 .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#subjectAltLabel> "Hypertext Transfer Protocol"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/HT013480902#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/edition> "1. ed."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/isbn> "1565925092"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/isbn> "9781565925090"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01357/HT013577568.nt
+++ b/src/test/resources/reverseTest/output/nt/01357/HT013577568.nt
@@ -1,42 +1,44 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/108092704> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4126078-8> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4126078-8, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049788-4> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4126078-8> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
 _:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049788-4> .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049788-4> .
 _:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020378-5> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076769-3> .
 _:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040629-5> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020378-5> .
 _:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4040629-5> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b13 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b14 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b14 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b15 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2003"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4, http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4020378-5, http://d-nb.info/gnd/4040629-5, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4, http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4020378-5, http://d-nb.info/gnd/4040629-5, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4076769-3, http://d-nb.info/gnd/4126078-8, Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049788-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/108092704> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/108092704> <http://www.w3.org/2000/01/rdf-schema#label> "Heinrichs, Johannes"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4020378-5> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -63,7 +65,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013577568> <http://purl.org/dc/terms/created> "20030212"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT013577568> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013577568#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT013577568#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT013577568#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "von Johannes Heinrichs"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/bibliographicCitation> "Kontinuit\u00E4t und Diskontinuit\u00E4t / hrsg. von Thomas Gr\u00FCnewald ... - Berlin [u.a.], 2003. - (Reallexikon der germanischen Altertumskunde : Erg\u00E4nzungsb\u00E4nde ; 35). - S. [266]-344 : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -85,7 +87,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FCnzschatz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheinlande (im engeren Sinn)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "R\u00F6mische Zeit"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT013577568#!> <http://rdaregistry.info/Elements/u/P60493> "Mittel- und Niederrhein ca. 70 - 71 v. Chr. anhand germanischer M\u00FCnzen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013577568#!> <http://schema.org/publication> _:b6 .
 <http://lobid.org/resources/HT013577568#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01379/HT013798403.nt
+++ b/src/test/resources/reverseTest/output/nt/01379/HT013798403.nt
@@ -8,6 +8,8 @@ _:b2 <http://schema.org/location> "Mannheim"^^<http://www.w3.org/2001/XMLSchema#
 _:b2 <http://schema.org/publishedBy> "ZEW"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2003"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <ftp://ftp.zew.de/pub/zew-docs/dp/dp0349.pdf> <http://www.w3.org/2000/01/rdf-schema#label> "ftp://ftp.zew.de/pub"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/13017923X> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1974"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/13017923X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -33,7 +35,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT013798403> <http://schema.org/provider> <http://lobid.org/organisations/DE-601#!> .
 <http://lobid.org/resources/HT013798403> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294-18#!> .
 <http://lobid.org/resources/HT013798403> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/extent> "56 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT013798403:DE-294-18:B%201324%20%2F%201%20:2003H.49#!> .
 <http://lobid.org/resources/HT013798403#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Tobias Hagen"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01392/HT013925945.nt
+++ b/src/test/resources/reverseTest/output/nt/01392/HT013925945.nt
@@ -1,20 +1,22 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/128355220> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2002"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7764102-4, http://d-nb.info/gnd/4049600-4, Geschichte 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7764102-4> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049600-4> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7764102-4, http://d-nb.info/gnd/4049600-4, Geschichte 2002"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7764102-4> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049600-4> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/128355220> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/128355220> <http://www.w3.org/2000/01/rdf-schema#label> "Ketteler, Karl-Josef von"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4049600-4> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -32,7 +34,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013925945> <http://purl.org/dc/terms/created> "20040216"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT013925945> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013925945#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT013925945#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT013925945#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Karl-Josef von Ketteler"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/elements/1.1/coverage> "B\u00F6kenf\u00F6rde"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/dc/elements/1.1/coverage> "Schwarzenraben"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -52,7 +54,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Konservierung (Restaurierung)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kunstwerk / Restaurierung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Restauration (Bestandserhaltung)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT013925945#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .

--- a/src/test/resources/reverseTest/output/nt/01401/HT014015351.nt
+++ b/src/test/resources/reverseTest/output/nt/01401/HT014015351.nt
@@ -4,7 +4,9 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/136788548> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/hnr> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -12,14 +14,16 @@ _:b4 <http://schema.org/location> "M\u00FCnchen"^^<http://www.w3.org/2001/XMLSch
 _:b4 <http://schema.org/publishedBy> "Fink"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "2005"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4604932-0, http://d-nb.info/gnd/4184194-3, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4604932-0> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4184194-3> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4604932-0, http://d-nb.info/gnd/4184194-3, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4604932-0> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4184194-3> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/129016713> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/129016713> <http://www.w3.org/2000/01/rdf-schema#label> "Fehrmann, Gisela"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/136788548> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1943"^^<http://www.w3.org/2001/XMLSchema#gYear> .
@@ -134,8 +138,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014015351> <http://schema.org/provider> <http://lobid.org/organisations/DE-292#!> .
 <http://lobid.org/resources/HT014015351> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT014015351> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/extent> "324 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014015351:DE-294:IFB9657#!> .
 <http://lobid.org/resources/HT014015351#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014015351:DE-361:OH058%20S7L5#!> .
@@ -154,7 +157,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/dc/terms/title> "Spuren, Lekt\u00FCren"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/129016713 | http://d-nb.info/gnd/136788548"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#hbzID> "HT014015351"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/HT014015351#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/ontology/bibo/isbn> "3770538471"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/ontology/bibo/isbn> "9783770538478"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014015351#!> <http://rdaregistry.info/Elements/u/P60493> "Praktiken des Symbolischen ; [Festschrift f\u00FCr Ludwig J\u00E4ger zum 60. Geburtstag]"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01404/HT014046679.nt
+++ b/src/test/resources/reverseTest/output/nt/01404/HT014046679.nt
@@ -11,6 +11,12 @@ _:b3 <http://schema.org/location> "Hennef"^^<http://www.w3.org/2001/XMLSchema#st
 _:b3 <http://schema.org/publishedBy> "INVENTION"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1997"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/175894612> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/175894612> <http://www.w3.org/2000/01/rdf-schema#label> "Hoefler, Angelika"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/183839064> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -38,9 +44,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT014046679> <http://schema.org/provider> <http://lobid.org/organisations/DE-604#!> .
 <http://lobid.org/resources/HT014046679> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Bi10#!> .
 <http://lobid.org/resources/HT014046679> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Spiel (Inhalt: 1 Spielanleitung, 100 Situationskarten: 60 f\u00FCr Frauen, 40 f\u00FCr M\u00E4dchen (ab 12 J.). 90 Brave-Karten, 90 B\u00F6se-Karten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014046679:DE-Bi10:ICE%20Brav#!> .
 <http://lobid.org/resources/HT014046679#!> <http://id.loc.gov/ontologies/bibframe/note> "Lizenziert f\u00FCr das Amt f\u00FCr Jugendarbeit der Evangelischen Kirche von Westfalen, Haus Villigast"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01421/HT014215912.nt
+++ b/src/test/resources/reverseTest/output/nt/01421/HT014215912.nt
@@ -1,20 +1,22 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/121815684> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2004"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118560034, http://d-nb.info/gnd/4159648-1, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118560034> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4159648-1> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118560034, http://d-nb.info/gnd/4159648-1, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118560034> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4159648-1> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118560034> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "0747"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118560034> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "0814"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118560034> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -36,7 +38,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014215912> <http://purl.org/dc/terms/created> "20041208"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT014215912> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014215912#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT014215912#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT014215912#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Sven L\u00FCken"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/bibliographicCitation> "Karl der Gro\u00DFe und Europa / hrsg. von der Schweizerischen Botschaft in der Bundesrepublik Deutschland ... - Frankfurt am Main [u.a.], 2004. - S. 67-86 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -67,7 +69,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "der Gro\u00DFe (747-814)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "le Grand (747-814)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "the Great (747-814)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT014215912#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .

--- a/src/test/resources/reverseTest/output/nt/01431/HT014319164.nt
+++ b/src/test/resources/reverseTest/output/nt/01431/HT014319164.nt
@@ -4,7 +4,11 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/159865794> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4046277-8> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -12,14 +16,14 @@ _:b5 <http://schema.org/location> "Sinzig"^^<http://www.w3.org/2001/XMLSchema#st
 _:b5 <http://schema.org/publishedBy> "[Selbstverl.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "1998"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/133595935, http://d-nb.info/gnd/4046277-8, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/133595935> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4046277-8> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/133595935, http://d-nb.info/gnd/4046277-8, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/133595935> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/133595935> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1948"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/133595935> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/133595935> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -61,8 +65,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014319164> <http://purl.org/dc/terms/modified> "20130117"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT014319164> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/extent> "183 S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014319164:DE-38:17B2432#!> .
 <http://lobid.org/resources/HT014319164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014319164:DE-929:2005%2F1952#!> .
@@ -86,7 +89,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Plastiken"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Skulptur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Skulpturen"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT014319164#!> <http://rdaregistry.info/Elements/u/P60493> "Bildhauer"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014319164#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT014319164#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01452/HT014525099.nt
+++ b/src/test/resources/reverseTest/output/nt/01452/HT014525099.nt
@@ -4,6 +4,20 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/806366-7> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/11850553X> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/prf> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -26,6 +40,8 @@ _:b8 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#st
 _:b8 <http://schema.org/publishedBy> "Dt. Schallplatten"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://schema.org/startDate> "1981"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/118500546> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1926"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118500546> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/118500546> <http://www.w3.org/2000/01/rdf-schema#label> "Adam, Theo"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -101,14 +117,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT014525099> <http://purl.org/dc/terms/created> "20051020"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014525099> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT014525099> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
-<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
+<http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9 .
 <http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/extent> "2 Schallpl. : 33 UpM, stereo ; 30 cm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014525099:DE-1156:AR%20ba%2071#!> .
 <http://lobid.org/resources/HT014525099#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Johann Sebastian Bach"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01468/HT014681992.nt
+++ b/src/test/resources/reverseTest/output/nt/01468/HT014681992.nt
@@ -4,15 +4,19 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/5176874-4> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://schema.org/location> "Neuss"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2005"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/6509781-6"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/6509781-6> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/6509781-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/6509781-6> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/5176874-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/5176874-4> <http://www.w3.org/2000/01/rdf-schema#label> "Cornelius-Gesellschaft (Neuss-Selikum)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/6509781-6> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -41,8 +45,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014681992> <http://purl.org/dc/terms/modified> "20151209"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT014681992> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/extent> "[ca. 50 Bl.] : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT014681992:DE-61-90:za%2F4269(2005)#!> .
 <http://lobid.org/resources/HT014681992#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Cornelius-Gesellschaft Neuss-Selikum e.V."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -58,7 +61,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuss (Neuss)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuss-Selikum (Neuss-Selikum)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
 <http://lobid.org/resources/HT014681992#!> <http://rdaregistry.info/Elements/u/P60493> "vom 3. bis 4. September"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014681992#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01499/HT014997977.nt
+++ b/src/test/resources/reverseTest/output/nt/01499/HT014997977.nt
@@ -13,6 +13,12 @@ _:b4 <http://www.w3.org/2004/02/skos/core#notation> "380"^^<http://www.w3.org/20
 _:b5 <http://schema.org/location> "Mainz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2003"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/10048424-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/10048424-4> <http://www.w3.org/2000/01/rdf-schema#label> "Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz (Koblenz)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/10048424-4> <http://www.w3.org/2004/02/skos/core#altLabel> "LSV"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -36,9 +42,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT014997977> <http://purl.org/dc/terms/created> "20070222"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT014997977> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/extent> "15, [14] S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Arbeitskreis Stra\u00DFenbauabf\u00E4lle Rheinland-Pfalz; Landesamt f\u00FCr Umweltschutz und Gewerbeaufsicht; Landesbetrieb Stra\u00DFen und Verkehr Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/dc/terms/hasVersion> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=1750752&custom_att_2=simple_viewer> .

--- a/src/test/resources/reverseTest/output/nt/01509/HT015090208.nt
+++ b/src/test/resources/reverseTest/output/nt/01509/HT015090208.nt
@@ -4,7 +4,7 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/11861729X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/drt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.loc.gov/mads/rdf/v1#componentList> _:b18 .
+_:b10 <http://www.loc.gov/mads/rdf/v1#componentList> _:b28 .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b11 <http://www.w3.org/2000/01/rdf-schema#label> "DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -18,15 +18,35 @@ _:b16 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#s
 _:b16 <http://schema.org/publishedBy> "Bel Air Ed. [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b16 <http://schema.org/startDate> "2007"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128140-8, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128140-8> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b11 .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/122265939> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/act> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b22 .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b23 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b24 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b25 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b8 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b26 .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4128140-8, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4128140-8> .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b29 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b11 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/124245765> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/act> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -293,16 +313,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 <http://lobid.org/resources/HT015090208> <http://purl.org/dc/terms/modified> "20100702"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT015090208> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
-<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9 .
+<http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b17 .
 <http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015090208:DE-465:CMAF1063-CD#!> .
 <http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015090208:DE-467:70KNLS3136-DVD#!> .
 <http://lobid.org/resources/HT015090208#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015090208:DE-5-13:DVD%202007%2F1#!> .
@@ -322,7 +333,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#isPartOf> _:b12 .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#isPartOf> _:b14 .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectAltLabel> "Goethe, Johann Wolfgang von (Faust et le second Faust)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectOrder> _:b17 .
+<http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectOrder> _:b27 .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:b16 .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01518/HT015183529.nt
+++ b/src/test/resources/reverseTest/output/nt/01518/HT015183529.nt
@@ -10,6 +10,10 @@ _:b3 <http://schema.org/location> "Cambridge [u.a.]"^^<http://www.w3.org/2001/XM
 _:b3 <http://schema.org/publishedBy> "Cambridge Univ. Press"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2006"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118533592> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1896"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118533592> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1940"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118533592> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -46,8 +50,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT015183529> <http://purl.org/dc/terms/created> "20070618"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT015183529> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/extent> "LV, 225 S. : Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015183529:DE-5:2007%2F4575#!> .
 <http://lobid.org/resources/HT015183529#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "F. Scott Fitzgerald. Ed. by Matthew J. Bruccoli"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01541/HT015414894.nt
+++ b/src/test/resources/reverseTest/output/nt/01541/HT015414894.nt
@@ -10,6 +10,12 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b3 <http://schema.org/location> "M\u00FCnster [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2002"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/11075851X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/11075851X> <http://www.w3.org/2000/01/rdf-schema#label> "Conrad, Christoph"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/122021878> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -31,9 +37,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT015414894> <http://purl.org/dc/terms/created> "20080125"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT015414894> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015414894:DE-6:#!> .
 <http://lobid.org/resources/HT015414894#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Sascha Werthes ; Richard Kim ; Christoph Conrad"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/dc/terms/bibliographicCitation> "Medien und Terrorismus; Christian Schicha ... (Hg.); 2002; S. 80 - 93"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01544/HT015440386.nt
+++ b/src/test/resources/reverseTest/output/nt/01544/HT015440386.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/111614597> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://purl.org/lobid/lv#hasSuperordinate> <http://lobid.org/resources/HT002091108#!> .
 _:b2 <http://purl.org/lobid/lv#numbering> "22392"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10,14 +10,16 @@ _:b3 <http://schema.org/location> "Reinbek bei Hamburg"^^<http://www.w3.org/2001
 _:b3 <http://schema.org/publishedBy> "Rowohlt-Taschenbuch-Verl."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "1998"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/119411970, http://d-nb.info/gnd/4010427-8, http://d-nb.info/gnd/4145395-5"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/119411970> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010427-8> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/119411970, http://d-nb.info/gnd/4010427-8, http://d-nb.info/gnd/4145395-5"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/119411970> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4145395-5> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4010427-8> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4145395-5> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/111614597> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/111614597> <http://www.w3.org/2000/01/rdf-schema#label> "K\u00F6nig, Ralf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/111614597> <http://www.w3.org/2004/02/skos/core#altLabel> "K\u00F6nig, R."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -49,7 +51,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015440386> <http://purl.org/dc/terms/created> "20080220"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-385#!> .
 <http://lobid.org/resources/HT015440386> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/extent> "181, VIII S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015440386:DE-385-AN:C%2Fld487#!> .
 <http://lobid.org/resources/HT015440386#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Ralf K\u00F6nig"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -83,7 +85,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectAltLabel> "Konig, Ralf (1960-)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectAltLabel> "K\u0113nigs, Ralfs (1960-)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photographien-Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT015440386#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/edition> "Orig.-Ausg., 31. - 40. Tsd."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/isbn> "3499223929"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/isbn> "9783499223921"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01545/HT015455455.nt
+++ b/src/test/resources/reverseTest/output/nt/01545/HT015455455.nt
@@ -3,7 +3,7 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b10 <http://www.w3.org/2000/01/rdf-schema#label> "Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b11 <http://www.loc.gov/mads/rdf/v1#componentList> _:b31 .
+_:b11 <http://www.loc.gov/mads/rdf/v1#componentList> _:b32 .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b12 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -13,60 +13,62 @@ _:b13 <http://www.w3.org/2004/02/skos/core#notation> "338.76"^^<http://www.w3.or
 _:b14 <http://schema.org/location> "Wien ; K\u00F6ln ; Weimar"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b14 <http://schema.org/startDate> "2007"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/118595881, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/4003988-2, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/118595881, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4443675-0, http://d-nb.info/gnd/4073757-3, Geschichte 1918-1940, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/2101246-5, http://d-nb.info/gnd/4003988-2, http://d-nb.info/gnd/4207786-2, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4576855-9, http://d-nb.info/gnd/4073757-3, Geschichte 1920-1945, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b19 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4443675-0, http://d-nb.info/gnd/4073757-3, Geschichte 1918-1940, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4576855-9, http://d-nb.info/gnd/4073757-3, Geschichte 1920-1945, Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b20 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4003988-2> .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
 _:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4003988-2> .
 _:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b22 .
-_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4576855-9> .
-_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b24 .
-_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b23 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4576855-9> .
 _:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b25 .
-_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
 _:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b26 .
-_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
-_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4443675-0> .
-_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b28 .
-_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b27 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4443675-0> .
 _:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b29 .
-_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073757-3> .
 _:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b30 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
-_:b30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
-_:b31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b32 .
-_:b32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118595881> .
+_:b30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b30 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b31 .
+_:b31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b31 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2101246-5> .
 _:b32 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b33 .
-_:b33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
+_:b33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118595881> .
 _:b33 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b34 .
-_:b34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b12 .
-_:b34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4207786-2> .
+_:b34 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b35 .
+_:b35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b12 .
+_:b35 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b4 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://www.w3.org/2004/02/skos/core#notation> "330"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.loc.gov/mads/rdf/v1#componentList> _:b23 .
+_:b5 <http://www.loc.gov/mads/rdf/v1#componentList> _:b24 .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1920-1945"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.loc.gov/mads/rdf/v1#componentList> _:b27 .
+_:b8 <http://www.loc.gov/mads/rdf/v1#componentList> _:b28 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1918-1940"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -129,7 +131,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1918-1940"^^<http:
 <http://lobid.org/resources/HT015455455> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT015455455> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT015455455> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b15 .
 <http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/extent> "291 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015455455:DE-107:208-316#!> .
 <http://lobid.org/resources/HT015455455#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015455455:DE-82:(1)043776#!> .
@@ -159,7 +161,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1918-1940"^^<http:
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectAltLabel> "SDP AG"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectAltLabel> "Steyr-Daimler-Puch-AG"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u00D6sterreichische Daimler-Motoren-Commanditgesellschaft Bierenz, Fischer und Co. (Wiener Neustadt)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectOrder> _:b15 .
+<http://lobid.org/resources/HT015455455#!> <http://purl.org/lobid/lv#subjectOrder> _:b16 .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/ontology/bibo/isbn> "3205776399"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/ontology/bibo/isbn> "9783205776390"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015455455#!> <http://rdaregistry.info/Elements/u/P60493> "Rivalen bis zur Fusion ; die fr\u00FChen Jahre des Ferdinand Porsche"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01586/HT015865114.nt
+++ b/src/test/resources/reverseTest/output/nt/01586/HT015865114.nt
@@ -1,9 +1,11 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/105667129> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020533-2> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1945-2003"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -16,11 +18,11 @@ _:b6 <http://schema.org/location> "Bamberg"^^<http://www.w3.org/2001/XMLSchema#s
 _:b6 <http://schema.org/publishedBy> "Buchner"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2003"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Geschichte 1945-2003, http://d-nb.info/gnd/4020533-2, Schulbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020533-2> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Geschichte 1945-2003, http://d-nb.info/gnd/4020533-2, Schulbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/105667129> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/105667129> <http://www.w3.org/2000/01/rdf-schema#label> "Weber, J\u00FCrgen"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -66,7 +68,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015865114> <http://purl.org/dc/terms/modified> "20090318"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT015865114> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015865114:DE-294-11:#!> .
 <http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015865114:DE-6-290:#!> .
 <http://lobid.org/resources/HT015865114#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015865114:DE-929:#!> .
@@ -86,7 +88,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectAltLabel> "Geschichte / Didaktik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectAltLabel> "Geschichte / Unterricht"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectAltLabel> "Geschichtsdidaktik"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#titleKeyword> "Schulbuch Buchner"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://rdaregistry.info/Elements/u/P60493> "die Welt nach 1945"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015865114#!> <http://schema.org/publication> _:b6 .

--- a/src/test/resources/reverseTest/output/nt/01589/HT015891797.nt
+++ b/src/test/resources/reverseTest/output/nt/01589/HT015891797.nt
@@ -4,11 +4,15 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/109702662> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/11850066X, Geschichte 1963-1967, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/11850066X> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1963-1967"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -21,10 +25,10 @@ _:b7 <http://schema.org/location> "Paderborn [u.a.]"^^<http://www.w3.org/2001/XM
 _:b7 <http://schema.org/publishedBy> "Sch\u00F6ningh"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2009"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/11850066X, Geschichte 1963-1967, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/11850066X> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/109702662> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1942"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/109702662> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/109702662> <http://www.w3.org/2000/01/rdf-schema#label> "Mensing, Hans Peter"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -148,8 +152,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015891797> <http://purl.org/dc/terms/modified> "20090817"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT015891797> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/extent> "670 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015891797:DE-107:9.1191%2F10,2#!> .
 <http://lobid.org/resources/HT015891797#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015891797:DE-121:09%20A%20756#!> .
@@ -175,7 +178,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#isPartOf> _:b6 .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectAltLabel> "Adenauer, ... (1876-1967)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectAltLabel> "Adenauer, Konrad Hermann Joseph (1876-1967)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
+<http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectOrder> _:b10 .
 <http://lobid.org/resources/HT015891797#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .

--- a/src/test/resources/reverseTest/output/nt/01589/HT015894164.nt
+++ b/src/test/resources/reverseTest/output/nt/01589/HT015894164.nt
@@ -11,6 +11,8 @@ _:b4 <http://schema.org/location> "Paris"^^<http://www.w3.org/2001/XMLSchema#str
 _:b4 <http://schema.org/publishedBy> "OECD Publishing"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "1999"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://dx.doi.org/10.1787/9789264273085-fr> <http://www.w3.org/2000/01/rdf-schema#label> "DOI-Link"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://hub.culturegraph.org/resource/HBZ-HT015894164> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/fra> <http://www.w3.org/2000/01/rdf-schema#label> "Franz\u00F6sisch"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -195,7 +197,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT015894164> <http://purl.org/dc/terms/created> "20090408"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164> <http://purl.org/dc/terms/modified> "20120815"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/extent> "88 p."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015894164:DE-1044:#!> .
 <http://lobid.org/resources/HT015894164#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT015894164:DE-1383:#!> .

--- a/src/test/resources/reverseTest/output/nt/01613/HT016135351.nt
+++ b/src/test/resources/reverseTest/output/nt/01613/HT016135351.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/186931808> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/pht> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -9,12 +9,14 @@ _:b3 <http://schema.org/location> "Marienfeld"^^<http://www.w3.org/2001/XMLSchem
 _:b3 <http://schema.org/publishedBy> "Selbstverl."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2006"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7684863-2, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7684863-2> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7684863-2, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7684863-2> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/186931808> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/186931808> <http://www.w3.org/2000/01/rdf-schema#label> "Buchmann, Helmut"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/7684863-2> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -41,7 +43,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016135351> <http://purl.org/dc/terms/modified> "20091210"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016135351> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/extent> "32 gez. S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016135351:DE-6:2C%208876#!> .
 <http://lobid.org/resources/HT016135351#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Hemut Buchmann"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -57,7 +59,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kornm\u00FChle Roberg (Harsewinkel)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "Lutter-Wasserm\u00FChle Roberg (Harsewinkel-Marienfeld)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FChle Roberg (Harsewinkel)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT016135351#!> <http://rdaregistry.info/Elements/u/P60493> "Zeitzeuge und Kleinod in Harsewinkel"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016135351#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/HT016135351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
+++ b/src/test/resources/reverseTest/output/nt/01638/HT016382441.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/14320713X> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://purl.org/lobid/lv#hasSuperordinate> _:b4 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
@@ -10,10 +10,12 @@ _:b5 <http://schema.org/location> "Weinheim"^^<http://www.w3.org/2001/XMLSchema#
 _:b5 <http://schema.org/publishedBy> "Wiley-VCH"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4337730-0"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4337730-0> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4337730-0"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4337730-0> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/14320713X> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1962"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/14320713X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/14320713X> <http://www.w3.org/2000/01/rdf-schema#label> "Blum, Richard"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -217,7 +219,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT016382441> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016382441> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/extent> "418 S. : zahlr. Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016382441:DE-1044:11%20=%20TWR5408#!> .
 <http://lobid.org/resources/HT016382441#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016382441:DE-1044:11%20=%20TWR5408%2B1#!> .
@@ -253,7 +255,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#contributorOrder> "http://d-nb.info/gnd/14320713X"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#hbzID> "HT016382441"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#isPartOf> _:b3 .
-<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT016382441#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/isbn> "9783527706495"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016382441#!> <http://rdaregistry.info/Elements/u/P60493> "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles f\u00FCr Ihr Rendezvous mit dem Pinguin]"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01655/HT016556189.nt
+++ b/src/test/resources/reverseTest/output/nt/01655/HT016556189.nt
@@ -4,6 +4,16 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/119011077> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/drt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/132332582> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/act> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -23,6 +33,10 @@ _:b7 <http://schema.org/location> "M\u00FCnchen"^^<http://www.w3.org/2001/XMLSch
 _:b7 <http://schema.org/publishedBy> "Sony Pictures Home Entertainment"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2009"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/108376990> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1935"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/108376990> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/108376990> <http://www.w3.org/2000/01/rdf-schema#label> "Alverson, Charles E."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -116,13 +130,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT016556189> <http://purl.org/dc/terms/modified> "20101028"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT016556189> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
+<http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016556189:DE-61:nc%2F12926#!> .
 <http://lobid.org/resources/HT016556189#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Michael Palin mit Harry H. Corbett ; John LeMesurier... Drehbuch: Charles Alverson ... Nach der Geschichte von Lewis Caroll. Regie: Terry Gilliam"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .

--- a/src/test/resources/reverseTest/output/nt/01660/HT016604323.nt
+++ b/src/test/resources/reverseTest/output/nt/01660/HT016604323.nt
@@ -4,13 +4,17 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/16090142-X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/16090142-X> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Soziale Probleme und Sozialdienste; Verb\u00E4nde"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://www.w3.org/2004/02/skos/core#notation> "360"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Medizin und Gesundheit"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "610"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -20,11 +24,11 @@ _:b6 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSch
 _:b6 <http://schema.org/publishedBy> "Landschaftsverb. Westfalen-Lippe"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2005"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/16090142-X, Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/16090142-X> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/16090142-X, Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/16090142-X> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/16090142-X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
@@ -66,8 +70,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016604323> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT016604323> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016604323> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016604323:DE-6:XB%203534#!> .
 <http://lobid.org/resources/HT016604323#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hrsg.: Landschaftsverband Westfalen-Lippe, LWL-Abteilung f\u00FCr Krankenh\u00E4user und Gesundheitswesen, LWL-PsychiatrieVerbund Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -82,7 +85,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#hbzID> "HT016604323"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014846970#!> .
-<http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#zdbID> "2581964-1"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://rdaregistry.info/Elements/u/P60493> "f\u00FCr das Jahr ..."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016604323#!> <http://schema.org/publication> _:b6 .

--- a/src/test/resources/reverseTest/output/nt/01660/HT016608165.nt
+++ b/src/test/resources/reverseTest/output/nt/01660/HT016608165.nt
@@ -12,6 +12,14 @@ _:b3 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b4 <http://schema.org/startDate> "1980"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118524186> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1862"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118524186> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1918"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118524186> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -59,10 +67,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT016608165> <http://purl.org/dc/terms/created> "20101130"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016608165> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-575#!> .
 <http://lobid.org/resources/HT016608165> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
+<http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016608165:DE-575:#!> .
 <http://lobid.org/resources/HT016608165#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Claude Debussy. [Text:] (Th\u00E9odore de Banville)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016608165#!> <http://purl.org/dc/terms/bibliographicCitation> "M\u00E9lodies; Claude Debussy; 1980"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01661/HT016618741.nt
+++ b/src/test/resources/reverseTest/output/nt/01661/HT016618741.nt
@@ -3,6 +3,8 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://schema.org/startDate> "2010"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/143001299> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1972"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/143001299> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/143001299> <http://www.w3.org/2000/01/rdf-schema#label> "Rasch, Christiane"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -24,7 +26,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT016618741> <http://purl.org/dc/terms/modified> "20110330"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT016618741> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/extent> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016618741:DE-61:#!> .
 <http://lobid.org/resources/HT016618741#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Christiane Rasch"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01667/HT016675714.nt
+++ b/src/test/resources/reverseTest/output/nt/01667/HT016675714.nt
@@ -7,6 +7,16 @@ _:b10 <http://schema.org/location> "\u0421\u0430\u0440\u0430\u0442\u043E\u0432"^
 _:b10 <http://schema.org/publishedBy> "\u041D\u0430\u0443\u043A\u0430"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b10 <http://schema.org/startDate> "2010"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b8 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> _:b3 .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -46,11 +56,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "\u0410\u043D\u0442\u043E\u043
 <http://lobid.org/resources/HT016675714> <http://purl.org/dc/terms/modified> "20110126"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016675714> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-1116#!> .
 <http://lobid.org/resources/HT016675714> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
-<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
+<http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11 .
 <http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/extent> "349 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016675714:DE-1116:DS%207200%200141#!> .
 <http://lobid.org/resources/HT016675714#!> <http://id.loc.gov/ontologies/bibframe/note> "\u0411\u0438\u0431\u043B\u0438\u043E\u0433\u0440. \u0432 \u0442\u0435\u043A\u0441\u0442\u0435"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01679/HT016791198.nt
+++ b/src/test/resources/reverseTest/output/nt/01679/HT016791198.nt
@@ -8,6 +8,8 @@ _:b2 <http://schema.org/location> "M\u00FCnchen"^^<http://www.w3.org/2001/XMLSch
 _:b2 <http://schema.org/publishedBy> "ProSport Verl."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1987"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/119134764> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1913"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/119134764> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1995"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/119134764> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -41,7 +43,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT016791198> <http://purl.org/dc/terms/modified> "20120119"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016791198> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn41#!> .
 <http://lobid.org/resources/HT016791198> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/extent> "312 S. : \u00FCberw. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016791198:DE-Kn41:2012%2F1#!> .
 <http://lobid.org/resources/HT016791198#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016791198:DE-Kn41:49618#!> .

--- a/src/test/resources/reverseTest/output/nt/01698/HT016987148.nt
+++ b/src/test/resources/reverseTest/output/nt/01698/HT016987148.nt
@@ -1,12 +1,14 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1015942377> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4047968-7> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4142176-0> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4047968-7> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
@@ -14,15 +16,15 @@ _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Medizin und Gesundheit"^^<htt
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "610"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4113303-1, http://d-nb.info/gnd/4006617-4, http://d-nb.info/gnd/4142176-0, http://d-nb.info/gnd/4047968-7, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113303-1> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042570-8, http://d-nb.info/gnd/4113303-1, http://d-nb.info/gnd/4006617-4, http://d-nb.info/gnd/4142176-0, http://d-nb.info/gnd/4047968-7, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4042570-8> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4006617-4> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4113303-1> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4142176-0> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4006617-4> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/1015942377> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1976"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/1015942377> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -67,7 +69,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT016987148> <http://purl.org/dc/terms/modified> "20150930"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT016987148> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/extent> "97 S. : graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT016987148:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT016987148#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "vorgelegt von Sebastian Friedrich Teschers"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -113,7 +115,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectAltLabel> "North-Rhine/Westphalia"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectAltLabel> "Quality control"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectAltLabel> "Qualit\u00E4tspr\u00FCfung"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:38m-0000004639"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/ontology/bibo/doi> "10.4126/38m-000000463"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT016987148#!> <http://rdaregistry.info/Elements/u/P60489> "K\u00F6ln, Univ., Diss., 2011"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01706/HT017066705.nt
+++ b/src/test/resources/reverseTest/output/nt/01706/HT017066705.nt
@@ -1,11 +1,13 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/16332939-4> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076388-2> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1911-2011"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -15,13 +17,13 @@ _:b5 <http://schema.org/location> "Landau"^^<http://www.w3.org/2001/XMLSchema#st
 _:b5 <http://schema.org/publishedBy> "Calimedia"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4362856-4, http://d-nb.info/gnd/4507427-6, http://d-nb.info/gnd/4076388-2, Geschichte 1911-2011, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4362856-4> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4507427-6> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4362856-4, http://d-nb.info/gnd/4507427-6, http://d-nb.info/gnd/4076388-2, Geschichte 1911-2011, DVD-Video"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4362856-4> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076388-2> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4507427-6> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/16332939-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/16332939-4> <http://www.w3.org/2000/01/rdf-schema#label> "Eugen Trauth & S\u00F6hne"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -56,7 +58,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017066705> <http://purl.org/dc/terms/modified> "20120106"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT017066705> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017066705:DE-107:DVD%20886#!> .
 <http://lobid.org/resources/HT017066705#!> <http://id.loc.gov/ontologies/bibframe/note> "Imagefilm"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -82,7 +84,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokolade / Industrie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokolade / S\u00FC\u00DFwarenindustrie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokoladeindustrie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/HT017066705#!> <http://rdaregistry.info/Elements/u/P60493> "Schokok\u00FCsse aus Herxheim"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017066705#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT017066705#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01715/HT017150239.nt
+++ b/src/test/resources/reverseTest/output/nt/01715/HT017150239.nt
@@ -1,15 +1,17 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/109537335> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7856688-5"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7856688-5> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7856688-5"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7856688-5> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/109537335> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/109537335> <http://www.w3.org/2000/01/rdf-schema#label> "Borgmann, Richard"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/7749153-1> <http://www.w3.org/2000/01/rdf-schema#label> "Gemeinsame Normdatei (GND)"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -28,7 +30,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017150239> <http://purl.org/dc/terms/modified> "20120229"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017150239> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017150239#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017150239#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT017150239#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Borgmann, Richard"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/elements/1.1/coverage> "M\u00FCnster <Westfalen>"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/dc/terms/bibliographicCitation> "Westfalen; 88. 2010 (2012), S. 175-179"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -44,7 +46,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectAltLabel> "M\u00FCnster (Westf) / Fachbereich Praktische Denkmalpflege und Baukultur"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen-Lippe. Fachbereich Praktische Denkmalpflege"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/HT017150239#!> <http://schema.org/publication> _:b2 .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .

--- a/src/test/resources/reverseTest/output/nt/01741/HT017411546.nt
+++ b/src/test/resources/reverseTest/output/nt/01741/HT017411546.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2140069-6> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b17 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b18 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b10 <http://www.w3.org/2000/01/rdf-schema#label> "Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -19,41 +19,43 @@ _:b13 <http://schema.org/publishedBy> "Historische Kommission, Landschaftsverban
 _:b13 <http://schema.org/publishedBy> "Regensberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b13 <http://schema.org/startDate> "1951"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4078937-8, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4073972-7, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, Geschichte, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4078937-8> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, http://d-nb.info/gnd/4078937-8, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4065781-4, Geschichte, Bibliographie 1800-1940, Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
 _:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4078937-8> .
 _:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b22 .
-_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
 _:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b23 .
-_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
 _:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b24 .
-_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
-_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
-_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b26 .
-_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b25 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4065781-4> .
 _:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b27 .
-_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4073972-7> .
 _:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b28 .
-_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
-_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b29 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b21 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b22 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -61,7 +63,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standar
 _:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Online-Publikation"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.loc.gov/mads/rdf/v1#componentList> _:b25 .
+_:b8 <http://www.loc.gov/mads/rdf/v1#componentList> _:b26 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -133,7 +135,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<ht
 <http://lobid.org/resources/HT017411546> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT017411546> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017411546> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b14 .
 <http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017411546:DE-385:#!> .
 <http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017411546:DE-38:#!> .
 <http://lobid.org/resources/HT017411546#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017411546:DE-466:#!> .
@@ -168,7 +170,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<ht
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen (Volk, Neuzeit)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westphalen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westphalie"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectOrder> _:b14 .
+<http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#subjectOrder> _:b15 .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:6-85659520092"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#zdbID> "2685248-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017411546#!> <http://schema.org/publication> _:b12 .

--- a/src/test/resources/reverseTest/output/nt/01743/HT017437638.nt
+++ b/src/test/resources/reverseTest/output/nt/01743/HT017437638.nt
@@ -1,10 +1,12 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/133658104> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4511937-5> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Kommentar"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://purl.org/lobid/lv#hasSuperordinate> _:b4 .
@@ -17,10 +19,10 @@ _:b7 <http://schema.org/location> "Baden-Baden"^^<http://www.w3.org/2001/XMLSche
 _:b7 <http://schema.org/publishedBy> "Nomos"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4511937-5, Kommentar"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4511937-5> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4511937-5, Kommentar"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://beck-online.beck.de/Default.aspx?vpath=bibdata%5Ckomm%5Cpewkokagbefrvo_1%5Ccont%5Cpewkokagbefrvo.htm&pos=0&hlwords=pewestorf%C3%90adrian%C3%90+adrian+%C3%90+pewestorf+#xhlhit> <http://www.w3.org/2000/01/rdf-schema#label> "http://beck-online.beck.de/Default.aspx?vpath=bibdata%5Ckomm%5Cpewkokagbefrvo_1%5Ccont%5Cpewkokagbefrvo.htm&pos=0&hlwords=pewestorf%C3%90adrian%C3%90+adrian+%C3%90+pewestorf+#xhlhit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/133658104> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/133658104> <http://www.w3.org/2000/01/rdf-schema#label> "Pewestorf, Adrian"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -44,7 +46,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017437638> <http://purl.org/dc/terms/created> "20121030"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT017437638> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017437638:DE-836:#!> .
 <http://lobid.org/resources/HT017437638#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Adrian Pewestorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/dc/terms/hasVersion> <http://beck-online.beck.de/Default.aspx?vpath=bibdata%5Ckomm%5Cpewkokagbefrvo_1%5Ccont%5Cpewkokagbefrvo.htm&pos=0&hlwords=pewestorf%C3%90adrian%C3%90+adrian+%C3%90+pewestorf+#xhlhit> .
@@ -65,7 +67,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Datenbank (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Dokument"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
+<http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017437638#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01746/HT017468042.nt
+++ b/src/test/resources/reverseTest/output/nt/01746/HT017468042.nt
@@ -5,6 +5,8 @@ _:b1 <http://schema.org/location> "N\u00FCrnberg"^^<http://www.w3.org/2001/XMLSc
 _:b1 <http://schema.org/publishedBy> "Homannianos Heredes"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "1757"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/5293676-4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/5293676-4> <http://www.w3.org/2000/01/rdf-schema#label> "Homannsche Erben, N\u00FCrnberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/5293676-4> <http://www.w3.org/2004/02/skos/core#altLabel> "Bureau Geographique de Homann"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -53,7 +55,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT017468042> <http://purl.org/dc/terms/modified> "20130220"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017468042> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017468042> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Kt. : grenzkolor., fl\u00E4chenkolor., Kupferst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017468042:DE-6:RK%2013#!> .
 <http://lobid.org/resources/HT017468042#!> <http://id.loc.gov/ontologies/bibframe/note> "Titelkartusche mit Ma\u00DFstab geschm\u00FC. mit 1 Wappen links Mitte"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01747/HT017472134.nt
+++ b/src/test/resources/reverseTest/output/nt/01747/HT017472134.nt
@@ -1,19 +1,21 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118018868> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
 _:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b12 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -22,12 +24,12 @@ _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Quelle"^^<http://www.w3.org/2
 _:b6 <http://schema.org/location> "Dortmund"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2011"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/102851445X> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/102851445X, Geschichte, Quelle"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/102851445X> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/102851445X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Family> .
 <http://d-nb.info/gnd/102851445X> <http://www.w3.org/2000/01/rdf-schema#label> "Dorhoff, Familie"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -46,7 +48,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017472134> <http://purl.org/dc/terms/modified> "20121203"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017472134> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017472134#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017472134#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT017472134#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Friedhelm Treckmann]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/elements/1.1/coverage> "Dortmund-Nette"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/dc/terms/bibliographicCitation> "Nachrichten aus der Netter Geschichte; 2 (2011), S. 18-35 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -61,7 +63,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#hbzID> "HT017472134"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectAltLabel> "Familie (Familie)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT017472134#!> <http://schema.org/publication> _:b6 .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .

--- a/src/test/resources/reverseTest/output/nt/01748/HT017480009.nt
+++ b/src/test/resources/reverseTest/output/nt/01748/HT017480009.nt
@@ -6,6 +6,8 @@ _:b1 <http://www.w3.org/2000/01/rdf-schema#label> "Medizin und Gesundheit"^^<htt
 _:b1 <http://www.w3.org/2004/02/skos/core#notation> "610"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1028627270> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1985"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/1028627270> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1028627270> <http://www.w3.org/2000/01/rdf-schema#label> "Fett, Anna Laura"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -30,7 +32,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT017480009> <http://purl.org/dc/terms/modified> "20150227"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017480009> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT017480009> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/extent> "59 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017480009:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT017480009#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "vorgelegt von Anna Laura Fett"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01752/HT017529028.nt
+++ b/src/test/resources/reverseTest/output/nt/01752/HT017529028.nt
@@ -4,10 +4,12 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/12226861X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118640038> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/120534983> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://purl.org/lobid/lv#hasSuperordinate> <http://lobid.org/resources/HT012848847#!> .
 _:b4 <http://purl.org/lobid/lv#numbering> "18"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -16,10 +18,14 @@ _:b5 <http://schema.org/location> "Freiburg i. Br. [u.a.]"^^<http://www.w3.org/2
 _:b5 <http://schema.org/publishedBy> "Herder"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2013"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118640038"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118640038> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118640038"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118617230> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1891"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118617230> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1942"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118617230> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -88,9 +94,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017529028> <http://schema.org/provider> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT017529028> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT017529028> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/extent> "XXXVII, 265 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017529028:DE-1032:PHBB%2018%2F22%2FXVIII#!> .
 <http://lobid.org/resources/HT017529028#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT017529028:DE-Kn28:PHBB%2018%2F22%2FXVIII#!> .
@@ -129,7 +133,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectAltLabel> "vom Creutz (1542-1591)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectAltLabel> "vom Cre\u00FCtz (1542-1591)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectAltLabel> "vom Kreuz (1542-1591)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT017529028#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/ontology/bibo/edition> "4., durchges. und korr. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/ontology/bibo/isbn> "9783451273889"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT017529028#!> <http://rdaregistry.info/Elements/u/P60493> "Studie \u00FCber Johannes vom Kreuz"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01813/HT018131501.nt
+++ b/src/test/resources/reverseTest/output/nt/01813/HT018131501.nt
@@ -1,21 +1,23 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/124348165> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1288-1815"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/location> "D\u00FCsseldorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4137215-3, Geschichte 1288-1815"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4137215-3> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4137215-3, Geschichte 1288-1815"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4137215-3> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/124348165> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1924"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/124348165> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/124348165> <http://www.w3.org/2000/01/rdf-schema#label> "Engelhardt, Manfred"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -36,7 +38,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018131501> <http://purl.org/dc/terms/created> "20140115"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018131501> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018131501#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018131501#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT018131501#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Manfred Engelhardt"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/elements/1.1/coverage> "D\u00FCsseldorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/dc/terms/bibliographicCitation> "Der Gie\u00DFerjunge; 34 (2014),1, S. 14-15"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -80,7 +82,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtgemeinde D\u00FCsseldorf"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverordnetenversammlung (D\u00FCsseldorf)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (D\u00FCsseldorf)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT018131501#!> <http://schema.org/publication> _:b3 .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .

--- a/src/test/resources/reverseTest/output/nt/01814/HT018147158.nt
+++ b/src/test/resources/reverseTest/output/nt/01814/HT018147158.nt
@@ -10,6 +10,8 @@ _:b2 <http://schema.org/location> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema
 _:b2 <http://schema.org/publishedBy> "Die Ehrenfelder, Gemeinn\u00FCtzige Wohnungsgenossenschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2008"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/2078024-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/2078024-2> <http://www.w3.org/2000/01/rdf-schema#label> "<<Die>> Ehrenfelder, Gemeinn\u00FCtzige Wohnungsgenossenschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/2078024-2> <http://www.w3.org/2004/02/skos/core#altLabel> "Die Ehrenfelder, Gemeinn\u00FCtzige Wohnungsgenossenschaft eG"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -32,7 +34,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018147158> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018147158> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-1141#!> .
 <http://lobid.org/resources/HT018147158> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018147158#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018147158#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/dc/terms/subject> _:b1 .

--- a/src/test/resources/reverseTest/output/nt/01823/HT018239864.nt
+++ b/src/test/resources/reverseTest/output/nt/01823/HT018239864.nt
@@ -4,7 +4,7 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Sprache"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://www.w3.org/2004/02/skos/core#notation> "400"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://purl.org/lobid/lv#hasSuperordinate> <http://lobid.org/resources/HT016777884#!> .
 _:b4 <http://purl.org/lobid/lv#numbering> "17"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -13,12 +13,14 @@ _:b5 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSc
 _:b5 <http://schema.org/publishedBy> "de Gruyter"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118722123, http://d-nb.info/gnd/4152975-3"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118722123> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4152975-3> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118722123, http://d-nb.info/gnd/4152975-3"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/118722123> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4152975-3> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1056946172> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1056946172> <http://www.w3.org/2000/01/rdf-schema#label> "Kennedy, Beate"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/118722123> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1905"^^<http://www.w3.org/2001/XMLSchema#gYear> .
@@ -120,7 +122,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018239864> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018239864> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018239864> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/extent> "517 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018239864:DE-107:115-289#!> .
 <http://lobid.org/resources/HT018239864#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018239864:DE-294:IFB10325-17#!> .
@@ -151,7 +153,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectAltLabel> "Narratologie"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u05E7\u05D5\u05D9\u05DF, \u05D0\u05D9\u05E8\u05DE\u05D2\u05E8\u05D3 (1905-1982)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u1E32oyn, Irmgard (1905-1982)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT018239864#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/ontology/bibo/isbn> "3050064641"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/ontology/bibo/isbn> "9783050064642"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018239864#!> <http://purl.org/ontology/bibo/isbn> "9783050103020"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01829/HT018290299.nt
+++ b/src/test/resources/reverseTest/output/nt/01829/HT018290299.nt
@@ -1,12 +1,14 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/109728068> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4002641-3> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4139439-2> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4002641-3> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
@@ -22,11 +24,11 @@ _:b6 <http://schema.org/location> "K\u00C3\u00B6ln"^^<http://www.w3.org/2001/XML
 _:b6 <http://schema.org/publishedBy> "Emons"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4139439-2, http://d-nb.info/gnd/4002641-3, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4139439-2> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4139439-2, http://d-nb.info/gnd/4002641-3, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/109728068> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/109728068> <http://www.w3.org/2000/01/rdf-schema#label> "Lehndorff-Felsko, Angelika"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -106,7 +108,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018290299> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018290299> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018290299> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/extent> "544 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018290299:DE-38:17B5040#!> .
 <http://lobid.org/resources/HT018290299#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018290299:DE-5-39:Gb%209130%2F650%20(19)#!> .
@@ -172,7 +174,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverordneten-Versammlung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectAltLabel> "Verwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/HT018290299#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/ontology/bibo/isbn> "9783954513673"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://rdaregistry.info/Elements/u/P60493> "Ausz\u00C3\u00BCge aus 500 Interviews mit ehemaligen Zwangsarbeiterinnen und Zwangsarbeitern"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018290299#!> <http://schema.org/publication> _:b6 .

--- a/src/test/resources/reverseTest/output/nt/01829/HT018295975.nt
+++ b/src/test/resources/reverseTest/output/nt/01829/HT018295975.nt
@@ -4,27 +4,31 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/12174793X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/hnr> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12174793X, Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059979-6, Geschichte, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059979-6> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12174793X, Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
-_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12174793X> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4059979-6, Geschichte, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4059979-6> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
 _:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
 _:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b12 .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12174793X> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b14 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.loc.gov/mads/rdf/v1#componentList> _:b15 .
+_:b6 <http://www.loc.gov/mads/rdf/v1#componentList> _:b17 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -90,8 +94,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018295975> <http://purl.org/dc/terms/modified> "20141105"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018295975> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b10 .
 <http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/extent> "596 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018295975:DE-5-39:C%2060%2F145%2F10#!> .
 <http://lobid.org/resources/HT018295975#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018295975:DE-6:3K%2051779#!> .
@@ -118,7 +121,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectAltLabel> "Thuringia"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectAltLabel> "Th\u00FCringer Land"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectAltLabel> "Vereinigte Th\u00FCringische Staaten"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectOrder> _:b10 .
+<http://lobid.org/resources/HT018295975#!> <http://purl.org/lobid/lv#subjectOrder> _:b12 .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/ontology/bibo/edition> "1. Aufl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/ontology/bibo/isbn> "9783943539233"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018295975#!> <http://rdaregistry.info/Elements/u/P60493> "Bonn - Koblenz - Weimar - Meiningen ; Festschrift f\u00FCr Johannes M\u00F6tsch zum 65. Geburtstag"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01831/HT018312899.nt
+++ b/src/test/resources/reverseTest/output/nt/01831/HT018312899.nt
@@ -1,19 +1,21 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1023391147> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "Bielefeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7683386-0, http://d-nb.info/gnd/4124796-6, http://d-nb.info/gnd/4049716-1"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7683386-0> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4124796-6> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/7683386-0, http://d-nb.info/gnd/4124796-6, http://d-nb.info/gnd/4049716-1"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/7683386-0> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049716-1> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4124796-6> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049716-1> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1023391147> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1023391147> <http://www.w3.org/2000/01/rdf-schema#label> "Maes, Sientje"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4049716-1> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -38,7 +40,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018312899> <http://purl.org/dc/terms/created> "20140702"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018312899> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018312899#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018312899#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT018312899#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Sientje Maes"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/elements/1.1/coverage> "Detmold"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/dc/terms/bibliographicCitation> "Grabbe-Jahrbuch ...; 32. 2013 (2014), S. 80-95"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -57,7 +59,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Nachleben"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Nachwirkung (Rezeption)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wirkungsgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/HT018312899#!> <http://rdaregistry.info/Elements/u/P60493> "der Cid als Zeit- und Gattungskritik"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018312899#!> <http://schema.org/publication> _:b2 .
 <http://lobid.org/resources/HT018312899#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01845/HT018454638.nt
+++ b/src/test/resources/reverseTest/output/nt/01845/HT018454638.nt
@@ -4,23 +4,29 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/2175350-7> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1060772442> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2175350-7> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/172845785> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/location> "Bergisch Gladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1060772442, http://d-nb.info/gnd/2175350-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1060772442> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/2175350-7> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1060772442, http://d-nb.info/gnd/2175350-7, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1060772442> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/1060772442> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
@@ -73,9 +79,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018454638> <http://purl.org/dc/terms/modified> "20150303"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT018454638> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/extent> "122 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018454638:DE-5-39:Gb%207470%2F201#!> .
 <http://lobid.org/resources/HT018454638#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018454638:DE-Kn28:Fc%206601#!> .
@@ -97,7 +101,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrei St. Antonius Abbas Herkenrath"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrgemeinderat (Pfarrei Sankt Antonius Abbas Herkenrath)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrgemeinderat Sankt Antonius Abbas Herkenrath"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/HT018454638#!> <http://rdaregistry.info/Elements/u/P60493> "Festschrift zum Jubil\u00E4um 2014 in St. Antonius Abbas, Herkenrath ; Ausstellungsbegleiter"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018454638#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT018454638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01846/HT018468645.nt
+++ b/src/test/resources/reverseTest/output/nt/01846/HT018468645.nt
@@ -4,26 +4,30 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/122511158> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219952-9> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4143413-4> .
-_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4136959-2> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4020517-4> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4143413-4> .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Deutschland und benachbarte mitteleurop\u00E4ische L\u00E4nder"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "943"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://schema.org/location> "K\u00C3\u00B6ln [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/publishedBy> "B\u00C3\u00B6hlau"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4219952-9, http://d-nb.info/gnd/4136959-2, http://d-nb.info/gnd/4020517-4, http://d-nb.info/gnd/4143413-4"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4219952-9> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4136959-2> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011882-4, http://d-nb.info/gnd/4219952-9, http://d-nb.info/gnd/4136959-2, http://d-nb.info/gnd/4020517-4, http://d-nb.info/gnd/4143413-4"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011882-4> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/122511158> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1960"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/122511158> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -68,8 +72,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018468645> <http://purl.org/dc/terms/created> "20141125"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-466#!> .
 <http://lobid.org/resources/HT018468645> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/extent> "394 S. : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018468645:DE-466:#!> .
 <http://lobid.org/resources/HT018468645#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hrsg. von Fritsche, Christiane ; Paulmann, Johannes"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -119,7 +122,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sammelwerk (Formschlagwort)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectAltLabel> "Zeitgeschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectAltLabel> "\u00C7\u00A6umh\u00C5\u00ABr\u00C4\u00AByat Alm\u00C4\u0081niy\u00C4\u0081 al-Itti\u00E1\u00B8\u00A5\u00C4\u0081d\u00C4\u00ABya"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT018468645#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/ontology/bibo/doi> "10.7788/boehlau.9783412216689"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/ontology/bibo/isbn> "9783412216689"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018468645#!> <http://schema.org/publication> _:b5 .

--- a/src/test/resources/reverseTest/output/nt/01858/HT018585406.nt
+++ b/src/test/resources/reverseTest/output/nt/01858/HT018585406.nt
@@ -4,20 +4,26 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/5079636-7> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4075561-7> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/121842118> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://schema.org/location> "Kaiserslautern"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2006"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4075561-7, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4075561-7> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4034268-2> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4075561-7, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/121842118> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1961"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/121842118> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/121842118> <http://www.w3.org/2000/01/rdf-schema#label> "Clev, Hans-G\u00FCnther"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -55,9 +61,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018585406> <http://purl.org/dc/terms/created> "20150319"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT018585406> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/extent> "45 S. : Ill., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018585406:DE-107:#!> .
 <http://lobid.org/resources/HT018585406#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Deutsch-Franz\u00F6sisch-Schweizerische Oberrheinkonferenz, AG Raumordnung. Hrsg.: Entwicklungsagentur Rheinland-Pfalz e.V. Red.: Hans-G\u00FCnther Clev ..."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -81,7 +85,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinebene"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinische Tiefebene"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinlande"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/HT018585406#!> <http://schema.org/publication> _:b5 .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .

--- a/src/test/resources/reverseTest/output/nt/01861/HT018612706.nt
+++ b/src/test/resources/reverseTest/output/nt/01861/HT018612706.nt
@@ -17,39 +17,45 @@ _:b13 <http://schema.org/publishedBy> "Verl. f\u00C3\u00BCr moderne Kunst"^^<htt
 _:b13 <http://schema.org/publishedBy> "Zentralarchiv des Internationalen Kunsthandels e.V., ZADIK"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b13 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011889-7, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
-_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b17 .
-_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b16 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b16 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4011889-7, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b18 .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
-_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4013255-9, http://d-nb.info/gnd/4031483-2, http://d-nb.info/gnd/4076259-2, Geschichte 1959-1972, Ausstellung, K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4013255-9> .
 _:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b20 .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1050748387> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4031483-2> .
 _:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
-_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011889-7> .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
+_:b21 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b22 .
+_:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
 _:b22 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b23 .
-_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
+_:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
 _:b23 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b24 .
-_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
-_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b25 .
-_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
+_:b24 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4011889-7> .
 _:b25 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b26 .
-_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b11 .
-_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4076259-2> .
+_:b26 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b27 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b9 .
+_:b27 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b28 .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b10 .
+_:b28 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b29 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b11 .
+_:b29 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "K\u00FCnste"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "700"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b16 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b19 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1959-1972"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -57,7 +63,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standar
 _:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Ausstellung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#PlaceOrGeographicName> .
 _:b7 <http://www.w3.org/2000/01/rdf-schema#label> "K\u00C3\u00B6ln <2015>"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.loc.gov/mads/rdf/v1#componentList> _:b22 .
+_:b8 <http://www.loc.gov/mads/rdf/v1#componentList> _:b25 .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1959-1972"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -141,9 +147,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1959-1972"^^<http:
 <http://lobid.org/resources/HT018612706> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018612706> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT018612706> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b14 .
 <http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/extent> "173 S. : zahlr. Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018612706:DE-465:KFG1163-26%2F26#!> .
 <http://lobid.org/resources/HT018612706#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018612706:DE-5-7:kund960.h582#!> .
@@ -261,7 +265,7 @@ _:b9 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1959-1972"^^<http:
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectAltLabel> "Verwaltung (K\u00C3\u00B6ln)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westdeutschland (Bundesrepublik, 1949-1990)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectOrder> _:b14 .
+<http://lobid.org/resources/HT018612706#!> <http://purl.org/lobid/lv#subjectOrder> _:b17 .
 <http://lobid.org/resources/HT018612706#!> <http://purl.org/ontology/bibo/isbn> "9783903004108"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://rdaregistry.info/Elements/u/P60493> "[... anl\u00C3\u00A4sslich der gleichnamigen Ausstellung auf der ART COLOGNE 16. - 19.4.2015, und im ZADIK, 4.5. - 28.8.2015]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018612706#!> <http://schema.org/publication> _:b13 .

--- a/src/test/resources/reverseTest/output/nt/01861/HT018617137.nt
+++ b/src/test/resources/reverseTest/output/nt/01861/HT018617137.nt
@@ -10,6 +10,8 @@ _:b4 <http://schema.org/location> "K\u00C3\u00B6ln"^^<http://www.w3.org/2001/XML
 _:b4 <http://schema.org/publishedBy> "Projekt \"Nachhaltige Forschung an Fachhochschulen in NRW\""^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://hub.culturegraph.org/resource/HBZ-HT018617137> <http://www.w3.org/2000/01/rdf-schema#label> "Culturegraph Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/iso639-2/deu> <http://www.w3.org/2000/01/rdf-schema#label> "Deutsch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://id.loc.gov/vocabulary/relators/cre> <http://www.w3.org/2000/01/rdf-schema#label> "Autor/in"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -26,7 +28,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018617137> <http://purl.org/dc/terms/created> "20150424"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT018617137> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/extent> "55 S. : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018617137:DE-5:#!> .
 <http://lobid.org/resources/HT018617137#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Text: Eva Maria Helm]"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01870/HT018700720.nt
+++ b/src/test/resources/reverseTest/output/nt/01870/HT018700720.nt
@@ -4,6 +4,14 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/136371671> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/129961604> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -25,6 +33,8 @@ _:b8 <http://schema.org/location> "K\u00C3\u00B6ln"^^<http://www.w3.org/2001/XML
 _:b8 <http://schema.org/publishedBy> "BZgA"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/115325859> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/115325859> <http://www.w3.org/2000/01/rdf-schema#label> "Wolter, Birgit"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/129961604> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1965"^^<http://www.w3.org/2001/XMLSchema#gYear> .
@@ -60,11 +70,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018700720> <http://purl.org/dc/terms/modified> "20150720"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018700720> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
+<http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9 .
 <http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/extent> "239 S. : zahlr. graph. Darst., Kt."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018700720:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT018700720#!> <http://id.loc.gov/ontologies/bibframe/note> "Literaturangaben"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01870/HT018703339.nt
+++ b/src/test/resources/reverseTest/output/nt/01870/HT018703339.nt
@@ -4,6 +4,10 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> _:b2 .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Borkenfeld, Stephan"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/agent> _:b4 .
@@ -20,6 +24,10 @@ _:b6 <http://www.w3.org/2004/02/skos/core#notation> "610"^^<http://www.w3.org/20
 _:b7 <http://schema.org/location> "Waltrop"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/115833986> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1940"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/115833986> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/115833986> <http://www.w3.org/2000/01/rdf-schema#label> "Kayser, Klaus"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -47,10 +55,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018703339> <http://purl.org/dc/terms/modified> "20170915"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018703339> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018703339> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
+<http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018703339:DE-38M:#!> .
 <http://lobid.org/resources/HT018703339#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Klaus Kayser ; Stephan Borkenfeld ; Amina Djenouni ; Gian Kayser"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018703339#!> <http://purl.org/dc/terms/bibliographicCitation> "Diagnostic pathology; 1 (2015), 14, S. 1 - 18 : Ill., graph. Darst."^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01872/HT018722247.nt
+++ b/src/test/resources/reverseTest/output/nt/01872/HT018722247.nt
@@ -8,6 +8,8 @@ _:b2 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#st
 _:b2 <http://schema.org/publishedBy> "Pro Generika e.V."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/16090896-6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/16090896-6> <http://www.w3.org/2000/01/rdf-schema#label> "Pro Generika e.V."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/16090896-6> <http://www.w3.org/2004/02/skos/core#altLabel> "Progenerika"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -26,7 +28,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018722247> <http://purl.org/dc/terms/created> "20150810"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018722247> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018722247> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018722247#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018722247#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT018722247#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018722247:DE-38M:#!> .
 <http://lobid.org/resources/HT018722247#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
 <http://lobid.org/resources/HT018722247#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDACarrierType/1018> .

--- a/src/test/resources/reverseTest/output/nt/01872/HT018726005.nt
+++ b/src/test/resources/reverseTest/output/nt/01872/HT018726005.nt
@@ -1,15 +1,17 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/137538766> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b4 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://schema.org/location> "Essen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2006"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/128989459"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/128989459> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/128989459"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/128989459> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/128989459> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1958"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/128989459> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/128989459> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -27,7 +29,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018726005> <http://purl.org/dc/terms/created> "20150813"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018726005> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018726005#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018726005#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT018726005#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Text: Hans Hoff"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/elements/1.1/coverage> "Bielefeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/dc/terms/bibliographicCitation> "K.West; 2006,1, S. 12-14 : Ill."^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -42,7 +44,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#fulltextOnline> <http://www.bibliothek.uni-regensburg.de/ezeit/?2655603> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#hbzID> "HT018726005"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
-<http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#subjectOrder> _:b3 .
+<http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
 <http://lobid.org/resources/HT018726005#!> <http://rdaregistry.info/Elements/u/P60493> "die Parallelwelten des Ingolf L\u00FCck"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018726005#!> <http://schema.org/publication> _:b2 .
 <http://lobid.org/resources/HT018726005#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018770176.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018770176.nt
@@ -11,6 +11,8 @@ _:b3 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#st
 _:b3 <http://schema.org/publishedBy> "Duncker & Humblot"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/1076583180/04> <http://www.w3.org/2000/01/rdf-schema#label> "http://d-nb.info/1076583180"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/1042242615> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1042242615> <http://www.w3.org/2000/01/rdf-schema#label> "Stahl, Dominik"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -44,7 +46,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018770176> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018770176> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6-228#!> .
 <http://lobid.org/resources/HT018770176> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/extent> "276 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018770176:DE-294-39:123%2FY%2F3264#!> .
 <http://lobid.org/resources/HT018770176#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018770176:DE-6-228:StrR%20XIV%2023%2F246#!> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018771475.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018771475.nt
@@ -4,12 +4,16 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/102654520X> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1074109953, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1074109953> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Sportarten und Sportspiele"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://www.w3.org/2004/02/skos/core#notation> "796"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -21,10 +25,10 @@ _:b7 <http://schema.org/location> "Hamburg"^^<http://www.w3.org/2001/XMLSchema#s
 _:b7 <http://schema.org/publishedBy> "Bauer"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1074109953, Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1074109953> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/1074113608/04> <http://www.w3.org/2000/01/rdf-schema#label> "http://d-nb.info/1074113608"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/102654520X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/102654520X> <http://www.w3.org/2000/01/rdf-schema#label> "R\u00F6sgen, Anya"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -44,8 +48,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018771475> <http://purl.org/dc/terms/created> "20151005"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018771475> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/extent> "42 S."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Text Anya R\u00F6sgen ; Hans-Joachim Wiehager]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/dc/elements/1.1/coverage> "Bergisch Gladbach- Bensberg"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -61,7 +64,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#isPartOf> _:b5 .
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectAltLabel> "7. Schloss Bensberg Classics"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
+<http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectOrder> _:b10 .
 <http://lobid.org/resources/HT018771475#!> <http://rdaregistry.info/Elements/u/P60493> "17. bis 19. Juli 2015"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018771475#!> <http://schema.org/publication> _:b7 .
 <http://lobid.org/resources/HT018771475#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .

--- a/src/test/resources/reverseTest/output/nt/01877/HT018779822.nt
+++ b/src/test/resources/reverseTest/output/nt/01877/HT018779822.nt
@@ -5,6 +5,8 @@ _:b1 <http://schema.org/location> "New York"^^<http://www.w3.org/2001/XMLSchema#
 _:b1 <http://schema.org/publishedBy> "Routledge"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/143846655> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1966"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/143846655> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/143846655> <http://www.w3.org/2000/01/rdf-schema#label> "Cross, Julie"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -23,7 +25,7 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018779822> <http://purl.org/dc/terms/created> "20151014"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kob7#!> .
 <http://lobid.org/resources/HT018779822> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
 <http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/extent> "264 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018779822:DE-Kob7:#!> .
 <http://lobid.org/resources/HT018779822#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Julie Cross"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01878/HT018781534.nt
+++ b/src/test/resources/reverseTest/output/nt/01878/HT018781534.nt
@@ -8,6 +8,8 @@ _:b2 <http://schema.org/location> "Mainz ; Berlin"^^<http://www.w3.org/2001/XMLS
 _:b2 <http://schema.org/publishedBy> "Schott"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/118823442> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1904"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118823442> <http://d-nb.info/standards/elementset/gnd#dateOfDeath> "1984"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/118823442> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -32,7 +34,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018781534> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018781534> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn38#!> .
 <http://lobid.org/resources/HT018781534> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Partitur (12 Seiten), 2 Stimmen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018781534:DE-Kn38:Fb%203533#!> .
 <http://lobid.org/resources/HT018781534#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Hermann Schroeder, 1904-1984"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01878/HT018782520.nt
+++ b/src/test/resources/reverseTest/output/nt/01878/HT018782520.nt
@@ -7,16 +7,20 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Christentum"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://www.w3.org/2004/02/skos/core#notation> "230"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
+_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://schema.org/location> "Stuttgart"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/publishedBy> "Gabriel"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12918814X"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12918814X> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/12918814X"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/12918814X> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1057040282> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1057040282> <http://www.w3.org/2000/01/rdf-schema#label> "Beutler, D\u00F6rte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/12918814X> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "0270"^^<http://www.w3.org/2001/XMLSchema#gYear> .
@@ -63,8 +67,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018782520> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018782520> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT018782520> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/extent> "circa 32 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018782520:DE-Kn28:Faf%209816#!> .
 <http://lobid.org/resources/HT018782520#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018782520:DE-Kn28:Faf%209816,01#!> .
@@ -84,7 +87,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectAltLabel> "of Myra (270-340)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Bari (270-340)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Myra (270-340)"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
+<http://lobid.org/resources/HT018782520#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/ontology/bibo/isbn> "3522304144"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/ontology/bibo/isbn> "9783522304146"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018782520#!> <http://rdaregistry.info/Elements/u/P60584> <http://d-nb.info/gnd/4006604-6> .

--- a/src/test/resources/reverseTest/output/nt/01878/HT018786244.nt
+++ b/src/test/resources/reverseTest/output/nt/01878/HT018786244.nt
@@ -14,6 +14,8 @@ _:b5 <http://schema.org/location> "Augsburg"^^<http://www.w3.org/2001/XMLSchema#
 _:b5 <http://schema.org/publishedBy> "Wi\u00DFner Musikbuch-Verlag"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1097306496> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1097306496> <http://www.w3.org/2000/01/rdf-schema#label> "Kruse, Andreas"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4149423-4> <http://www.w3.org/2000/01/rdf-schema#label> "Dewey-Dezimalklassifikation"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -83,7 +85,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018786244> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018786244> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018786244> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/extent> "353 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018786244:DE-1156:Sbh%2010%20%2F%20For%201%20%2F%20133#!> .
 <http://lobid.org/resources/HT018786244#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018786244:DE-1156:Sbh%2010%20%2F%20For%201%20%2F%20133%20%2F%20a#!> .

--- a/src/test/resources/reverseTest/output/nt/01880/HT018801101.nt
+++ b/src/test/resources/reverseTest/output/nt/01880/HT018801101.nt
@@ -4,6 +4,8 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1080327355> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1049793021> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -20,6 +22,12 @@ _:b6 <http://schema.org/location> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema
 _:b6 <http://schema.org/publishedBy> "ZB MED - Leibniz-Informationszentrum Lebenswissenschaften"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/1049793021> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1049793021> <http://www.w3.org/2000/01/rdf-schema#label> "Roesner, Elke"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/1072011352> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -49,10 +57,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018801101> <http://purl.org/dc/terms/modified> "20160307"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018801101> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018801101> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
+<http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (1 Videodatei)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018801101:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT018801101#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "[Konzeption und Redaktion: Ursula Arning, Bettina Kullmer, Elke Roesner ; Mitarbeit: Jasmin Schmitz]"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01889/HT018895767.nt
+++ b/src/test/resources/reverseTest/output/nt/01889/HT018895767.nt
@@ -14,6 +14,8 @@ _:b5 <http://schema.org/location> "Mainz"^^<http://www.w3.org/2001/XMLSchema#str
 _:b5 <http://schema.org/publishedBy> "Landeszentrale f\u00FCr Politische Bildung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1019562781> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1981"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/1019562781> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1019562781> <http://www.w3.org/2000/01/rdf-schema#label> "R\u00F6del, Eva"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -53,7 +55,7 @@ _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018895767> <http://purl.org/dc/terms/created> "20160225"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT018895767> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/extent> "7 Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018895767:DE-107:#!> .
 <http://lobid.org/resources/HT018895767#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018895767:DE-929:#!> .

--- a/src/test/resources/reverseTest/output/nt/01890/HT018907266.nt
+++ b/src/test/resources/reverseTest/output/nt/01890/HT018907266.nt
@@ -4,6 +4,14 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1080327355> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/105204266X> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -23,6 +31,10 @@ _:b7 <http://schema.org/location> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema
 _:b7 <http://schema.org/publishedBy> "ZB MED - Leibniz Information Centre for Life Sciences"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/105204266X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/105204266X> <http://www.w3.org/2000/01/rdf-schema#label> "Lindst\u00E4dt, Birte"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/1072011352> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -53,12 +65,7 @@ _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018907266> <http://purl.org/dc/terms/created> "20160307"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018907266> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
+<http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (1 Videodatei)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018907266:DE-38M:Elektronische%20Publikation#!> .
 <http://lobid.org/resources/HT018907266#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "created by: Simone Haas, Bettina Kullmer, Birte Lindst\u00E4dt, Katja Pletsch ; with the assistance of: Ursula Arning, Jasmin Schmitz"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01892/HT018924091.nt
+++ b/src/test/resources/reverseTest/output/nt/01892/HT018924091.nt
@@ -1,7 +1,7 @@
 _:b0 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1093886471> .
 _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/cre> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b1 <http://www.loc.gov/mads/rdf/v1#componentList> _:b6 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b2 <http://www.w3.org/2000/01/rdf-schema#label> "K\u00FCnste"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10,12 +10,14 @@ _:b3 <http://schema.org/location> "Dinslaken"^^<http://www.w3.org/2001/XMLSchema
 _:b3 <http://schema.org/publishedBy> "StadtIndianer-Verlag"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1093886471, http://d-nb.info/gnd/4147365-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1093886471> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4147365-6> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1093886471, http://d-nb.info/gnd/4147365-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1093886471> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4147365-6> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1093886471> <http://d-nb.info/standards/elementset/gnd#dateOfBirthAndDeath> "ca. 20.-21. Jh."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/1093886471> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/1093886471> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
@@ -48,7 +50,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018924091> <http://schema.org/provider> <http://lobid.org/organisations/DE-101#!> .
 <http://lobid.org/resources/HT018924091> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018924091> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/extent> "108 ungez\u00E4hlte Seiten"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018924091:DE-61:pfl%2Fe6097#!> .
 <http://lobid.org/resources/HT018924091#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Poverino Peppino"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -64,7 +66,7 @@ _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#hbzID> "HT018924091"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kartoon"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT018924091#!> <http://purl.org/lobid/lv#subjectOrder> _:b5 .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/ontology/bibo/edition> "1. Auflage"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/ontology/bibo/isbn> "3981189337"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018924091#!> <http://purl.org/ontology/bibo/isbn> "9783981189339"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
+++ b/src/test/resources/reverseTest/output/nt/01893/HT018939763.nt
@@ -4,24 +4,28 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/185493769> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b5 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4074032-8> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4077723-6> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b3 <http://schema.org/location> "Frankfurt am Main"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/publishedBy> "Peter Lang Edition"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120316-1> .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120108-5> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4327015-3> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b5 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4120316-1, http://d-nb.info/gnd/4120108-5, http://d-nb.info/gnd/4327015-3, http://d-nb.info/gnd/4074032-8, http://d-nb.info/gnd/4077723-6"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120316-1> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4074032-8> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4120108-5> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4077723-6> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4327015-3> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/1068655429> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1068655429> <http://www.w3.org/2000/01/rdf-schema#label> "Avelar, Juanito Ornelas de"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/1068655429> <http://www.w3.org/2004/02/skos/core#altLabel> "Ornelas de Avelar, Juanito"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -65,8 +69,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018939763> <http://purl.org/dc/terms/modified> "20160510"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT018939763> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (265 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018939763:DE-38:#!> .
 <http://lobid.org/resources/HT018939763#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Juanito Ornelas de Avelar / Laura \u00C1lvarez L\u00F3pez (eds.)"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -85,7 +88,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachber\u00FChrung"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachbeziehungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachenkontakt"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectOrder> _:b4 .
+<http://lobid.org/resources/HT018939763#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/doi> "10.3726/978-3-653-05265-7"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/isbn> "9783631660249"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/isbn> "9783653052657"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01899/HT018998891.nt
+++ b/src/test/resources/reverseTest/output/nt/01899/HT018998891.nt
@@ -8,6 +8,8 @@ _:b2 <http://schema.org/location> "Leipzig"^^<http://www.w3.org/2001/XMLSchema#s
 _:b2 <http://schema.org/publishedBy> "Grosse"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "1593"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/130303402> <http://d-nb.info/standards/elementset/gnd#dateOfBirthAndDeath> "ca. 2. H\u00E4lfte 16. Jh."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/130303402> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/130303402> <http://www.w3.org/2000/01/rdf-schema#label> "Stieber, Thomas"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -31,7 +33,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT018998891> <http://purl.org/dc/terms/modified> "20160620"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT018998891> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/extent> "[10], 232 Bl."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT018998891#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT018998891:DE-Zw1:#!> .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .

--- a/src/test/resources/reverseTest/output/nt/01901/HT019011249.nt
+++ b/src/test/resources/reverseTest/output/nt/01901/HT019011249.nt
@@ -8,6 +8,8 @@ _:b2 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#st
 _:b2 <http://schema.org/publishedBy> "Language science press"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/185844154> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/185844154> <http://www.w3.org/2000/01/rdf-schema#label> "Bickerton, Derek"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://dx.doi.org/10.17169/langsci.b91.109> <http://www.w3.org/2000/01/rdf-schema#label> "http://dx.doi.org/10.17169"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -27,7 +29,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT019011249> <http://purl.org/dc/terms/created> "20160623"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT019011249> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (x, 284 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019011249:DE-38:#!> .
 <http://lobid.org/resources/HT019011249#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Derek Bickerton"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01905/HT019054687.nt
+++ b/src/test/resources/reverseTest/output/nt/01905/HT019054687.nt
@@ -4,6 +4,18 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/137397755> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b13 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
+_:b13 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b14 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b14 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b15 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b15 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1082286761> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
@@ -26,6 +38,8 @@ _:b8 <http://schema.org/location> "Karlsruhe"^^<http://www.w3.org/2001/XMLSchema
 _:b8 <http://schema.org/publishedBy> "Bundesanstalt f\u00FCr Wasserbau (BAW)"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://d-nb.info/gnd/10518151X> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/10518151X> <http://www.w3.org/2000/01/rdf-schema#label> "Rudolph, Elisabeth"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/10518151X> <http://www.w3.org/2004/02/skos/core#altLabel> "Schwan, Elisabeth"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -57,13 +71,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT019054687> <http://purl.org/dc/terms/created> "20160805"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019054687> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-B23#!> .
 <http://lobid.org/resources/HT019054687> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
-<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
+<http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b9 .
 <http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (VIII, 192 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019054687:DE-B23:E-Publikation#!> .
 <http://lobid.org/resources/HT019054687#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Bearbeiter: F. Hesser, R. Seiffert, A. B\u00FCscher, I. Holzwarth, E. Rudolph, A. Sehili, N. Winkel"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01909/HT019093814.nt
+++ b/src/test/resources/reverseTest/output/nt/01909/HT019093814.nt
@@ -4,24 +4,32 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/5555595-0> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1063656419, http://d-nb.info/gnd/4045895-7"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1063656419> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045895-7> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1108328849> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/pht> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1067217789> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/pht> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b7 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/publishedBy> "Distanz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1063656419, http://d-nb.info/gnd/4045895-7"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/1063656419> .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045895-7> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1063656419> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/1063656419> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#ConferenceOrEvent> .
 <http://d-nb.info/gnd/1063656419> <http://www.w3.org/2000/01/rdf-schema#label> "Ruhrtriennale, 2015-2017, Nordrhein-Westfalen"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -87,10 +95,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT019093814> <http://purl.org/dc/terms/modified> "20161111"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-Kn3#!> .
 <http://lobid.org/resources/HT019093814> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
+<http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b6 .
 <http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/extent> "[96] S. : zahlr. Ill., \u00FCberw. farb."^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019093814:DE-465:JZH43391#!> .
 <http://lobid.org/resources/HT019093814#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019093814:DE-6:LC%201017#!> .
@@ -134,7 +139,7 @@ _:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/0
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photographieren"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photographische Aufnahme"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectAltLabel> "Photokunst"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectOrder> _:b6 .
+<http://lobid.org/resources/HT019093814#!> <http://purl.org/lobid/lv#subjectOrder> _:b10 .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/ontology/bibo/edition> "[1. Auflage]"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://purl.org/ontology/bibo/isbn> "9783954761586"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019093814#!> <http://rdaregistry.info/Elements/u/P60493> "junge Fotografie, Ruhrtriennale 2016 : Meisterkurse Daniel Josefson und Julian R\u00F6mer; Louisa Boeszoermeny, Jakob Ganslmeier, Gregro Schmidt, Julian Slagman"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01914/HT019149667.nt
+++ b/src/test/resources/reverseTest/output/nt/01914/HT019149667.nt
@@ -4,24 +4,28 @@ _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontolo
 _:b1 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/105822094> .
 _:b1 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/edt> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045612-2> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049795-1, http://d-nb.info/gnd/4045612-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049795-1> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4045612-2> .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Soziale Probleme und Sozialdienste; Verb\u00E4nde"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "360"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://id.loc.gov/ontologies/bibframe/source> _:b5 .
 _:b4 <http://www.w3.org/2004/02/skos/core#notation> "rpbr_99_11100000_"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b6 <http://www.loc.gov/mads/rdf/v1#componentList> _:b9 .
+_:b6 <http://www.loc.gov/mads/rdf/v1#componentList> _:b11 .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b7 <http://schema.org/location> "Mainz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/publishedBy> "Rheinland-Pfalz, Landesamt f\u00FCr Soziales, Jugend und Versorgung - Landesjugendamt"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b7 <http://schema.org/startDate> "2004"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4049795-1, http://d-nb.info/gnd/4045612-2"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4049795-1> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/105822094> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/105822094> <http://www.w3.org/2000/01/rdf-schema#label> "B\u00F6ning, Horst"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/4045612-2> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
@@ -60,8 +64,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT019149667> <http://purl.org/dc/terms/modified> "20161222"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019149667> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b8 .
 <http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (35 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019149667:DE-929:#!> .
 <http://lobid.org/resources/HT019149667#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Herausgeber: Landesamt f\u00FCr Soziales, Jugend und Versorgung ; Text und Redaktion: Horst B\u00F6ning (KV Mayen-Koblenz), Elke Gr\u00FCn (LSJV - LJA), Peter Krauthausen (LSJV - LJA), Katharina Rothenbacher-Dostert (StV Kaiserslautern), Anne Scherr-Schmitt (SkF Trier)"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -90,7 +93,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rheinland Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rhineland-Palatinate"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectAltLabel> "Rh\u00E9nanie-Palatinat"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectOrder> _:b8 .
+<http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#subjectOrder> _:b10 .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:02-edoweb:70052615"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://purl.org/ontology/bibo/edition> "2. Auflage"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019149667#!> <http://rdaregistry.info/Elements/u/P60493> "eine Brosch\u00FCre f\u00FCr Pflegeeltern und solche, die es werden m\u00F6chten : ... damit Kinder die Gewinner sind"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01924/HT019248596.nt
+++ b/src/test/resources/reverseTest/output/nt/01924/HT019248596.nt
@@ -8,6 +8,8 @@ _:b3 <http://schema.org/location> "Oppenheim"^^<http://www.w3.org/2001/XMLSchema
 _:b3 <http://schema.org/publishedBy> "[Landesamt f\u00FCr Umwelt, Wasserwirtschaft und Gewerbeaufsicht Rheinland-Pfalz]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b3 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/3061200-7> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#CorporateBody> .
 <http://d-nb.info/gnd/3061200-7> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/3061200-7> <http://www.w3.org/2004/02/skos/core#altLabel> "LUWG"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -49,7 +51,7 @@ _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT019248596> <http://purl.org/dc/terms/modified> "20170426"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019248596> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019248596> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
+<http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b4 .
 <http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019248596:DE-107:#!> .
 <http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019248596:DE-929:#!> .
 <http://lobid.org/resources/HT019248596#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019248596:DE-Zw1:#!> .

--- a/src/test/resources/reverseTest/output/nt/01932/HT019322941.nt
+++ b/src/test/resources/reverseTest/output/nt/01932/HT019322941.nt
@@ -8,6 +8,10 @@ _:b2 <http://schema.org/location> "G\u00F6ttingen"^^<http://www.w3.org/2001/XMLS
 _:b2 <http://schema.org/publishedBy> "Universit\u00E4tsverlag G\u00F6ttingen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b2 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b4 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/112163912> <http://d-nb.info/standards/elementset/gnd#dateOfBirth> "1966"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 <http://d-nb.info/gnd/112163912> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/112163912> <http://www.w3.org/2000/01/rdf-schema#label> "Habermann, Katharina"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -29,8 +33,7 @@ _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT019322941> <http://purl.org/dc/terms/created> "20170510"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019322941> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-B23#!> .
 <http://lobid.org/resources/HT019322941> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
 <http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (376 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019322941:DE-B23:Link#!> .
 <http://lobid.org/resources/HT019322941#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Katharina Habermann, Klaus-Dieter Herbst (Hg.)"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01944/HT019440025.nt
+++ b/src/test/resources/reverseTest/output/nt/01944/HT019440025.nt
@@ -8,6 +8,10 @@ _:b10 <http://schema.org/location> "Mainz"^^<http://www.w3.org/2001/XMLSchema#st
 _:b10 <http://schema.org/publishedBy> "Landtag Rheinland-Pfalz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b10 <http://schema.org/startDate> "2017"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b3 <http://id.loc.gov/ontologies/bibframe/source> _:b4 .
 _:b3 <http://www.w3.org/2004/02/skos/core#notation> "rpbr_99_o31500000_"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -60,8 +64,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv
 <http://lobid.org/resources/HT019440025> <http://purl.org/dc/terms/created> "20170905"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019440025> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019440025> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
+<http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b11 .
 <http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (89 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019440025:DE-929:#!> .
 <http://lobid.org/resources/HT019440025#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Herausgeber: Der Pr\u00E4sident des Landtags Rheinland-Pfalz ; verantwortlich: Hans-Peter Hexemer, Leiter Kommunikation und neue Medien"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/01947/HT019474284.nt
+++ b/src/test/resources/reverseTest/output/nt/01947/HT019474284.nt
@@ -14,6 +14,14 @@ _:b4 <http://schema.org/location> "Cham"^^<http://www.w3.org/2001/XMLSchema#stri
 _:b4 <http://schema.org/publishedBy> "Springer"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b6 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b1 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b7 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b3 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/1071861417> <http://www.w3.org/2000/01/rdf-schema#label> "Konferenzschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://d-nb.info/gnd/1089593244> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 <http://d-nb.info/gnd/1089593244> <http://www.w3.org/2000/01/rdf-schema#label> "Bischoff-Ferrari, Heike"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -49,10 +57,7 @@ _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Public
 <http://lobid.org/resources/HT019474284> <http://purl.org/dc/terms/modified> "20171019"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019474284> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT019474284> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b1 .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
-<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b3 .
+<http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b5 .
 <http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/extent> "1 Online-Ressource (ix, 335 Seiten)"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/hasItem> <http://lobid.org/items/HT019474284:DE-38M:#!> .
 <http://lobid.org/resources/HT019474284#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "Connie M. Weaver, Robin M. Daly, Heike A. Bischoff-Ferrari editors"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/src/test/resources/reverseTest/output/nt/05040/TT050409948.nt
+++ b/src/test/resources/reverseTest/output/nt/05040/TT050409948.nt
@@ -3,14 +3,18 @@ _:b0 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 _:b1 <http://www.w3.org/2000/01/rdf-schema#label> "Siekmann, Holger"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
-_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4061694-0> .
+_:b10 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b11 .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4227766-8> .
+_:b11 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b12 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b5 .
+_:b12 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b2 <http://id.loc.gov/ontologies/bibframe/agent> _:b3 .
 _:b2 <http://id.loc.gov/ontologies/bibframe/role> <http://id.loc.gov/vocabulary/relators/ctb> .
 _:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#Person> .
 _:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Irlenbusch, Lars"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b4 <http://www.loc.gov/mads/rdf/v1#componentList> _:b10 .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -18,12 +22,12 @@ _:b6 <http://schema.org/location> "Berlin, Heidelberg"^^<http://www.w3.org/2001/
 _:b6 <http://schema.org/publishedBy> "Springer Berlin Heidelberg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/startDate> "2012"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4061694-0, http://d-nb.info/gnd/4227766-8, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4061694-0> .
-_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b9 .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4227766-8> .
-_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b0 .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b8 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b2 .
+_:b8 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4061694-0, http://d-nb.info/gnd/4227766-8, Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 <http://d-nb.info/gnd/4061694-0> <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/7749153-1> .
 <http://d-nb.info/gnd/4061694-0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 <http://d-nb.info/gnd/4061694-0> <http://www.w3.org/2000/01/rdf-schema#label> "Unfallchirurgie"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -44,8 +48,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT050409948> <http://schema.org/provider> <http://lobid.org/organisations/DE-He213#!> .
 <http://lobid.org/resources/TT050409948> <http://schema.org/sourceOrganization> <http://lobid.org/organisations/DE-He213#!> .
 <http://lobid.org/resources/TT050409948> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b0 .
-<http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b2 .
+<http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/contribution> _:b7 .
 <http://lobid.org/resources/TT050409948#!> <http://id.loc.gov/ontologies/bibframe/responsibilityStatement> "herausgegeben von Holger Siekmann, Lars Irlenbusch"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/hasVersion> <http://dx.doi.org/10.1007/978-3-642-20784-6> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/dc/terms/language> <http://id.loc.gov/vocabulary/iso639-2/deu> .
@@ -57,7 +60,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b10 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#hbzID> "TT050409948"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/organisations/ZDB-2-SMD#!> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#subjectAltLabel> "Operation / Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
-<http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#subjectOrder> _:b7 .
+<http://lobid.org/resources/TT050409948#!> <http://purl.org/lobid/lv#subjectOrder> _:b9 .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/ontology/bibo/doi> "10.1007/978-3-642-20784-6"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/ontology/bibo/isbn> "9783642207846"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://lobid.org/resources/TT050409948#!> <http://schema.org/publication> _:b6 .

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -30,7 +30,7 @@
     },
     "contribution" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/contribution",
-      "@container" : "@set"
+      "@container" : "@list"
     },
     "notation" : {
       "@id" : "http://www.w3.org/2004/02/skos/core#notation",


### PR DESCRIPTION
Reported by @jschnasse. `curl -s -L -H"accept:text/plain" https://lobid.org/resources/HT018703339|grep contribution` had many entries instead of the desired 1.

Complements #133.