### PR TITLE
Add "Braille"

### DIFF
--- a/src/main/resources/labels/labels.json
+++ b/src/main/resources/labels/labels.json
@@ -14666,7 +14666,7 @@
    },
    {
       "uri" : "http://purl.org/library/BrailleBook",
-      "label" : "Blindenschrift"
+      "name" : "Blindenschrift"
    },
    {
       "uri":"http://rdaregistry.info/termList/RDAMediaType/1003",

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -363,6 +363,9 @@
     "Thesis" : {
       "@id" : "http://purl.org/ontology/bibo/Thesis"
     },
+    "Blindenschrift" : {
+      "@id" : "http://purl.org/library/BrailleBook"
+    },
     "ArchivedWebPage" : {
       "@id" : "http://purl.org/lobid/lv#ArchivedWebPage"
     },


### PR DESCRIPTION
Using "name" instead of "label" makes the labels exported to context.json.

This seems strange because:

1. we have many definitions of Uris using "label" instead of "name"
2. I think somewhere in the code is a fallback for "name" when "name" is missing so "label" is used.

However I now I grasped once the idea of the difference between "name" and "label", but it's lost to me again. Maybe this "label-name" thing should be made simpler by dropping one definition, it seems superflous @jschnasse ?

See #897.