### PR TITLE
Enrich isbn

### DIFF
--- a/src/main/resources/alma/common/fields.xml
+++ b/src/main/resources/alma/common/fields.xml
@@ -97,9 +97,10 @@
   </data>
 
   <entity name="isbn[]" flushWith="record">
-    <data name="" source="@cleanIsbn"/>
     <data name="" source="@cleanIsbn">
-      <regexp match="^\d{10}$"/>
+      <isbn to="isbn10"/>
+    </data>
+    <data name="" source="@cleanIsbn">
       <isbn to="isbn13"/>
     </data>
   </entity>

--- a/src/main/resources/alma/common/fields.xml
+++ b/src/main/resources/alma/common/fields.xml
@@ -91,11 +91,19 @@
     </entity>
   </entity>
 
+  <data source="020  .a" name="@cleanIsbn">
+    <isbn to="clean"/>
+    <unique />
+  </data>
+
   <entity name="isbn[]" flushWith="record">
-    <data name="" source="020  .a">
-      <unique />
+    <data name="" source="@cleanIsbn"/>
+    <data name="" source="@cleanIsbn">
+      <regexp match="^\d{10}$"/>
+      <isbn to="isbn13"/>
     </data>
   </entity>
+
   <entity name="issn[]" flushWith="record">
     <data name="" source="022? .a">
       <replace pattern="-" with="" />

--- a/src/test/resources/alma/(CKB)2560000000104439.json
+++ b/src/test/resources/alma/(CKB)2560000000104439.json
@@ -71,7 +71,7 @@
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
   } ],
-  "isbn" : [ "3-642-32079-1" ],
+  "isbn" : [ "3642320791", "9783642320798" ],
   "IdentifierDOI" : [ "10.1007/978-3-642-32079-8" ],
   "edition" : [ "11th ed. 2013." ],
   "publication" : [ {
@@ -111,7 +111,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-03-25T23:11:07",
+      "endTime" : "2021-04-01T16:13:11",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT005207972.json
+++ b/src/test/resources/alma/(DE-605)HT005207972.json
@@ -42,7 +42,7 @@
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
   } ],
-  "isbn" : [ "0256018243" ],
+  "isbn" : [ "0256018243", "9780256018240" ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT005207972",
     "label" : "Culturegraph Ressource"
@@ -111,7 +111,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-03-24T09:26:31",
+      "endTime" : "2021-04-01T16:13:12",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT017398609.json
+++ b/src/test/resources/alma/(DE-605)HT017398609.json
@@ -22,7 +22,7 @@
     "label" : "Englisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
   } ],
-  "isbn" : [ "9780415641043" ],
+  "isbn" : [ "0415641047", "9780415641043" ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT017398609",
     "label" : "Culturegraph Ressource"
@@ -72,7 +72,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-03-25T10:20:52",
+      "endTime" : "2021-04-07T09:38:37",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT020202475.json
+++ b/src/test/resources/alma/(DE-605)HT020202475.json
@@ -28,7 +28,7 @@
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
   } ],
-  "isbn" : [ "9783161546303" ],
+  "isbn" : [ "316154630X", "9783161546303" ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT020202475",
     "label" : "Culturegraph Ressource"
@@ -81,7 +81,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-03-24T09:26:32",
+      "endTime" : "2021-04-07T09:38:37",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],


### PR DESCRIPTION
If an isbn10 exists a corresponding isbn13 is generated.
Also, an isbn is normalized by removing semnatic sugar, so that:

-  "isbn" : [ "3-642-32079-1" ],
+  "isbn" : [ "3642320791", "9783642320798" ],

See #1180.