### PR TITLE
Set maxZoom to 17

### DIFF
--- a/web/app/views/tags/items_map.scala.html
+++ b/web/app/views/tags/items_map.scala.html
@@ -38,6 +38,7 @@ var nrw = new L.LatLng(51.50, 7.8)
 var map = new L.Map("items-map", {
     center: nrw,
     zoom: 7,
+    maxZoom: 17,
     scrollWheelZoom: true,
     attributionControl: false,
     zoomControl: false


### PR DESCRIPTION
hbz' tileserver is constrained to zoom level 17.

See https://github.com/hbz/lobid/issues/309.

Test e.g. http://test.lobid.org/resources/TT002009694.