### PR TITLE
Fix `publication` issues in details view

### DIFF
--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -18,9 +18,11 @@
   }
 }
 
-@optional(label: String, key: String, v: JsValue) = {
-  @if((v\key).asOpt[String].isDefined) {
-    @((v\key).as[String]) <br/>
+@optional(lookup: JsLookupResult) = {
+  @defining(lookup.asOpt[Seq[JsValue]].getOrElse(Seq(lookup))) { elems =>
+    @for(elem <- elems; elemString <- elem.asOpt[String]) {
+      @(elemString)@if(elem!=elems.last){ | } else {<br/>}
+    }
   }
 }
 
@@ -35,6 +37,7 @@
         }
       </td>
       <td>
+        @optional(pub \ "description")
         @if(start != end && !(pub \ "type").toString.contains("SecondaryPublicationEvent") &&
             ((start.asOpt[String].isDefined && end.asOpt[String].isDefined) ||
             (doc\"type").toString.contains("Series") || (doc\"type").toString.contains("Periodical"))) {
@@ -45,10 +48,10 @@
           @start.asOpt[String].getOrElse(end.asOpt[String].getOrElse(""))
         }
         @if(start.toOption.isDefined || end.toOption.isDefined) { <br/> }
-        @optional("Erscheinungsort", "location", pub)
-        @optional("Verlag", "publishedBy", pub)
+        @optional(pub \ "location")
+        @optional(pub \ "publishedBy")
         @((pub\"frequency").asOpt[Seq[JsValue]].map { freq =>
-          optional("Erscheinungsweise", "label", freq.head)
+          optional(freq.head \ "label")
         })
       </td>
     </tr>
@@ -161,7 +164,7 @@
 }
 
 @sortedPublications(seq: Seq[JsValue]) = @{
-  seq.sortBy((v: JsValue) => ((v\"startDate").asOpt[String].getOrElse((v\"endDate").asOpt[String].getOrElse("0")).toInt))
+  seq.sortBy((v: JsValue) => ((v\"type").asOpt[Seq[String]].map({case t::Nil => Seq("PublicationEvent", "SecondaryPublicationEvent").indexOf(t)})))
 }
 
 @withPrefixedLink(label: String, prefix: String, node: JsReadable) = {


### PR DESCRIPTION
- Support multiple values in `publication` object subfields
- Always show `SecondaryPublicationEvent` after `PublicationEvent`
- Show `description` subfield

Will resolve https://github.com/hbz/lobid-resources/issues/630