### PR TITLE
Make coverage notations searchable

### DIFF
--- a/src/main/resources/index-config.json
+++ b/src/main/resources/index-config.json
@@ -604,9 +604,7 @@
                }
             },
             "coverage" : {
-               "type" : "text",
-               "analyzer" : "ngram_analyzer",
-               "search_analyzer" : "german_analyzer"
+               "type" : "text"
             },
             "isPartOf" : {
                "properties" : {

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -75,7 +75,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.publishedBy:DAG", /*->*/ 1 },
 			{ "publication.publishedBy:DÄG", /*->*/ 1 },
 			{ "hasItem.id:\"http\\://lobid.org/items/TT003059252\\:DE-5-58\\:9%2F041#\\!\"", /*->*/ 1 },
-			{ "hasItem.id:TT003059252\\:DE-5-58\\:9%2F041", /*->*/ 0 }
+			{ "hasItem.id:TT003059252\\:DE-5-58\\:9%2F041", /*->*/ 0 },
+			{ "coverage:99", /*->*/ 22}
 		});
 	} // @formatter:on
 


### PR DESCRIPTION
See #763.

Remove the ngram-analyzer because it's not used.
Remnove the german-analyzer because it prevented the number of the notations
to be searchable.

This complements #763.