### PR TITLE
Add class for switching index aliases

### DIFF
--- a/src/main/java/org/lobid/resources/ElasticsearchIndexer.java
+++ b/src/main/java/org/lobid/resources/ElasticsearchIndexer.java
@@ -481,25 +481,25 @@ public class ElasticsearchIndexer
 	}
 
 	/**
-	 * This adds the productive_prefix as alias to the newest index (which names
-	 * begins with productive_prefix) and adds the staging alias to the second
+	 * This adds the productive prefix as alias to the newest index (which names
+	 * begins with productive prefix) and adds the staging alias to the second
 	 * newest index name.
 	 * 
-	 * @param productive_prefix the productive alias (and also the prefix of the
+	 * @param productivePrefix the productive alias (and also the prefix of the
 	 *          names of the indices)
 	 * @param staging the "-staging" alias
 	 */
-	public void swapProductionAndStagingAliases(final String productive_prefix,
+	public void swapProductionAndStagingAliases(final String productivePrefix,
 			final String staging) {
 		final SortedSet<String> indicesWithProductionPrefix =
-				groupByIndexCollection(productive_prefix).get(productive_prefix);
+				groupByIndexCollection(productivePrefix).get(productivePrefix);
 		final String newestIndex = indicesWithProductionPrefix.last();
 		String secondNewestIndex = (String) indicesWithProductionPrefix
 				.toArray()[indicesWithProductionPrefix.size() - 2];
-		createNewAlias(newestIndex, productive_prefix);
+		createNewAlias(newestIndex, productivePrefix);
 		createNewAlias(secondNewestIndex, staging);
 		removeAlias(newestIndex, staging);
-		removeAlias(secondNewestIndex, productive_prefix);
+		removeAlias(secondNewestIndex, productivePrefix);
 	}
 
 	private SortedSetMultimap<String, String> groupByIndexCollection(

--- a/src/main/java/org/lobid/resources/run/UpdateAliases.java
+++ b/src/main/java/org/lobid/resources/run/UpdateAliases.java
@@ -1,0 +1,45 @@
+/* Copyright 2019 hbz. Licensed under the EPL 2.0 */
+
+package org.lobid.resources.run;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.lobid.resources.ElasticsearchIndexer;
+
+/**
+ * Updates the index aliases "[resources|geo_nwbib]-staging" to
+ * "[resources|geo_nwbib]" and vice versa. I.e. making the staging index
+ * productive and the productive index to be stage.
+ * 
+ * @author Pascal Christoph (dr0i)
+ *
+ */
+public class UpdateAliases {
+
+	/**
+	 * @param args ignored
+	 */
+	public static void main(String... args) {
+		try (
+				TransportClient tc = new PreBuiltTransportClient(
+						Settings.builder().put("cluster.name", "weywot").build());
+				Client client = tc.addTransportAddress(new InetSocketTransportAddress(
+						InetAddress.getByName("weywot4.hbz-nrw.de"), 9300))) {
+			ElasticsearchIndexer esIndexer = new ElasticsearchIndexer();
+			esIndexer.setElasticsearchClient(client);
+			esIndexer.swapProductionAndStagingAliases("resources",
+					"resources-staging");
+			esIndexer.swapProductionAndStagingAliases("geo_nwbib",
+					"geo_nwbib-staging");
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+		}
+
+	}
+}


### PR DESCRIPTION
This adds the alias "resources" to the newest index of "lobid-resources" and
the alias "resources-staging" to the second newest index of "lobid-resources".
The same goes for "geo_nwbib" and "geo_nwbib-staging".

I.e. the aliases found after a fulldump update are switched to go productive.

- improve some logic
- rename some variables to be more pecise in what they stand for

See #968.