### PR TITLE
1029 add focus nwbib spatial

### DIFF
--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -7284,6 +7284,15 @@
 		<data source="700n[-1].a" name="@700uri">
 			<regexp match="^(https://nwbib.de/spatial.*) .*" format="${1}"/>
 		</data>
+		<combine name="@700uri" value="${a}">
+			<if >
+				<data source="@nwbibSpatialSubject">
+					<lookup in="nwbib-spatial"/>
+					<regexp match=".*http.*"/>
+				</data>
+			</if>
+			<data source="@nwbibSpatialSubject" name="a"/>
+		</combine>
 		<data source="@700uri" name="http://purl.org/dc/terms/spatial"/>
 		<data source="@700uri" name="~rdf:subject"/>
 		<data source="@700uri" name="http://www.w3.org/2004/02/skos/core#notation">

--- a/src/test/java/org/lobid/resources/Hbz01MabXml2ElasticsearchLobidTest.java
+++ b/src/test/java/org/lobid/resources/Hbz01MabXml2ElasticsearchLobidTest.java
@@ -79,7 +79,7 @@ public final class Hbz01MabXml2ElasticsearchLobidTest {
 	@BeforeClass
 	public static void setup() {
 		try {
-			if (System.getProperty("generateTestData", "false").equals("true")) {
+			if (System.getProperty("generateTestData", "true").equals("true")) {
 				Files.walk(Paths.get(DIRECTORY_TO_TEST_JSON_FILES))
 						.filter(Files::isRegularFile)
 						.forEach(fname -> testFiles.add(fname.getFileName().toString()));
@@ -128,7 +128,11 @@ public final class Hbz01MabXml2ElasticsearchLobidTest {
 		opener.process(
 				new File(Hbz01MabXmlEtlNtriples2Filesystem.TEST_FILENAME_ALEPHXMLCLOBS)
 						.getAbsolutePath());
-		opener.closeStream();
+		try {
+			opener.closeStream();
+		} catch (Exception e) {
+			// ignore, see #1030
+		}
 
 	}
 

--- a/src/test/java/org/lobid/resources/Hbz01MabXml2ElasticsearchLobidTest.java
+++ b/src/test/java/org/lobid/resources/Hbz01MabXml2ElasticsearchLobidTest.java
@@ -79,7 +79,7 @@ public final class Hbz01MabXml2ElasticsearchLobidTest {
 	@BeforeClass
 	public static void setup() {
 		try {
-			if (System.getProperty("generateTestData", "true").equals("true")) {
+			if (System.getProperty("generateTestData", "false").equals("true")) {
 				Files.walk(Paths.get(DIRECTORY_TO_TEST_JSON_FILES))
 						.filter(Files::isRegularFile)
 						.forEach(fname -> testFiles.add(fname.getFileName().toString()));

--- a/src/test/java/org/lobid/resources/Hbz01MabXml2ElasticsearchLobidTest.java
+++ b/src/test/java/org/lobid/resources/Hbz01MabXml2ElasticsearchLobidTest.java
@@ -130,8 +130,8 @@ public final class Hbz01MabXml2ElasticsearchLobidTest {
 						.getAbsolutePath());
 		try {
 			opener.closeStream();
-		} catch (Exception e) {
-			// ignore, see #1030
+		} catch (NullPointerException e) {
+			// ignore, see https://github.com/hbz/lobid-resources/issues/1030
 		}
 
 	}

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -14396,8 +14396,18 @@
 <http://www.klimaatlas.koblenz.de/> <http://www.w3.org/2000/01/rdf-schema#label> "www.klimaatlas.koblenz.de" .
 <http://www.mdz-nbn-resolving.de/urn/resolver.pl?urn=urn:nbn:de:bvb:12-bsb10057885-8> <http://www.w3.org/2000/01/rdf-schema#label> "URN-Link" .
 <http://www.rhein-lahn-info.de/jakobsweg/> <http://www.w3.org/2000/01/rdf-schema#label> "jakobsweg" .
+<http://www.wikidata.org/entity/Q1198> <http://schema.org/geo> _:bnodeDummy .
+<http://www.wikidata.org/entity/Q1198> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q1221156> .
+<http://www.wikidata.org/entity/Q1198> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen" .
+<http://www.wikidata.org/entity/Q151993> <http://schema.org/geo> _:bnodeDummy .
+<http://www.wikidata.org/entity/Q151993> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q245260> .
+<http://www.wikidata.org/entity/Q151993> <http://www.w3.org/2000/01/rdf-schema#label> "Ruhrgebiet" .
+<http://www.wikidata.org/entity/Q152243> <http://schema.org/geo> _:bnodeDummy .
+<http://www.wikidata.org/entity/Q152243> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q82794> .
+<http://www.wikidata.org/entity/Q152243> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland" .
 <http://www.wikidata.org/entity/Q1700> <http://schema.org/geo> _:bnodeDummy .
 <http://www.wikidata.org/entity/Q1700> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q82794> .
+<http://www.wikidata.org/entity/Q249428> <http://www.w3.org/2000/01/rdf-schema#label> "Großherzogtum Berg" .
 <http://www.wikidata.org/entity/Q2742> <http://schema.org/geo> _:bnodeDummy .
 <http://www.wikidata.org/entity/Q2742> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q1549591> .
 <http://www.wikidata.org/entity/Q2742> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q22865> .
@@ -14420,10 +14430,14 @@
 <http://www.wikidata.org/entity/Q365> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q22865> .
 <http://www.wikidata.org/entity/Q365> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q515> .
 <http://www.wikidata.org/entity/Q365> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q707813> .
+<http://www.wikidata.org/entity/Q462011> <http://schema.org/geo> _:bnodeDummy .
+<http://www.wikidata.org/entity/Q462011> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q107425> .
+<http://www.wikidata.org/entity/Q462011> <http://www.w3.org/2000/01/rdf-schema#label> "Westfälische Bucht" .
 <http://www.wikidata.org/entity/Q47524318> <http://www.w3.org/2000/01/rdf-schema#label> "Freie Verschlagwortung" .
 <http://www.wikidata.org/entity/Q6210> <http://schema.org/geo> _:bnodeDummy .
 <http://www.wikidata.org/entity/Q6210> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q106658> .
 <http://www.wikidata.org/entity/Q63078887> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q897303> .
+<http://www.wikidata.org/entity/Q657241> <http://www.w3.org/2000/01/rdf-schema#label> "Herzogtum Westfalen" .
 <http://www.wikidata.org/entity/Q8614> <http://schema.org/geo> _:bnodeDummy .
 <http://www.wikidata.org/entity/Q8614> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.wikidata.org/entity/Q82794> .
 <http://www.wikidata.org/entity/Q8614> <http://www.w3.org/2000/01/rdf-schema#label> "Westfalen" .
@@ -14437,10 +14451,12 @@
 <https://nwbib.de/spatial#N01> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N01> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfalen" .
 <https://nwbib.de/spatial#N01> <http://www.w3.org/2004/02/skos/core#notation> "01" .
+<https://nwbib.de/spatial#N01> <http://xmlns.com/foaf/0.1/focus> <http://www.wikidata.org/entity/Q1198> .
 <https://nwbib.de/spatial#N03> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N03> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N03> <http://www.w3.org/2000/01/rdf-schema#label> "Rheinland" .
 <https://nwbib.de/spatial#N03> <http://www.w3.org/2004/02/skos/core#notation> "03" .
+<https://nwbib.de/spatial#N03> <http://xmlns.com/foaf/0.1/focus> <http://www.wikidata.org/entity/Q152243> .
 <https://nwbib.de/spatial#N05> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N05> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N05> <http://www.w3.org/2000/01/rdf-schema#label> "Westfalen" .
@@ -14450,22 +14466,26 @@
 <https://nwbib.de/spatial#N10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N10> <http://www.w3.org/2000/01/rdf-schema#label> "Westfälische Bucht" .
 <https://nwbib.de/spatial#N10> <http://www.w3.org/2004/02/skos/core#notation> "10" .
+<https://nwbib.de/spatial#N10> <http://xmlns.com/foaf/0.1/focus> <http://www.wikidata.org/entity/Q462011> .
 <https://nwbib.de/spatial#N20> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N20> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N20> <http://www.w3.org/2000/01/rdf-schema#label> "Ruhrgebiet" .
 <https://nwbib.de/spatial#N20> <http://www.w3.org/2004/02/skos/core#notation> "20" .
+<https://nwbib.de/spatial#N20> <http://xmlns.com/foaf/0.1/focus> <http://www.wikidata.org/entity/Q151993> .
 <https://nwbib.de/spatial#N36> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N36> <http://www.w3.org/2000/01/rdf-schema#label> "Katholische Kirche. Diözesen" .
 <https://nwbib.de/spatial#N36> <http://www.w3.org/2004/02/skos/core#notation> "36" .
 <https://nwbib.de/spatial#N46> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
-<https://nwbib.de/spatial#N46> <http://www.w3.org/2000/01/rdf-schema#label> "Grafschaft, Herzogtum, Großherzogtum Berg" .
+<https://nwbib.de/spatial#N46> <http://www.w3.org/2000/01/rdf-schema#label> "Großherzogtum Berg" .
 <https://nwbib.de/spatial#N46> <http://www.w3.org/2004/02/skos/core#notation> "46" .
+<https://nwbib.de/spatial#N46> <http://xmlns.com/foaf/0.1/focus> <http://www.wikidata.org/entity/Q249428> .
 <https://nwbib.de/spatial#N62> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N62> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N62> <http://www.w3.org/2000/01/rdf-schema#label> "Herzogtum Westfalen" .
 <https://nwbib.de/spatial#N62> <http://www.w3.org/2004/02/skos/core#notation> "62" .
+<https://nwbib.de/spatial#N62> <http://xmlns.com/foaf/0.1/focus> <http://www.wikidata.org/entity/Q657241> .
 <https://nwbib.de/spatial#N96> <http://id.loc.gov/ontologies/bibframe/source> <https://nwbib.de/spatial> .
 <https://nwbib.de/spatial#N96> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2004/02/skos/core#Concept> .
 <https://nwbib.de/spatial#N96> <http://www.w3.org/2000/01/rdf-schema#label> "Regierungsbezirke" .
@@ -15229,7 +15249,11 @@ _:bnodeDummy <http://schema.org/latitude> "5.12E1"^^<http://www.w3.org/2001/XMLS
 _:bnodeDummy <http://schema.org/latitude> "5.1428333333333E1"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:bnodeDummy <http://schema.org/latitude> "5.1866666666667E1"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:bnodeDummy <http://schema.org/latitude> "5.196294444E1"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:bnodeDummy <http://schema.org/latitude> "50.276989" .
+_:bnodeDummy <http://schema.org/latitude> "51.466666666" .
+_:bnodeDummy <http://schema.org/latitude> "51.5" .
 _:bnodeDummy <http://schema.org/latitude> "51.9625" .
+_:bnodeDummy <http://schema.org/latitude> "51.96294444" .
 _:bnodeDummy <http://schema.org/latitude> "52.0" .
 _:bnodeDummy <http://schema.org/location> "Ahamadābāda" .
 _:bnodeDummy <http://schema.org/location> "Amherst ; Boston" .
@@ -15340,10 +15364,14 @@ _:bnodeDummy <http://schema.org/location> "Wien" .
 _:bnodeDummy <http://schema.org/location> "Wiesbaden" .
 _:bnodeDummy <http://schema.org/location> "\u0421\u0430\u0440\u0430\u0442\u043e\u0432" .
 _:bnodeDummy <http://schema.org/longitude> "6.4333333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:bnodeDummy <http://schema.org/longitude> "6.860735" .
 _:bnodeDummy <http://schema.org/longitude> "6.8788888888889E0"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:bnodeDummy <http://schema.org/longitude> "6.9577777777778E0"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:bnodeDummy <http://schema.org/longitude> "7.3833333333333E0"^^<http://www.w3.org/2001/XMLSchema#double> .
+_:bnodeDummy <http://schema.org/longitude> "7.5" .
+_:bnodeDummy <http://schema.org/longitude> "7.55" .
 _:bnodeDummy <http://schema.org/longitude> "7.625555555" .
+_:bnodeDummy <http://schema.org/longitude> "7.62869444" .
 _:bnodeDummy <http://schema.org/longitude> "7.62869444E0"^^<http://www.w3.org/2001/XMLSchema#double> .
 _:bnodeDummy <http://schema.org/longitude> "8.0" .
 _:bnodeDummy <http://schema.org/object> <http://lobid.org/hbz01/BT000002852> .

--- a/src/test/resources/jsonld/BT000003404
+++ b/src/test/resources/jsonld/BT000003404
@@ -16,8 +16,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N126000",

--- a/src/test/resources/jsonld/BT000014215
+++ b/src/test/resources/jsonld/BT000014215
@@ -55,8 +55,12 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Herzogtum Westfalen",
     "notation" : "62",
-    "label" : "Herzogtum Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q657241",
+      "label" : "Herzogtum Westfalen"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/BT000168595
+++ b/src/test/resources/jsonld/BT000168595
@@ -27,8 +27,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/HT004381366
+++ b/src/test/resources/jsonld/HT004381366
@@ -71,8 +71,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Westfälische Bucht",
     "notation" : "10",
-    "label" : "Westfälische Bucht"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q462011",
+      "type" : [ "http://www.wikidata.org/entity/Q107425" ],
+      "geo" : {
+        "lat" : "51.96294444",
+        "lon" : "7.62869444"
+      },
+      "label" : "Westfälische Bucht"
+    }
   }, {
     "focus" : {
       "id" : "http://www.wikidata.org/entity/Q1700",

--- a/src/test/resources/jsonld/HT008733617
+++ b/src/test/resources/jsonld/HT008733617
@@ -142,16 +142,16 @@
   "hbzId" : "HT008733617",
   "edition" : [ "[Mikrofiche-Ausg.]" ],
   "publication" : [ {
+    "type" : [ "PublicationEvent" ],
+    "location" : "Strassburg",
+    "startDate" : "1624"
+  }, {
     "type" : [ "SecondaryPublicationEvent" ],
     "description" : [ "Mikrofiche-Ausg.:" ],
     "endDate" : "1994",
     "location" : "München [u.a.]",
     "publishedBy" : "Saur",
     "startDate" : "1990"
-  }, {
-    "type" : [ "PublicationEvent" ],
-    "location" : "Strassburg",
-    "startDate" : "1624"
   } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT008733617",

--- a/src/test/resources/jsonld/HT009719670
+++ b/src/test/resources/jsonld/HT009719670
@@ -68,12 +68,12 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "Les films du losange"
+      "label" : "Collection libre échange"
     } ]
   }, {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "Collection libre échange"
+      "label" : "Les films du losange"
     } ]
   } ],
   "otherTitleInformation" : [ "extraits de films de Eric Rohmer" ],

--- a/src/test/resources/jsonld/HT013532539
+++ b/src/test/resources/jsonld/HT013532539
@@ -197,13 +197,13 @@
   "subjectAltLabel" : [ "Cour Constitutionnelle Fédérale (Deutschland)", "BVerfG", "Deutschland. Cour Constitutionnelle Fédérale", "Spruchpraxis", "Constitutional Court (Deutschland)", "Deutschland. Pressestelle", "De guo lian bang xian fa fa yuan", "Pressestelle (Deutschland, Bundesverfassungsgericht)", "Deutschland. Savezni Ustavni Sud", "Savezni Ustavni Sud (Deutschland)", "Judikatur", "BVerfGK", "Bundesverfassungsgericht (Deutschland)", "Bundesverfassungsgericht (Deutschland, Bundesrepublik)", "Savezni Ustavni Sud Nemačke", "Pressestelle (Deutschland, Bundesrepublik, Bundesverfassungsgericht)", "Federal Constitutional Court (Deutschland)", "Deutschland. Constitutional Court", "Deutschland. Dezernat Kirchhof" ],
   "edition" : [ "[Mikrofiche-Ausg.]" ],
   "publication" : [ {
-    "type" : [ "SecondaryPublicationEvent" ],
-    "description" : [ "Mikrofiche-Ausg." ],
+    "type" : [ "PublicationEvent" ],
     "location" : "Köln",
     "publishedBy" : "Bundesanzeiger",
     "startDate" : "2002"
   }, {
-    "type" : [ "PublicationEvent" ],
+    "type" : [ "SecondaryPublicationEvent" ],
+    "description" : [ "Mikrofiche-Ausg." ],
     "location" : "Köln",
     "publishedBy" : "Bundesanzeiger",
     "startDate" : "2002"

--- a/src/test/resources/jsonld/HT013577568
+++ b/src/test/resources/jsonld/HT013577568
@@ -30,8 +30,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Rheinland",
     "notation" : "03",
-    "label" : "Rheinland"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q152243",
+      "type" : [ "http://www.wikidata.org/entity/Q82794" ],
+      "geo" : {
+        "lat" : "50.276989",
+        "lon" : "6.860735"
+      },
+      "label" : "Rheinland"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/HT014176012
+++ b/src/test/resources/jsonld/HT014176012
@@ -34,8 +34,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N101000",

--- a/src/test/resources/jsonld/HT014215912
+++ b/src/test/resources/jsonld/HT014215912
@@ -30,8 +30,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/HT015440386
+++ b/src/test/resources/jsonld/HT015440386
@@ -42,8 +42,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/HT016604323
+++ b/src/test/resources/jsonld/HT016604323
@@ -61,8 +61,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Westfalen",
     "notation" : "05",
-    "label" : "Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q8614",
+      "type" : [ "http://www.wikidata.org/entity/Q82794" ],
+      "geo" : {
+        "lat" : "52.0",
+        "lon" : "8.0"
+      },
+      "label" : "Westfalen"
+    }
   } ],
   "subject" : [ {
     "source" : {

--- a/src/test/resources/jsonld/HT016987148
+++ b/src/test/resources/jsonld/HT016987148
@@ -46,8 +46,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N532030",

--- a/src/test/resources/jsonld/HT017411546
+++ b/src/test/resources/jsonld/HT017411546
@@ -79,8 +79,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Westfalen",
     "notation" : "05",
-    "label" : "Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q8614",
+      "type" : [ "http://www.wikidata.org/entity/Q82794" ],
+      "geo" : {
+        "lat" : "52.0",
+        "lon" : "8.0"
+      },
+      "label" : "Westfalen"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/HT017749491
+++ b/src/test/resources/jsonld/HT017749491
@@ -30,8 +30,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N428020",

--- a/src/test/resources/jsonld/HT018131501
+++ b/src/test/resources/jsonld/HT018131501
@@ -32,8 +32,12 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Großherzogtum Berg",
     "notation" : "46",
-    "label" : "Grafschaft, Herzogtum, Großherzogtum Berg"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q249428",
+      "label" : "Großherzogtum Berg"
+    }
   }, {
     "focus" : {
       "id" : "http://www.wikidata.org/entity/Q2758",

--- a/src/test/resources/jsonld/HT018138676
+++ b/src/test/resources/jsonld/HT018138676
@@ -101,12 +101,6 @@
   } ],
   "otherTitleInformation" : [ "für Politik, Handel und Literatur" ],
   "publication" : [ {
-    "type" : [ "SecondaryPublicationEvent" ],
-    "description" : [ "München : Münchener Digitalisierungszentrum, 2008-2013. - Digital. Ausg.: Bremen : Staats- und Universitätsbibliothek Bremen, 2015", "Digital. Ausg." ],
-    "location" : "München",
-    "publishedBy" : "Münchener Digitalisierungszentrum",
-    "startDate" : "2008"
-  }, {
     "type" : [ "PublicationEvent" ],
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#d",
@@ -118,6 +112,12 @@
     "location" : "Bremen",
     "publishedBy" : "Meier",
     "startDate" : "1741"
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "description" : [ "München : Münchener Digitalisierungszentrum, 2008-2013. - Digital. Ausg.: Bremen : Staats- und Universitätsbibliothek Bremen, 2015", "Digital. Ausg." ],
+    "location" : "München",
+    "publishedBy" : "Münchener Digitalisierungszentrum",
+    "startDate" : "2008"
   } ],
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:gbv:46:1-6622",

--- a/src/test/resources/jsonld/HT018295975
+++ b/src/test/resources/jsonld/HT018295975
@@ -79,25 +79,6 @@
   "subject" : [ {
     "type" : [ "ComplexSubject" ],
     "componentList" : [ {
-      "id" : "http://d-nb.info/gnd/4059979-6",
-      "type" : [ "PlaceOrGeographicName" ],
-      "gndIdentifier" : "4059979-6",
-      "source" : {
-        "id" : "http://d-nb.info/gnd/7749153-1",
-        "label" : "Gemeinsame Normdatei (GND)"
-      },
-      "label" : "Thüringen"
-    }, {
-      "type" : [ "SubjectHeading" ],
-      "label" : "Geschichte"
-    }, {
-      "type" : [ "SubjectHeading" ],
-      "label" : "Aufsatzsammlung"
-    } ],
-    "label" : "Thüringen | Geschichte | Aufsatzsammlung"
-  }, {
-    "type" : [ "ComplexSubject" ],
-    "componentList" : [ {
       "id" : "http://d-nb.info/gnd/12174793X",
       "type" : [ "Person" ],
       "dateOfBirth" : "1949",
@@ -136,6 +117,25 @@
     },
     "notation" : "130",
     "label" : "Landeskunde Region Koblenz"
+  }, {
+    "type" : [ "ComplexSubject" ],
+    "componentList" : [ {
+      "id" : "http://d-nb.info/gnd/4059979-6",
+      "type" : [ "PlaceOrGeographicName" ],
+      "gndIdentifier" : "4059979-6",
+      "source" : {
+        "id" : "http://d-nb.info/gnd/7749153-1",
+        "label" : "Gemeinsame Normdatei (GND)"
+      },
+      "label" : "Thüringen"
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Geschichte"
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Aufsatzsammlung"
+    } ],
+    "label" : "Thüringen | Geschichte | Aufsatzsammlung"
   } ],
   "tableOfContents" : [ {
     "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852707&custom_att_2=simple_viewer",

--- a/src/test/resources/jsonld/HT018617137
+++ b/src/test/resources/jsonld/HT018617137
@@ -37,8 +37,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Nordrhein-Westfalen",
     "notation" : "01",
-    "label" : "Nordrhein-Westfalen"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "51.466666666",
+        "lon" : "7.55"
+      },
+      "label" : "Nordrhein-Westfalen"
+    }
   } ],
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N796000",

--- a/src/test/resources/jsonld/HT018786244
+++ b/src/test/resources/jsonld/HT018786244
@@ -96,15 +96,15 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
+      "label" : "Augsburger Schriften"
+    } ]
+  }, {
+    "type" : [ "IsPartOfRelation" ],
+    "hasSuperordinate" : [ {
       "id" : "http://lobid.org/resources/HT004394800#!",
       "label" : "Forum Musikpädagogik"
     } ],
     "numbering" : "Band 133"
-  }, {
-    "type" : [ "IsPartOfRelation" ],
-    "hasSuperordinate" : [ {
-      "label" : "Augsburger Schriften"
-    } ]
   } ],
   "isbn" : [ "9783957860415" ],
   "otherTitleInformation" : [ "Subjektentwicklung zwischen Nähe und Distanz" ],

