### PR TITLE
Fix issue in context, improve RDFConverterTests

### DIFF
--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -354,6 +354,11 @@
       "multilangLabel" : {}
    },
    {
+      "name" : "Location",
+      "uri" : "http://purl.org/dc/terms/Location",
+      "multilangLabel" : {}
+   },
+   {
       "name" : "geo",
       "multilangLabel" : {},
       "label" : "Geokoordinaten",

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -6703,7 +6703,7 @@
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb2 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb3 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb5 .
-<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb6 .
+<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb7 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb8 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:Bb9 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/title> "Homo ludens"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10210,15 +10210,15 @@
 <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> <http://www.w3.org/2000/01/rdf-schema#label> "URN-Link"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.rhein-lahn-info.de/jakobsweg/> <http://www.w3.org/2000/01/rdf-schema#label> "http://www.rhein-lahn-info.de/jakobsweg"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.wikidata.org/entity/Q2758> <http://schema.org/geo> _:Bb2 .
-<http://www.wikidata.org/entity/Q2758> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <Location> .
+<http://www.wikidata.org/entity/Q2758> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/Location> .
 <http://www.wikidata.org/entity/Q2758> <http://www.w3.org/2000/01/rdf-schema#label> "M\u00F6nchengladbach"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.wikidata.org/entity/Q365> <http://schema.org/geo> _:Bb1 .
 <http://www.wikidata.org/entity/Q365> <http://schema.org/geo> _:Bb2 .
-<http://www.wikidata.org/entity/Q365> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <Location> .
+<http://www.wikidata.org/entity/Q365> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/Location> .
 <http://www.wikidata.org/entity/Q365> <http://www.w3.org/2000/01/rdf-schema#label> "K\u00F6ln"^^<http://www.w3.org/2001/XMLSchema#string> .
 <http://www.wikidata.org/entity/Q6210> <http://schema.org/geo> _:Bb1 .
 <http://www.wikidata.org/entity/Q6210> <http://schema.org/geo> _:Bb3 .
-<http://www.wikidata.org/entity/Q6210> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <Location> .
+<http://www.wikidata.org/entity/Q6210> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/Location> .
 <http://www.wikidata.org/entity/Q6210> <http://www.w3.org/2000/01/rdf-schema#label> "Kreis Coesfeld"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://digipress.digitale-sammlungen.de/calendar/newspaper/bsbmult00000492> <http://www.w3.org/2000/01/rdf-schema#label> "https://digipress.digitale-sammlungen.de/calendar"^^<http://www.w3.org/2001/XMLSchema#string> .
 <https://repository.publisso.de/resource/frl:6399387> <http://www.w3.org/2000/01/rdf-schema#label> "https://repository.publisso.de/resource"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10494,8 +10494,8 @@ _:Bb1 <http://purl.org/lobid/lv#numbering> "1"^^<http://www.w3.org/2001/XMLSchem
 _:Bb1 <http://purl.org/lobid/lv#numbering> "3"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/endDate> "1925"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb1 <http://schema.org/endDate> "1975"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb1 <http://schema.org/latitude> "5,0942222222222E1"^^<http://www.w3.org/2001/XMLSchema#double> .
-_:Bb1 <http://schema.org/latitude> "5,1866666666667E1"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb1 <http://schema.org/latitude> "5.0942222222222E1"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb1 <http://schema.org/latitude> "5.1866666666667E1"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:Bb1 <http://schema.org/location> "Amstelodami"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "Bad Ems"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "Cologne [i.e.] Amsterdam"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10507,8 +10507,8 @@ _:Bb1 <http://schema.org/location> "N\u00FCrnberg"^^<http://www.w3.org/2001/XMLS
 _:Bb1 <http://schema.org/location> "New York"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "Paderborn"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/location> "WIEN"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb1 <http://schema.org/longitude> "6,9577777777778E0"^^<http://www.w3.org/2001/XMLSchema#double> .
-_:Bb1 <http://schema.org/longitude> "7,3833333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb1 <http://schema.org/longitude> "6.9577777777778E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb1 <http://schema.org/longitude> "7.3833333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:Bb1 <http://schema.org/publishedBy> "Blindenhochschulb\u00FCcherei"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/publishedBy> "Delpeuck"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb1 <http://schema.org/publishedBy> "Elzevir"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10858,6 +10858,7 @@ _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb10 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb2 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb3 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb5 .
+_:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb6 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:Bb7 .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:Bb19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:Bb20 .
@@ -10920,8 +10921,8 @@ _:Bb2 <http://purl.org/lobid/lv#numbering> "Neue Folge, Band 264"^^<http://www.w
 _:Bb2 <http://purl.org/lobid/lv#numbering> "no.33"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/endDate> "1845"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb2 <http://schema.org/endDate> "1994"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb2 <http://schema.org/latitude> "5,0942222222222E1"^^<http://www.w3.org/2001/XMLSchema#double> .
-_:Bb2 <http://schema.org/latitude> "5,12E1"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb2 <http://schema.org/latitude> "5.0942222222222E1"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb2 <http://schema.org/latitude> "5.12E1"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:Bb2 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Bielefeld"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -10940,8 +10941,8 @@ _:Bb2 <http://schema.org/location> "M\u00FCnster"^^<http://www.w3.org/2001/XMLSc
 _:Bb2 <http://schema.org/location> "Mainz ; Berlin"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "Mannheim"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/location> "s.l."^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb2 <http://schema.org/longitude> "6,4333333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
-_:Bb2 <http://schema.org/longitude> "6,9577777777778E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb2 <http://schema.org/longitude> "6.4333333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb2 <http://schema.org/longitude> "6.9577777777778E0"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:Bb2 <http://schema.org/publishedBy> "AMERICAN DENTAL ASSOCIATION"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/publishedBy> "American Institute of Physics"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb2 <http://schema.org/publishedBy> "Apple Films"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11144,7 +11145,7 @@ _:Bb3 <http://purl.org/lobid/lv#numbering> "F2001/F2003"^^<http://www.w3.org/200
 _:Bb3 <http://purl.org/lobid/lv#numbering> "Tezemu"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/endDate> "1983"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb3 <http://schema.org/endDate> "2004"^^<http://www.w3.org/2001/XMLSchema#gYear> .
-_:Bb3 <http://schema.org/latitude> "5,1866666666667E1"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb3 <http://schema.org/latitude> "5.1866666666667E1"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:Bb3 <http://schema.org/location> "Bad Kreuznach"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/location> "Berlin [u.a.]"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/location> "Berlin"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11168,7 +11169,7 @@ _:Bb3 <http://schema.org/location> "Reinbek bei Hamburg"^^<http://www.w3.org/200
 _:Bb3 <http://schema.org/location> "Strassburg"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/location> "Stuttgart"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/location> "Velbert"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb3 <http://schema.org/longitude> "7,3833333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:Bb3 <http://schema.org/longitude> "7.3833333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:Bb3 <http://schema.org/publishedBy> "Beuth"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/publishedBy> "Cambridge Univ. Press"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb3 <http://schema.org/publishedBy> "DAG"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11371,7 +11372,6 @@ _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/l
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:Bb4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "... f\u00FCr Dummies"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Atlas"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Augsburger Schriften"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11391,11 +11391,12 @@ _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Ottovay, Kathrin"^^<http://w
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Schulbuch"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "Wirtschaft"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Darbietungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "020"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "330"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "380"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "791"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb4 <http://www.w3.org/2004/02/skos/core#notation> "rpbr_99_11100000_"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1082286788> .
 _:Bb5 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/108376990> .
@@ -11461,6 +11462,7 @@ _:Bb5 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb5 <http://schema.org/startDate> "2016"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb13 .
 _:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
+_:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb18 .
 _:Bb5 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb24 .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/1093886471, http://d-nb.info/gnd/4147365-6"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/118560034, http://d-nb.info/gnd/4159648-1, Geschichte"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11495,10 +11497,10 @@ _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/l
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#SecondaryPublicationEvent> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:Bb5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Bericht"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Bildband"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Chemische Verfahrenstechnik und verwandte Technologien"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 1959-1972"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Geschichte 71 v. Chr.-70 v. Chr"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11513,13 +11515,11 @@ _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http:/
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Understanding Web internals"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Vogelschutz"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Darbietungen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2000/01/rdf-schema#label> "\u0418\u043D-\u0442 \u0441\u043E\u0446\u0438\u0430\u043B\u044C\u043D\u043E\u0433\u043E \u043E\u0431\u0440\u0430\u0437\u043E\u0432\u0430\u043D\u0438\u044F (\u0444\u0438\u043B.) \u0420\u0413\u0421\u0423 \u0432 \u0433. \u0421\u0430\u0440\u0430\u0442\u043E\u0432\u0435"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "320"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "610"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "660"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:Bb5 <http://www.w3.org/2004/02/skos/core#notation> "791"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/114975760> .
 _:Bb6 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/118500546> .
 _:Bb6 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/11851928X> .
@@ -11584,7 +11584,6 @@ _:Bb6 <http://schema.org/startDate> "2014"^^<http://www.w3.org/2001/XMLSchema#gY
 _:Bb6 <http://schema.org/startDate> "2015"^^<http://www.w3.org/2001/XMLSchema#gYear> .
 _:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb11 .
 _:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb17 .
-_:Bb6 <http://www.loc.gov/mads/rdf/v1#componentList> _:Bb18 .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Herne"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4040619-2, http://d-nb.info/gnd/4306876-5, http://d-nb.info/gnd/4040613-1, http://d-nb.info/gnd/4034268-2"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "http://d-nb.info/gnd/4042203-3, Geschichte, Zeitschrift"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11619,6 +11618,7 @@ _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontol
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
 _:Bb6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Ausstellung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie 1800-1940"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb6 <http://www.w3.org/2000/01/rdf-schema#label> "Classic cars"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11713,8 +11713,8 @@ _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standa
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Contribution> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#IsPartOfRelation> .
 _:Bb7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationEvent> .
-_:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Bibliographie"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Dokumentarische Medien, publizistische Medien, Unterrichtsmedien; Journalismus; Verlagswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Handel, Kommunikation, Verkehr"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Il grande cinema"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -11727,6 +11727,7 @@ _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "RPB-Raumsystematik"^^<http:/
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "Verzeichnis"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2000/01/rdf-schema#label> "\u0410\u043D\u0434\u0440\u0435\u0435\u0432\u0430, \u0413. \u0424."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "070"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "380"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb7 <http://www.w3.org/2004/02/skos/core#notation> "860"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:Bb8 <http://id.loc.gov/ontologies/bibframe/agent> <http://d-nb.info/gnd/1041277814> .

--- a/src/test/resources/output/json/00306/TT003060418.json
+++ b/src/test/resources/output/json/00306/TT003060418.json
@@ -163,7 +163,7 @@
   "note" : [ "AD: 9+10/1958" ],
   "otherTitleInformation" : [ "Oper in fünf Akten" ],
   "publication" : [ {
-    "location" : [ "s.l.", "EMI Records Ltd, p 1969" ],
+    "location" : [ "EMI Records Ltd, p 1969", "s.l." ],
     "publishedBy" : "EMI Records",
     "startDate" : "1994",
     "type" : [ "PublicationEvent" ]

--- a/src/test/resources/output/json/01330/HT013304490.json
+++ b/src/test/resources/output/json/01330/HT013304490.json
@@ -142,15 +142,15 @@
       "label" : "Dewey-Dezimalklassifikation"
     }
   }, {
-    "label" : "Allgemeine fortlaufende Sammelwerke",
-    "notation" : "050",
+    "label" : "Öffentliche Darbietungen",
+    "notation" : "791",
     "source" : {
       "id" : "http://d-nb.info/gnd/4149423-4",
       "label" : "Dewey-Dezimalklassifikation"
     }
   }, {
-    "label" : "Öffentliche Darbietungen",
-    "notation" : "791",
+    "label" : "Allgemeine fortlaufende Sammelwerke",
+    "notation" : "050",
     "source" : {
       "id" : "http://d-nb.info/gnd/4149423-4",
       "label" : "Dewey-Dezimalklassifikation"

--- a/src/test/resources/reverseTest/output/nt/01305/HT013056453.nt
+++ b/src/test/resources/reverseTest/output/nt/01305/HT013056453.nt
@@ -27,7 +27,7 @@ _:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b4 .
 _:b17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4182273-0> .
 _:b18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b19 .
-_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b6 .
+_:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:b7 .
 _:b19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
 _:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://d-nb.info/gnd/4056218-9> .
 _:b20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b21 .
@@ -37,13 +37,13 @@ _:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b16 .
 _:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
 _:b4 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
 _:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.loc.gov/mads/rdf/v1#componentList> _:b18 .
-_:b5 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
-_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
-_:b6 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
-_:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b7 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
+_:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Bildung und Erziehung"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/2004/02/skos/core#notation> "370"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b6 <http://www.loc.gov/mads/rdf/v1#componentList> _:b18 .
+_:b6 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:b7 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://d-nb.info/standards/elementset/gnd#SubjectHeading> .
+_:b7 <http://www.w3.org/2000/01/rdf-schema#label> "Aufsatzsammlung"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b8 <http://www.w3.org/2000/01/rdf-schema#label> "Spiele und Freizeitaktivit\u00E4ten f\u00FCr drinnen"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b8 <http://www.w3.org/2004/02/skos/core#notation> "793"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -198,7 +198,7 @@ _:b9 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b2 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b3 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b5 .
-<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b7 .
+<http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b6 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b8 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> _:b9 .
 <http://lobid.org/resources/HT013056453#!> <http://purl.org/dc/terms/subject> <https://w3id.org/lobid/rpb2#n990> .

--- a/src/test/resources/reverseTest/output/nt/01330/HT013304490.nt
+++ b/src/test/resources/reverseTest/output/nt/01330/HT013304490.nt
@@ -4,17 +4,17 @@ _:b0 <http://www.w3.org/2004/02/skos/core#notation> "620"^^<http://www.w3.org/20
 _:b1 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
 _:b1 <http://www.w3.org/2000/01/rdf-schema#label> "Freizeitgestaltung, darstellende K\u00FCnste, Sport"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b1 <http://www.w3.org/2004/02/skos/core#notation> "790"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b2 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
-_:b2 <http://www.w3.org/2000/01/rdf-schema#label> "Dokumentarische Medien, publizistische Medien, Unterrichtsmedien; Journalismus; Verlagswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b2 <http://www.w3.org/2004/02/skos/core#notation> "070"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b3 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
-_:b3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:b2 <http://www.loc.gov/mads/rdf/v1#componentList> _:b8 .
+_:b2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.loc.gov/mads/rdf/v1#ComplexSubject> .
+_:b3 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
+_:b3 <http://www.w3.org/2000/01/rdf-schema#label> "Dokumentarische Medien, publizistische Medien, Unterrichtsmedien; Journalismus; Verlagswesen"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b3 <http://www.w3.org/2004/02/skos/core#notation> "070"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b4 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
-_:b4 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b4 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Darbietungen"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b4 <http://www.w3.org/2004/02/skos/core#notation> "791"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b5 <http://id.loc.gov/ontologies/bibframe/source> <http://d-nb.info/gnd/4149423-4> .
-_:b5 <http://www.w3.org/2000/01/rdf-schema#label> "\u00D6ffentliche Darbietungen"^^<http://www.w3.org/2001/XMLSchema#string> .
-_:b5 <http://www.w3.org/2004/02/skos/core#notation> "791"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/2000/01/rdf-schema#label> "Allgemeine fortlaufende Sammelwerke"^^<http://www.w3.org/2001/XMLSchema#string> .
+_:b5 <http://www.w3.org/2004/02/skos/core#notation> "050"^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://id.loc.gov/ontologies/bibframe/frequency> <http://marc21rdf.info/terms/continuingfre#q> .
 _:b6 <http://id.loc.gov/ontologies/bibframe/note> "Periodizit\u00E4t: viertelj\u00E4hrl."^^<http://www.w3.org/2001/XMLSchema#string> .
 _:b6 <http://schema.org/endDate> "2002"^^<http://www.w3.org/2001/XMLSchema#gYear> .

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -445,7 +445,7 @@
     "PublicationEvent" : {
       "@id" : "http://schema.org/PublicationEvent"
     },
-    "location" : {
+    "Location" : {
       "@id" : "http://schema.org/location",
       "@container" : "@set"
     },

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -445,12 +445,15 @@
     "PublicationEvent" : {
       "@id" : "http://schema.org/PublicationEvent"
     },
-    "Location" : {
+    "location" : {
       "@id" : "http://schema.org/location",
       "@container" : "@set"
     },
     "Contribution" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/Contribution"
+    },
+    "Location" : {
+      "@id" : "http://purl.org/dc/terms/Location"
     },
     "sameAs" : {
       "@type" : "@id",


### PR DESCRIPTION
Will resolve https://github.com/hbz/lobid-resources/issues/652

Data uses uppercase `Location` for `type` of `spatial`, see:
https://lobid.org/resources/HT018472857.json

Context declares a lowercase `location` key, see:
http://lobid.org/resources/context.jsonld

Besides the context change, this pull request expands the RDFConverterTests to test multiple resources.