### PR TITLE
Fix routes for item IDs with dots 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/test/resources/test.tar.bz2
 src/test/resources/xml/
 stats.*.csv
 *.swp
+java.log

--- a/web/app/views/details_item.scala.html
+++ b/web/app/views/details_item.scala.html
@@ -11,9 +11,9 @@
 @if(docJson.isEmpty){
   @main("", "lobid-resources - Bestandsdetails") {
     @if(flash.get("error")!=null){
-    <div class="alert alert-danger">@flash.get("error")</div>
+    <div id="search-results" class="alert alert-danger">@flash.get("error")</div>
     } else {
-    <div class="alert alert-info text-center">Bestand mit der ID @id konnte nicht gefunden werden.</div>
+    <div id="search-results" class="alert alert-info text-center">Bestand mit der ID @id konnte nicht gefunden werden.</div>
     }
   }
 } else {

--- a/web/conf/resources.routes
+++ b/web/conf/resources.routes
@@ -22,7 +22,7 @@ GET    /resources/context.jsonld        controllers.resources.Application.contex
 GET    /resources/dataset.jsonld        controllers.resources.Application.dataset(format="json")
 GET    /resources/dataset               controllers.resources.Application.dataset(format?="")
 GET    /resources/:id.:format           controllers.resources.Application.resourceDotFormat(id, format)
-GET    /items/:id.:format               controllers.resources.Application.itemDotFormat(id, format)
+GET    /items/:id.$format<html|json|rdf|ttl|nt> controllers.resources.Application.itemDotFormat(id, format)
 GET    /resources/:id                   controllers.resources.Application.resource(id, format ?= null)
 GET    /items/:id                       controllers.resources.Application.item(id, format ?= null)
 


### PR DESCRIPTION
Will resolve https://github.com/hbz/lobid-resources/issues/640

See http://stage.lobid.org/items/HT017412936:DE-361:NA088.88-4442721

The dot in the item ID was interpreted as the dot to specify a format, like:
http://stage.lobid.org/items/HT017412936:DE-361:NA088.88-4442721.json

The routes file now describes the possible formats to support item IDs with dots.

Additionally, this PR tweaks the layout of the item 404 page.