### PR TITLE
Tweak creation of internal Elasticsearch ID

### DIFF
--- a/src/main/java/org/lobid/resources/RecordReaderEnhanced.java
+++ b/src/main/java/org/lobid/resources/RecordReaderEnhanced.java
@@ -85,8 +85,7 @@ public final class RecordReaderEnhanced
 			json.put(ElasticsearchIndexer.Properties.INDEX.getName(), INDEX);
 			json.put(ElasticsearchIndexer.Properties.TYPE.getName(), TYPE);
 			json.put(ElasticsearchIndexer.Properties.ID.getName(),
-					node.findValue("describedBy").findValue("@id").asText()
-							.replaceFirst("http://hub.culturegraph.org/entityfacts/", ""));
+					node.get("@id").asText().substring("http://d-nb.info/gnd/".length()));
 			json.put(ElasticsearchIndexer.Properties.GRAPH.getName(), jsonStr);
 		} catch (IOException e) {
 			e.printStackTrace();


### PR DESCRIPTION
The `describedBy.@id` values in the latest EntityFacts dump have 
switched from HTTP to HTTPS URIs, causing the ID creation to break.

This change creates the internal ID from the top-level `@id` field.

See https://github.com/hbz/lobid-gnd/issues/183