### PR TITLE
Add manual Wikidata mapping for "Hamm"

### DIFF
--- a/src/main/resources/string2wikidata.tsv
+++ b/src/main/resources/string2wikidata.tsv
@@ -140,3 +140,4 @@ Diözese Köln | 36	Q11805
 Köln (Erzdiözese) | 36	Q11805
 Bielefeld-Senne | 99	Q1457938
 Seelbach-Marienthal | 99	Q645030
+Hamm | 99	Q2880


### PR DESCRIPTION
Fixes issue reported via email
(subject "Mismatching  Hamm (Westf)")
by I.M. on 2019-05-22.