### PR TITLE
Enforce literal for dct:bibliographicCitation and callNumber

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -1933,7 +1933,9 @@
 			<data source="@itemId"/>
 			<data source="088 ?.c" name="signature"/>
 		</combine>
-		<data source="@signature" name="http://purl.org/lobid/lv#callNumber"/>
+		<data source="@signature" name="http://purl.org/lobid/lv#callNumber">
+		    <replace pattern="^http" with="Siehe: http" />
+		</data>
 		<data source="@signature" name="http://www.w3.org/2000/01/rdf-schema#label"/>
 		<!-- provenance -->
     <combine name="@created" value="${a}">
@@ -4707,11 +4709,13 @@
 			<data source="59[0123568][-abcd][-12].a">
 				<replace pattern="&gt;&gt;" with=""/>
 				<replace pattern="&lt;&lt;" with=""/>
+				<replace pattern="^http" with="Siehe: http" />
 			</data>
 		</concat>
 		<data source="525[-a][-1].a" name="http://purl.org/dc/terms/bibliographicCitation">
 			<replace pattern="&gt;&gt;" with=""/>
 			<replace pattern="&lt;&lt;" with=""/>
+			<replace pattern="^http" with="Siehe: http" />
 		</data>
 		<combine name="http://id.loc.gov/ontologies/bibframe/supplement" value="${a}">
 			<choose name="a" flushWith="@supplement" sameEntity="true">


### PR DESCRIPTION
Following #675 this avoids MapperParsingExceptions.

Resolves #682.