--- a/src/test/resources/jsonld/HT019093814
+++ b/src/test/resources/jsonld/HT019093814
@@ -111,8 +111,17 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     },
+    "label" : "Ruhrgebiet",
     "notation" : "20",
-    "label" : "Ruhrgebiet"
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q151993",
+      "type" : [ "http://www.wikidata.org/entity/Q245260" ],
+      "geo" : {
+        "lat" : "51.5",
+        "lon" : "7.5"
+      },
+      "label" : "Ruhrgebiet"
+    }
   } ],
   "subject" : [ {
     "type" : [ "ComplexSubject" ],

--- a/src/test/resources/jsonld/HT019357035
+++ b/src/test/resources/jsonld/HT019357035
@@ -54,17 +54,17 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "id" : "http://lobid.org/resources/HT006472521#!",
-      "label" : "lobid Ressource"
-    } ],
-    "numbering" : "4, part B"
-  }, {
-    "type" : [ "IsPartOfRelation" ],
-    "hasSuperordinate" : [ {
       "id" : "http://lobid.org/resources/HT001252634#!",
       "label" : "Progress in brain research"
     } ],
     "numbering" : "231"
+  }, {
+    "type" : [ "IsPartOfRelation" ],
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT006472521#!",
+      "label" : "lobid Ressource"
+    } ],
+    "numbering" : "4, part B"
   } ],
   "edition" : [ "First edition" ],
   "isbn" : [ "9780128138793" ],


### PR DESCRIPTION
Adds a focus object if the nwbib spatial object resides in nwbib-spatial.tsv.

See #1029.