### PR TITLE
1248 contributor roles

### DIFF
--- a/src/main/resources/alma/common/contribution.xml
+++ b/src/main/resources/alma/common/contribution.xml
@@ -23,12 +23,10 @@
           </data>
         </entity>
       </entity>
-      <entity name="role" reset="true">
-        <data name="id" source="100[01] .[4e]">
-          <regexp match="^([Aa]ut|[Cc]re)" format="http://id.loc.gov/vocabulary/relators/cre"/>
-        </data>
-        <data name="label" source="100[01] .[4e]">
-          <regexp match="^([Aa]ut|[Cc]re)" format="Autor/in"/>
+      <entity name="role" reset="true" sameEntity="true" flushWith="100[01] ">
+        <data name="label" source="100[01] .e" />
+        <data name="id" source="100[01] .4">
+          <compose prefix="http://id.loc.gov/vocabulary/relators/"/>
         </data>
       </entity>
     </entity>
@@ -49,33 +47,14 @@
           </data>
         </entity>
       </entity>
-      <entity name="role" reset="true">
-        <if>
-          <data name="id" source="700[01] .[4e]">
-            <regexp match="^([Aa]ut|[Cc]re)"/>
-          </data>
-        </if>
-        <data name="id" source="700[01] .[4e]">
-          <regexp match="^([Aa]ut|[Cc]re)" format="http://id.loc.gov/vocabulary/relators/cre"/>
-        </data>
-        <data name="label" source="700[01] .[4e]">
-          <regexp match="^([Aa]ut|[Cc]re)" format="Autor/in"/>
-        </data>
-      </entity>
-      <entity name="role" reset="true">
-        <if>
-          <data name="id" source="700[01] .[4e]">
-            <regexp match="^oth"/>
-          </data>
-        </if>
-        <data name="id" source="700[01] .[4e]">
-          <regexp match="^oth" format="http://id.loc.gov/vocabulary/relators/oth"/>
-        </data>
-        <data name="label" source="700[01] .[4e]">
-          <regexp match="^oth" format="Sonstiges"/>
+      <entity name="role" reset="true" sameEntity="true" flushWith="700[01] ">
+        <data name="label" source="700[01] .e" />
+        <data name="id" source="700[01] .4">
+          <compose prefix="http://id.loc.gov/vocabulary/relators/"/>
         </data>
       </entity>
     </entity>
+
     <!-- 110|710[012] -->
     <entity name="" flushWith="[17]10[012] " sameEntity="true">
       <entity name="type[]" reset="true">
@@ -114,6 +93,7 @@
       </entity>
     </entity>
 
+    <!-- 111 -->
     <entity name="Conference" flushWith="record">
       <data name="conferenceName" source="111[012] .a">
         <replace pattern="[.,]$" with="" />

--- a/src/main/resources/alma/common/contribution.xml
+++ b/src/main/resources/alma/common/contribution.xml
@@ -83,12 +83,10 @@
           </data>
         </entity>
       </entity>
-      <entity name="role" reset="true">
-        <data name="id" source="[17]10[012] .a">
-          <constant value="http://id.loc.gov/vocabulary/relators/ctb"/>
-        </data>
-        <data name="label" source="[17]10[012] .a">
-          <constant value="Mitwirkende"/>
+      <entity name="role" reset="true" sameEntity="true" flushWith="[17]10[012] ">
+        <data name="label" source="[17]10[012] .e" />
+        <data name="id" source="[17]10[012] .4">
+          <compose prefix="http://id.loc.gov/vocabulary/relators/"/>
         </data>
       </entity>
     </entity>

