### PR TITLE
Improve tests, remove `stop` filter for default analyzer

### DIFF
--- a/src/main/resources/index-config.json
+++ b/src/main/resources/index-config.json
@@ -7,7 +7,6 @@
                "german_analyzer" : {
                   "filter" : [
                      "lowercase",
-                     "stop",
                      "snowball"
                   ],
                   "tokenizer" : "standard",

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -6,8 +6,9 @@ import static org.fest.assertions.Assertions.assertThat;
 import static play.test.Helpers.fakeApplication;
 import static play.test.Helpers.running;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +32,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	@Parameters(name = "{0}")
 	public static Collection<Object[]> data() {
 		// @formatter:off
-		return Arrays.asList(new Object[][] {
+		return queries(new Object[][] {
 			{ "title:der", /*->*/ 25 },
 			{ "title:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 9 },
@@ -91,13 +92,23 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 		});
 	} // @formatter:on
 
+	private static List<Object[]> queries(Object[][] objects) {
+		List<Object[]> result = new ArrayList<>();
+		for (Object[] testCase : objects) {
+			String s = (String) testCase[0];
+			Integer hits = (Integer) testCase[1];
+			result.add(new Object[] { new Queries.Builder().q(s), /*->*/ hits });
+			result.add(new Object[] { new Queries.Builder().word(s), /*->*/ hits });
+		}
+		return result;
+	}
+
 	private int expectedResultCount;
 	private Search index;
 
-	public IndexIntegrationTest(String queryString, int resultCount) {
+	public IndexIntegrationTest(Queries.Builder query, int resultCount) {
 		this.expectedResultCount = resultCount;
-		this.index = new Search.Builder()
-				.query(new Queries.Builder().q(queryString).build()).build();
+		this.index = new Search.Builder().query(query.build()).build();
 	}
 
 	@Test

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -81,7 +81,13 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "hasItem.id:TT003059252\\:DE-5-58\\:9%2F041", /*->*/ 0 },
 			{ "coverage:99", /*->*/ 24},
 			{ "isbn:3454128013", /*->*/ 1},
-			{ "isbn:345-4128-013", /*->*/ 1}
+			{ "isbn:345-4128-013", /*->*/ 1},
+			{ "\"Studies in social and political theory\"", /*->*/ 1},
+			{ "(+Studies +in +social +and +political +theory)", /*->*/ 1},
+			{ "\"Zeitzeuge und Kleinod in Harsewinkel\"", /*->*/ 1},
+			{ "(+Zeitzeuge +und +Kleinod +in +Harsewinkel)", /*->*/ 1},
+			{ "\"Mülheim an der Ruhr\"", /*->*/ 1},
+			{ "(+Mülheim +an +der +Ruhr)", /*->*/ 1}
 		});
 	} // @formatter:on
 


### PR DESCRIPTION
Will resolve https://github.com/hbz/nwbib/issues/506

@dr0i: This only affects the index config (except tests). Could you deploy this to (small) test and stage?