### PR TITLE
Delete note-Element

### DIFF
--- a/src/main/resources/alma/common/fields.xml
+++ b/src/main/resources/alma/common/fields.xml
@@ -558,10 +558,7 @@
 
 
   <!-- 5xx -->
-  <data name="note" source="500  .a" />
-  <entity name="abstract[]" flushWith="record">
-    <data name="" source="520[ 13] .[ab]" />
-  </entity>
+
 
   <!-- 6xx -->
 	<!--
@@ -579,7 +576,8 @@
       <data name="prefix" source="77[356]??.i">
         <replace pattern=":?$" with="" />
       </data>
-      <entity name="note[]" flushWith="77[356]??" sameEntity="true">
+      <entity name="
+[]" flushWith="77[356]??" sameEntity="true">
         <data name="" source="77[356]??.n" />
       </entity>
     </entity>


### PR DESCRIPTION
The transformation to "note" is creating problems in the mapping.

Since the information in "note" is not coherent we decided 
off-board that at the moment there is no need for "note".