--- a/src/test/resources/alma/(DE-605)HT000161712.json
+++ b/src/test/resources/alma/(DE-605)HT000161712.json
@@ -154,6 +154,9 @@
       "type" : [ "Person" ],
       "gndIdentifier" : "1023590484",
       "id" : "https://d-nb.info/gnd/1023590484"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt"
     }
   } ],
   "describedBy" : {
@@ -172,7 +175,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:53",
+      "endTime" : "2021-05-05T16:05:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT004285445.json
+++ b/src/test/resources/alma/(DE-605)HT004285445.json
@@ -41,6 +41,9 @@
       "type" : [ "Person" ],
       "gndIdentifier" : "134465202",
       "id" : "https://d-nb.info/gnd/134465202"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/cmp"
     }
   } ],
   "describedBy" : {
@@ -63,7 +66,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T09:42:45",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT005207972.json
+++ b/src/test/resources/alma/(DE-605)HT005207972.json
@@ -105,36 +105,33 @@
   } ],
   "extent" : "XIV, 633 S.",
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Marshall, Ray",
       "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   }, {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Cartter, Allan Murray",
       "type" : [ "Person" ],
       "gndIdentifier" : "127022538",
       "id" : "https://d-nb.info/gnd/127022538"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   }, {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "King, Allan G.",
       "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -157,7 +154,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-29T14:33:24",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT006855611.json
+++ b/src/test/resources/alma/(DE-605)HT006855611.json
@@ -92,16 +92,15 @@
     "label" : "OCLC Ressource"
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Furlan, Peter",
       "type" : [ "Person" ],
       "gndIdentifier" : "1049517296",
       "id" : "https://d-nb.info/gnd/1049517296"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -124,7 +123,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-28T14:12:05",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT015011399.json
+++ b/src/test/resources/alma/(DE-605)HT015011399.json
@@ -52,16 +52,15 @@
   } ],
   "thesisInformation" : [ "Dortmund, Univ., Diss., 2007" ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/oth",
-      "label" : "Sonstiges"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Itzen, Aymelt",
       "type" : [ "Person" ],
       "gndIdentifier" : "1023557622",
       "id" : "https://d-nb.info/gnd/1023557622"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/oth"
     }
   } ],
   "describedBy" : {
@@ -80,7 +79,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT015671602.json
+++ b/src/test/resources/alma/(DE-605)HT015671602.json
@@ -90,16 +90,15 @@
     "label" : "Inhaltsverzeichnis"
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Maxwell, Robert L.",
       "type" : [ "Person" ],
       "gndIdentifier" : "142840386",
       "id" : "https://d-nb.info/gnd/142840386"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -126,7 +125,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:52",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT016709661.json
+++ b/src/test/resources/alma/(DE-605)HT016709661.json
@@ -98,15 +98,14 @@
     "type" : [ "Collection" ]
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
-      "label" : "Mitwirkende"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "type" : [ "CorporateBody" ],
       "id" : "https://d-nb.info/gnd/16031104-4",
       "label" : "Düsseldorf. Amt für Wohnungswesen"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/oth"
     }
   } ],
   "describedBy" : {
@@ -133,7 +132,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-05T16:34:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT017015300.json
+++ b/src/test/resources/alma/(DE-605)HT017015300.json
@@ -182,16 +182,15 @@
     "label" : "Inhaltsverzeichnis"
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Derecik, Ahmet",
       "type" : [ "Person" ],
       "gndIdentifier" : "1017737398",
       "id" : "https://d-nb.info/gnd/1017737398"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -214,7 +213,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:52",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT017398609.json
+++ b/src/test/resources/alma/(DE-605)HT017398609.json
@@ -71,6 +71,9 @@
       "type" : [ "Person" ],
       "gndIdentifier" : "172377897",
       "id" : "https://d-nb.info/gnd/172377897"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt"
     }
   } ],
   "describedBy" : {
@@ -93,7 +96,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:53",
+      "endTime" : "2021-05-05T16:05:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT017411546.json
+++ b/src/test/resources/alma/(DE-605)HT017411546.json
@@ -91,15 +91,14 @@
     "type" : [ "Collection" ]
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
-      "label" : "Mitwirkende"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "type" : [ "CorporateBody" ],
       "id" : "https://d-nb.info/gnd/2140069-6",
       "label" : "Historische Kommission für Westfalen"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/isb"
     }
   } ],
   "describedBy" : {
@@ -126,7 +125,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T15:46:14",
+      "endTime" : "2021-05-05T16:34:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT019246898.json
+++ b/src/test/resources/alma/(DE-605)HT019246898.json
@@ -288,15 +288,14 @@
       "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   }, {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
-      "label" : "Mitwirkende"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "type" : [ "CorporateBody" ],
       "id" : "https://d-nb.info/gnd/1058035266",
       "label" : "Transcript GbR"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/pbl"
     }
   } ],
   "describedBy" : {
@@ -323,7 +322,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-05T16:05:52",
+      "endTime" : "2021-05-05T16:34:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT019246898.json
+++ b/src/test/resources/alma/(DE-605)HT019246898.json
@@ -264,28 +264,28 @@
     "label" : "Inhaltsverzeichnis"
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Abel, Alexandra",
       "type" : [ "Person" ],
       "gndIdentifier" : "1069204668",
       "id" : "https://d-nb.info/gnd/1069204668"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt",
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   }, {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Rudolf, Bernd",
       "type" : [ "Person" ],
       "gndIdentifier" : "1038489679",
       "id" : "https://d-nb.info/gnd/1038489679"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt",
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   }, {
     "role" : {
@@ -323,7 +323,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:52",
+      "endTime" : "2021-05-05T16:05:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT020202475.json
+++ b/src/test/resources/alma/(DE-605)HT020202475.json
@@ -61,16 +61,15 @@
     "type" : [ "Collection" ]
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Breuer, Stefan",
       "type" : [ "Person" ],
       "gndIdentifier" : "120195364",
       "id" : "https://d-nb.info/gnd/120195364"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -93,7 +92,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:50",
+      "endTime" : "2021-05-05T16:05:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)HT020391499.json
+++ b/src/test/resources/alma/(DE-605)HT020391499.json
@@ -62,14 +62,13 @@
     "type" : [ "Collection" ]
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
-      "label" : "Mitwirkende"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "type" : [ "CorporateBody" ],
       "label" : "Organisation de coopération et de développement économiques"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/oth"
     }
   } ],
   "describedBy" : {
@@ -92,7 +91,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-05T16:34:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)TT003907920.json
+++ b/src/test/resources/alma/(DE-605)TT003907920.json
@@ -45,16 +45,15 @@
     "numbering" : "3"
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Furlan, Peter",
       "type" : [ "Person" ],
       "gndIdentifier" : "1049517296",
       "id" : "https://d-nb.info/gnd/1049517296"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -77,7 +76,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-28T14:12:06",
+      "endTime" : "2021-05-05T16:05:52",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],

--- a/src/test/resources/alma/(DE-605)TT050421649.json
+++ b/src/test/resources/alma/(DE-605)TT050421649.json
@@ -115,14 +115,13 @@
     "type" : [ "Collection" ]
   } ],
   "contribution" : [ {
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/cre",
-      "label" : "Autor/in"
-    },
     "type" : [ "Contribution" ],
     "agent" : {
       "label" : "Wolfinger, Christine",
       "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut"
     }
   } ],
   "describedBy" : {
@@ -149,7 +148,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T14:36:40",
+      "endTime" : "2021-05-05T16:05:51",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],


### PR DESCRIPTION
See #1248
Until now we have only cre (label: Autor/-in), oth (Mitwirkende) But there are many more marc relators which seem to be used.

Questions:
- Are the code always [marc relators](https://id.loc.gov/vocabulary/relators.html)?
- How do we handle contributors with more than one role? See HT019246898 We need an array perhaps.
- How do we provide labels, is there a mapping list?