### PR TITLE
Exclude the big beacon files from being copied by maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,14 @@
 		</dependency>
 	</dependencies>
 	<build>
+		  <resources>
+                        <resource>
+                                <directory>${basedir}/src/main/resources</directory>
+                                <excludes>
+                                        <exclude>beacon/data/*.jsonl</exclude>
+                                </excludes>
+                        </resource>
+                </resources>
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,29 +22,29 @@
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-arq</artifactId>
 			<version>2.10.1</version>
-      <exclusions> 
-      <exclusion> 
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-      </exclusion>
-    </exclusions>
+			<exclusions> 
+			<exclusion> 
+				<groupId>log4j</groupId>
+				<artifactId>log4j</artifactId>
+			</exclusion>
+		</exclusions>
 		</dependency>
- <dependency>
-      <groupId>com.github.jsonld-java</groupId>
-      <artifactId>jsonld-java</artifactId>
-      <version>0.3</version>
-    </dependency>
- <dependency>
-      <groupId>com.github.jsonld-java</groupId>
-      <artifactId>jsonld-java-sesame</artifactId>
-      <version>0.3</version>
-    </dependency>
-   <dependency>
-     <groupId>com.github.jsonld-java</groupId>
-     <artifactId>jsonld-java-jena</artifactId>
-     <version>0.3</version>
-   </dependency>
- <dependency>
+		<dependency>
+			<groupId>com.github.jsonld-java</groupId>
+			<artifactId>jsonld-java</artifactId>
+			<version>0.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.jsonld-java</groupId>
+			<artifactId>jsonld-java-sesame</artifactId>
+			<version>0.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.jsonld-java</groupId>
+			<artifactId>jsonld-java-jena</artifactId>
+			<version>0.3</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.gdata</groupId>
 			<artifactId>core</artifactId>
 			<version>1.47.1</version>
@@ -80,9 +80,9 @@
 			<version>3.0.9</version>
 		</dependency>
 		<dependency>
-		  <groupId>com.ning</groupId>
-		  <artifactId>async-http-client</artifactId>
-		  <version>1.9.33</version>
+			<groupId>com.ning</groupId>
+			<artifactId>async-http-client</artifactId>
+			<version>1.9.33</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-validator</groupId>
@@ -117,21 +117,21 @@
 		</dependency>
 	</dependencies>
 	<build>
-		  <resources>
-                        <resource>
-                                <directory>${basedir}/src/main/resources</directory>
-                                <excludes>
-                                        <exclude>beacon/data/*.jsonl</exclude>
-                                </excludes>
-                        </resource>
-                </resources>
+		<resources>
+			<resource>
+				<directory>${basedir}/src/main/resources</directory>
+					<excludes>
+						<exclude>beacon/data/*.jsonl</exclude>
+					</excludes>
+			</resource>
+		</resources>
 		<pluginManagement>
 			<plugins>
 				<plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.3</version>
-              <configuration>
+				 <groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<version>3.3</version>
+							<configuration>
 						<source>${target.jdk}</source>
 						<target>${target.jdk}</target>
 						<showWarnings>true</showWarnings>


### PR DESCRIPTION
The several GB big beacon files were copied to "target" every time maven
was building. This was unneccessary and annoying since copying took some minutes.

See #685.