### PR TITLE
Add EtikettJson to the flow

### DIFF
--- a/src/main/java/org/lobid/resources/EtikettJson.java
+++ b/src/main/java/org/lobid/resources/EtikettJson.java
@@ -1,0 +1,132 @@
+/* Copyright 2018-2021 Pascal Christoph, hbz. Licensed under the Eclipse Public License 1.0 */
+
+package org.lobid.resources;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.github.jsonldjava.utils.JsonUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+
+import de.hbz.lobid.helper.EtikettMaker;
+
+/**
+ * Enriches a JSON document using Etikett. Thus every's object "id" will have a
+ * "label". Optionally creates a JSON-LD context from the labels.
+ * 
+ * @author Pascal Christoph (dr0i)
+ */
+@In(String.class)
+@Out(String.class)
+public final class EtikettJson
+    extends DefaultObjectPipe<String, ObjectReceiver<String>> {
+  private static final Logger LOG = LogManager.getLogger(EtikettJson.class);
+  private String labelsDirectoryName = "labels";
+  private String contextFilenameLocation;
+  private boolean generateContext = false;
+  private EtikettMaker etikettMaker;
+
+  @Override
+  public void onSetReceiver() {
+    etikettMaker = new EtikettMaker(new File(Thread.currentThread()
+        .getContextClassLoader().getResource(labelsDirectoryName).getFile()));
+    if (generateContext) {
+      etikettMaker.setContextLocation(contextFilenameLocation);
+      etikettMaker.writeContext();
+    }
+  }
+
+  @Override
+  public void process(final String json) {
+    if (json.isEmpty()) {
+      return;
+    }
+    try {
+      Map<String, Object> jsonMap =
+          (Map<String, Object>) JsonUtils.fromInputStream(
+              new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+      if (jsonMap.get("id") != null)
+        getReceiver().process(getEtikettForEveryUri(jsonMap));
+      else
+        LOG.warn("jsonMap without id, ignoring");
+    } catch (IOException e) {
+      LOG.error("Couldn't etikett json. %s", e.toString());
+    }
+  }
+
+  private String getEtikettForEveryUri(final Map<String, Object> jsonMap)
+      throws IOException {
+    // don't label the root id
+    Object rootId = jsonMap.remove("id");
+    getAllJsonNodes(jsonMap);
+    jsonMap.put("id", rootId);
+    return JsonUtils.toPrettyString(jsonMap);
+  }
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private Map<String, Object> getAllJsonNodes(Map<String, Object> jsonMap) {
+    Iterator<String> it = jsonMap.keySet().iterator();
+    boolean hasLabel = false;
+    String id = null;
+    while (it.hasNext()) {
+      String key = it.next();
+      if (key.equals("label"))
+        hasLabel = true;
+      else if (!hasLabel && key.equals("id"))
+        id = (String) jsonMap.get(key);
+      if (jsonMap.get(key) instanceof ArrayList)
+        ((ArrayList) jsonMap.get(key))//
+            .stream().filter(e -> (e instanceof LinkedHashMap))
+            .forEach(e -> getAllJsonNodes((Map<String, Object>) e));
+      else if (jsonMap.get(key) instanceof LinkedHashMap)
+        getAllJsonNodes((Map<String, Object>) jsonMap.get(key));
+    }
+    if (id != null && !(hasLabel))
+      jsonMap.put("label", etikettMaker.getEtikett(id).label);
+    return jsonMap;
+  }
+
+  /**
+   * Sets the name of the directory of the label(s). Will be used to create
+   * jsonld-context.
+   * 
+   * @param DIR_TO_LABELS the directory ehre the labels reside
+   * 
+   */
+  public void setLabelsDirectoryName(final String DIR_TO_LABELS) {
+    this.labelsDirectoryName = DIR_TO_LABELS;
+  }
+
+  /**
+   * Sets the name of the file of the context that is generated from the labels.
+   * 
+   * @param FILENAME_OF_CONTEXT the directory wehre the labels reside
+   * 
+   */
+  public void setFilenameOfContext(final String FILENAME_OF_CONTEXT) {
+    contextFilenameLocation = FILENAME_OF_CONTEXT;
+  }
+
+  /**
+   * Generate the context from labels and store it.
+   * 
+   * @param GENERATE_CONTEXT if true generate the context. Defaults to false.
+   * 
+   */
+  public void setGenerateContext(final boolean GENERATE_CONTEXT) {
+    generateContext = GENERATE_CONTEXT;
+  }
+
+}

--- a/src/main/java/org/lobid/resources/run/AlmaMarcXml2lobidJsonEs.java
+++ b/src/main/java/org/lobid/resources/run/AlmaMarcXml2lobidJsonEs.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lobid.resources.ElasticsearchIndexer;
-import org.lobid.resources.JsonLdEtikett;
+import org.lobid.resources.EtikettJson;
 import org.lobid.resources.JsonToElasticsearchBulkMap;
 import org.metafacture.biblio.marc21.MarcXmlHandler;
 import org.metafacture.flowcontrol.ObjectThreader;
@@ -106,9 +106,6 @@ public class AlmaMarcXml2lobidJsonEs {
         final String KEY_TO_GET_MAIN_ID =
             System.getProperty("keyToGetMainId", "almaIdMMS");
         LOG.info("using keyToGetMainId:%s", KEY_TO_GET_MAIN_ID);
-        LOG.info("using etikettLablesDirectory: %s",
-            JsonLdEtikett.getLabelsDirectoryName());
-
         if (inputPath.toLowerCase().endsWith("tar.bz2")
             || inputPath.toLowerCase().endsWith("tar.gz")) {
           LOG.info("recognised as tar archive");
@@ -185,6 +182,10 @@ public class AlmaMarcXml2lobidJsonEs {
     objectBatchLogger.setBatchSize(500000);
     MarcXmlHandler marcXmlHandler = new MarcXmlHandler();
     marcXmlHandler.setNamespace(null);
+    EtikettJson jsonEtikettJsonLd = new EtikettJson();
+    jsonEtikettJsonLd.setLabelsDirectoryName("labels");
+    jsonEtikettJsonLd.setFilenameOfContext("web/conf/context.jsonld");
+    jsonEtikettJsonLd.setGenerateContext(true);
     JsonEncoder jsonEncoder = new JsonEncoder();
     StringReader sr = new StringReader();
 
@@ -193,6 +194,7 @@ public class AlmaMarcXml2lobidJsonEs {
         .setReceiver(new Metamorph(morphFileName, morphVariables))
         .setReceiver(batchLogger)//
         .setReceiver(jsonEncoder)//
+        .setReceiver(jsonEtikettJsonLd)//
         .setReceiver(new JsonToElasticsearchBulkMap(KEY_TO_GET_MAIN_ID,
             "resource", "lobid-almaresources"))//
         .setReceiver(getElasticsearchIndexer());

--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -459,6 +459,13 @@
       "name" : "hbzId"
    },
    {
+      "referenceType" : "String",
+      "uri" : "http://purl.org/lobid/lv#almaIdMMS",
+      "label" : "Alma Katalog Id",
+      "multilangLabel" : {},
+      "name" : "almaIdMMS"
+   },
+   {
       "name" : "numbering",
       "label" : "Nummer",
       "uri" : "http://purl.org/lobid/lv#numbering",
@@ -574,6 +581,13 @@
       "multilangLabel" : {},
       "name" : "shortTitle",
       "container" : "@set"
+   },
+   {
+      "multilangLabel" : {},
+      "referenceType" : "String",
+      "label" : "Standort",
+      "uri" : "http://purl.org/lobid/lv#currentLocation",
+      "name" : "currentLocation"
    },
    {
       "multilangLabel" : {},

--- a/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonTest.java
+++ b/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonTest.java
@@ -54,8 +54,7 @@ public final class AlmaMarc21XmlToLobidJsonTest {
   private static final PrintStream ORIG_OUT = System.out;
   private static final Logger LOG =
       LogManager.getLogger(AlmaMarc21XmlToLobidJsonTest.class);
-  private static final String PATTERN_TO_IDENTIFY_XML_RECORDS =
-      ".*";
+  private static final String PATTERN_TO_IDENTIFY_XML_RECORDS = ".*";
 
   /**
    * Sets necessary morph variables.
@@ -67,7 +66,7 @@ public final class AlmaMarc21XmlToLobidJsonTest {
     morphVariables.put("catalogid", "DE-605");
     GENERATE_TESTDATA = true;
     if (GENERATE_TESTDATA) {
-     extractXmlTestRecords(PATTERN_TO_IDENTIFY_XML_RECORDS);
+      extractXmlTestRecords(PATTERN_TO_IDENTIFY_XML_RECORDS);
     }
   }
 
@@ -103,8 +102,7 @@ public final class AlmaMarc21XmlToLobidJsonTest {
         .setReceiver(xmlElementSplitter) //
         .setReceiver(logger) //
         .setReceiver(new LiteralToObject()) //
-        .setReceiver(stringFilter)
-        .setReceiver(new StringReader()) //
+        .setReceiver(stringFilter).setReceiver(new StringReader()) //
         .setReceiver(new XmlDecoder()) //
         .setReceiver(xmlElementSplitter_1) //
         .setReceiver(xmlFilenameWriter);
@@ -135,27 +133,29 @@ public final class AlmaMarc21XmlToLobidJsonTest {
   public void transformFiles() {
     Arrays.asList(DIRECTORY.listFiles(f -> f.getAbsolutePath().endsWith(XML)))
         .forEach(file -> {
-           MarcXmlHandler marcXmlHandler = new MarcXmlHandler();
-           marcXmlHandler.setNamespace(null);
-          JsonEncoder jsonEncoder = new JsonEncoder();
-          jsonEncoder.setPrettyPrinting(true);
+          MarcXmlHandler marcXmlHandler = new MarcXmlHandler();
+          marcXmlHandler.setNamespace(null);
+          EtikettJson jsonEtikettJsonLd = new EtikettJson();
+          jsonEtikettJsonLd.setLabelsDirectoryName("labels");
+          jsonEtikettJsonLd.setFilenameOfContext("web/conf/context.jsonld");
+          jsonEtikettJsonLd.setGenerateContext(true);
+
           ObjectMapper mapper = new ObjectMapper();
           final String filenameJson =
               file.getAbsolutePath().replaceAll("\\." + XML, "\\.json");
           try {
             FileOpener opener = new FileOpener();
-            opener.setReceiver(new XmlDecoder())
-                .setReceiver(marcXmlHandler)
+            opener.setReceiver(new XmlDecoder()).setReceiver(marcXmlHandler)
                 .setReceiver(new Metamorph(MORPH, morphVariables))
-                .setReceiver(jsonEncoder);
+                .setReceiver(new JsonEncoder()).setReceiver(jsonEtikettJsonLd);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             PrintStream ps = new PrintStream(baos);
             System.setOut(ps);
             if (GENERATE_TESTDATA) {
-              jsonEncoder.setReceiver(new ObjectWriter<>(filenameJson));
+              jsonEtikettJsonLd.setReceiver(new ObjectWriter<>(filenameJson));
             } else {
-              jsonEncoder.setReceiver(new ObjectStdoutWriter<String>());
+              jsonEtikettJsonLd.setReceiver(new ObjectStdoutWriter<String>());
             }
             opener.process(file.getAbsolutePath());
             opener.closeStream();

--- a/src/test/resources/alma/(DE-605)HT000161712.json
+++ b/src/test/resources/alma/(DE-605)HT000161712.json
@@ -16,35 +16,40 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990001412590206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990001412590206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-361#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991021156319706442",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991021156319706442"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991001000599706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991001000599706445"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990000382740206447",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990000382740206447"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-61#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990000278820206443",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990000278820206443"
   }, {
     "id" : "https://lobid.org/item/22278036670006442",
     "type" : [ "HOL" ],
@@ -130,7 +135,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT000161712#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -172,7 +176,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-04T15:27:18",
+      "endTime" : "2021-05-18T14:59:30",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -210,5 +214,6 @@
       "gndIdentifier" : "4063861-3"
     } ]
   } ],
-  "subjectAltLabel" : [ "Volksbildung", "Volksschule", "Volksschulen" ]
+  "subjectAltLabel" : [ "Volksbildung", "Volksschule", "Volksschulen" ],
+  "id" : "http://lobid.org/resources/HT000161712#!"
 }

--- a/src/test/resources/alma/(DE-605)HT000312236.json
+++ b/src/test/resources/alma/(DE-605)HT000312236.json
@@ -21,42 +21,48 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990053976760206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990053976760206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-361#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991002639399706442",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991002639399706442"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991001721369706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991001721369706445"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990000630920206446",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990000630920206446"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990000735140206447",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990000735140206447"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-61#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990000536970206443",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990000536970206443"
   }, {
     "currentLocation" : "UB_BI / 17_Zs",
     "callNumber" : "17 QD000 P600",
@@ -130,7 +136,6 @@
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT000312236#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -175,7 +180,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T15:46:15",
+      "endTime" : "2021-05-18T14:59:27",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -246,5 +251,6 @@
       "label" : "Zeitschrift"
     } ]
   } ],
-  "subjectAltLabel" : [ "Physik", "Physikdidaktik", "Periodikum", "Zeitschriften" ]
+  "subjectAltLabel" : [ "Physik", "Physikdidaktik", "Periodikum", "Zeitschriften" ],
+  "id" : "http://lobid.org/resources/HT000312236#!"
 }

--- a/src/test/resources/alma/(DE-605)HT003176544.json
+++ b/src/test/resources/alma/(DE-605)HT003176544.json
@@ -20,18 +20,19 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990054301770206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990054301770206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991007182009706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991007182009706445"
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT003176544#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -72,7 +73,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-04T15:27:18",
+      "endTime" : "2021-05-18T14:59:30",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -135,5 +136,6 @@
       "gndIdentifier" : "4141451-2"
     } ]
   } ],
-  "subjectAltLabel" : [ "Anschrift", "Einwohnerbuch", "Adressverzeichnis", "Adressenverzeichnis", "Adressbücher", "Touristik", "Fremdenverkehr", "Alemanha", "Alemania", "Allemagne", "Almanija", "Almāniyā", "Bondsrepubliek Duitsland", "BRD", "Bundesrepublik Deutschland", "Deutschland", "Federal Republic of Germany", "Förbundsrepubliken Tyskland", "Förbundsrepublikken Tyskland", "FRG", "Germany", "Németországi Szövetségi Kőztársaság", "Niemiecka Republika Federalna Niemiecka Republika Federalna", "NRF", "Repubblica Federale di Germania", "Republic of Germany", "República Federal da Alemanha", "República Federal de Alemania", "Republik Federasi Djerman", "Republika Federalna Niemiec", "République Fédérale d'Allemagne", "RFN", "Saksan Liittotasavalta", "Westdeutschland", "Periodikum", "Zeitschriften" ]
+  "subjectAltLabel" : [ "Anschrift", "Einwohnerbuch", "Adressverzeichnis", "Adressenverzeichnis", "Adressbücher", "Touristik", "Fremdenverkehr", "Alemanha", "Alemania", "Allemagne", "Almanija", "Almāniyā", "Bondsrepubliek Duitsland", "BRD", "Bundesrepublik Deutschland", "Deutschland", "Federal Republic of Germany", "Förbundsrepubliken Tyskland", "Förbundsrepublikken Tyskland", "FRG", "Germany", "Németországi Szövetségi Kőztársaság", "Niemiecka Republika Federalna Niemiecka Republika Federalna", "NRF", "Repubblica Federale di Germania", "Republic of Germany", "República Federal da Alemanha", "República Federal de Alemania", "Republik Federasi Djerman", "Republika Federalna Niemiec", "République Fédérale d'Allemagne", "RFN", "Saksan Liittotasavalta", "Westdeutschland", "Periodikum", "Zeitschriften" ],
+  "id" : "http://lobid.org/resources/HT003176544#!"
 }

--- a/src/test/resources/alma/(DE-605)HT004285445.json
+++ b/src/test/resources/alma/(DE-605)HT004285445.json
@@ -17,13 +17,14 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990016782920206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990016782920206441"
   } ],
   "type" : [ "Book", "PublishedScore", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT004285445#!",
   "language" : [ {
-    "id" : "http://id.loc.gov/vocabulary/iso639-2/###"
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/###",
+    "label" : "###"
   } ],
   "ismn" : [ "M204421206" ],
   "sameAs" : [ {
@@ -63,7 +64,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T09:42:45",
+      "endTime" : "2021-05-18T14:59:32",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -84,5 +85,6 @@
       "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
     } ]
   },
-  "subjectAltLabel" : [ "Molsen, Gert-Ulrich" ]
+  "subjectAltLabel" : [ "Molsen, Gert-Ulrich" ],
+  "id" : "http://lobid.org/resources/HT004285445#!"
 }

--- a/src/test/resources/alma/(DE-605)HT005207972.json
+++ b/src/test/resources/alma/(DE-605)HT005207972.json
@@ -18,21 +18,24 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990021367710206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990021367710206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-361#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991020595659706442",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991020595659706442"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991012396599706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991012396599706445"
   }, {
     "id" : "https://lobid.org/item/22251929380006442",
     "type" : [ "HOL" ],
@@ -90,7 +93,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT005207972#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -157,7 +159,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-29T14:33:24",
+      "endTime" : "2021-05-18T14:59:32",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -191,5 +193,6 @@
       "gndIdentifier" : "4322126-9"
     } ]
   } ],
-  "subjectAltLabel" : [ "Labor economics", "Labour economics", "Arbeitsökonomik", "Cartter, Allan M.", "Murray Cartter, Allan" ]
+  "subjectAltLabel" : [ "Labor economics", "Labour economics", "Arbeitsökonomik", "Cartter, Allan M.", "Murray Cartter, Allan" ],
+  "id" : "http://lobid.org/resources/HT005207972#!"
 }

--- a/src/test/resources/alma/(DE-605)HT006855611.json
+++ b/src/test/resources/alma/(DE-605)HT006855611.json
@@ -17,49 +17,56 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990050000600206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990050000600206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-A96#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991002141299706444",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991002141299706444"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-361#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991013990859706442",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991013990859706442"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991001802079706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991001802079706445"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990007292520206446",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990007292520206446"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990007452950206447",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990007452950206447"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-61#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990010318920206443",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990010318920206443"
   }, {
     "id" : "https://lobid.org/item/22369588590006446",
     "type" : [ "HOL" ],
@@ -79,7 +86,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT006855611#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -124,7 +130,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-04T15:27:18",
+      "endTime" : "2021-05-18T14:59:31",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -192,5 +198,6 @@
       "gndIdentifier" : "4155620-3"
     } ]
   } ],
-  "subjectAltLabel" : [ "Borowski, Peter", "Technikwissenschaften", "Technische Wissenschaften", "Ingenieurwissenschaft", "Ingenieurwesen", "Engineering", "Naturforschung", "Naturlehre", "Naturwissenschaft" ]
+  "subjectAltLabel" : [ "Borowski, Peter", "Technikwissenschaften", "Technische Wissenschaften", "Ingenieurwissenschaft", "Ingenieurwesen", "Engineering", "Naturforschung", "Naturlehre", "Naturwissenschaft" ],
+  "id" : "http://lobid.org/resources/HT006855611#!"
 }

--- a/src/test/resources/alma/(DE-605)HT012734833.json
+++ b/src/test/resources/alma/(DE-605)HT012734833.json
@@ -16,7 +16,8 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990108873860206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990108873860206441"
   } ],
   "medium" : [ {
     "id" : "http://rdaregistry.info/termList/RDAMediaType/1003",
@@ -27,7 +28,6 @@
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT012734833#!",
   "language" : [ {
     "label" : "Englisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
@@ -82,7 +82,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-04T15:27:18",
+      "endTime" : "2021-05-18T14:59:31",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -106,5 +106,6 @@
   "natureOfContent" : [ {
     "label" : "Zeitschrift",
     "id" : "http://d-nb.info/gnd/4067488-5"
-  } ]
+  } ],
+  "id" : "http://lobid.org/resources/HT012734833#!"
 }

--- a/src/test/resources/alma/(DE-605)HT012734884.json
+++ b/src/test/resources/alma/(DE-605)HT012734884.json
@@ -17,7 +17,8 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990108874370206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990108874370206441"
   } ],
   "medium" : [ {
     "id" : "http://rdaregistry.info/termList/RDAMediaType/1003",
@@ -28,7 +29,6 @@
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT012734884#!",
   "language" : [ {
     "label" : "Englisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
@@ -89,7 +89,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-04T15:27:19",
+      "endTime" : "2021-05-18T14:59:31",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -145,5 +145,6 @@
       "gndIdentifier" : "4511937-5"
     } ]
   } ],
-  "subjectAltLabel" : [ "Netzpublikation", "Online-Publikation", "Computerdatei im Fernzugriff", "Formschlagwort", "Online-Dokument", "On-line-Dokument", "On-line-Publikation", "Periodikum", "Zeitschriften", "Menschenkunde" ]
+  "subjectAltLabel" : [ "Netzpublikation", "Online-Publikation", "Computerdatei im Fernzugriff", "Formschlagwort", "Online-Dokument", "On-line-Dokument", "On-line-Publikation", "Periodikum", "Zeitschriften", "Menschenkunde" ],
+  "id" : "http://lobid.org/resources/HT012734884#!"
 }

--- a/src/test/resources/alma/(DE-605)HT015011399.json
+++ b/src/test/resources/alma/(DE-605)HT015011399.json
@@ -13,14 +13,16 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990156027740206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990156027740206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991010117289706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991010117289706445"
   }, {
     "id" : "https://lobid.org/item/53209607190006445",
     "type" : [ "POR" ],
@@ -41,7 +43,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT015011399#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -80,7 +81,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-18T14:59:28",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -107,5 +108,6 @@
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "Freie Verschlagwortung durch DE-290"
     }
-  } ]
+  } ],
+  "id" : "http://lobid.org/resources/HT015011399#!"
 }

--- a/src/test/resources/alma/(DE-605)HT015671602.json
+++ b/src/test/resources/alma/(DE-605)HT015671602.json
@@ -17,21 +17,24 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990171142550206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990171142550206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-361#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991011838949706442",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991011838949706442"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991011741359706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991011741359706445"
   }, {
     "id" : "https://lobid.org/item/22278788370006442",
     "type" : [ "HOL" ],
@@ -71,7 +74,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT015671602#!",
   "language" : [ {
     "label" : "Englisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
@@ -126,7 +128,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:52",
+      "endTime" : "2021-05-18T14:59:27",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -174,5 +176,6 @@
       "gndIdentifier" : "7615733-7"
     } ]
   } ],
-  "subjectAltLabel" : [ "FRBR", "Maxwell, Robert LeGrand" ]
+  "subjectAltLabel" : [ "FRBR", "Maxwell, Robert LeGrand" ],
+  "id" : "http://lobid.org/resources/HT015671602#!"
 }

--- a/src/test/resources/alma/(DE-605)HT016709661.json
+++ b/src/test/resources/alma/(DE-605)HT016709661.json
@@ -17,7 +17,8 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990184127410206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990184127410206441"
   }, {
     "id" : "https://lobid.org/item/53726127820006441",
     "type" : [ "POR" ],
@@ -76,7 +77,6 @@
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT016709661#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -133,7 +133,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-18T14:59:31",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -180,5 +180,6 @@
       "label" : "Zeitschrift"
     } ]
   } ],
-  "subjectAltLabel" : [ "Dusseldorf", "Djussel'dorf", "Dyusserudorufu", "Duseerduofu", "Stadtgemeinde Düsseldorf", "Landeshauptstadt Düsseldorf", "Stadt Düsseldorf" ]
+  "subjectAltLabel" : [ "Dusseldorf", "Djussel'dorf", "Dyusserudorufu", "Duseerduofu", "Stadtgemeinde Düsseldorf", "Landeshauptstadt Düsseldorf", "Stadt Düsseldorf" ],
+  "id" : "http://lobid.org/resources/HT016709661#!"
 }

--- a/src/test/resources/alma/(DE-605)HT017015300.json
+++ b/src/test/resources/alma/(DE-605)HT017015300.json
@@ -17,28 +17,32 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990189160110206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990189160110206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991004273939706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991004273939706445"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990183542540206446",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990183542540206446"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990012285250206447",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990012285250206447"
   }, {
     "id" : "https://lobid.org/item/22197228560006445",
     "type" : [ "HOL" ],
@@ -154,7 +158,6 @@
   } ],
   "type" : [ "Thesis", "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT017015300#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -214,7 +217,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-07T14:03:52",
+      "endTime" : "2021-05-18T14:59:29",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -284,5 +287,6 @@
       "gndIdentifier" : "4130615-6"
     } ]
   } ],
-  "subjectAltLabel" : [ "Marbourg", "Universitätsstadt Marburg", "Marburg (Lahn)", "Marburg an der Lahn", "Marburg", "Marburgi", "Marpurgi Cattorum", "Marpurg", "Marpurgum", "Marpurgum Cattorum", "Marburgum Cattorum", "Marburgi Cattorum", "Magistrat der Universitätsstadt Marburg", "Ganztagesschule", "Ganztagschule", "Informelle Bildung", "Nichtschulisches Lernen", "Sozialer Raum", "Raum", "Sozialwissenschaften", "Sozialräume", "Pausenhof", "Schulhöfe", "Pausenplatz" ]
+  "subjectAltLabel" : [ "Marbourg", "Universitätsstadt Marburg", "Marburg (Lahn)", "Marburg an der Lahn", "Marburg", "Marburgi", "Marpurgi Cattorum", "Marpurg", "Marpurgum", "Marpurgum Cattorum", "Marburgum Cattorum", "Marburgi Cattorum", "Magistrat der Universitätsstadt Marburg", "Ganztagesschule", "Ganztagschule", "Informelle Bildung", "Nichtschulisches Lernen", "Sozialer Raum", "Raum", "Sozialwissenschaften", "Sozialräume", "Pausenhof", "Schulhöfe", "Pausenplatz" ],
+  "id" : "http://lobid.org/resources/HT017015300#!"
 }

--- a/src/test/resources/alma/(DE-605)HT017398609.json
+++ b/src/test/resources/alma/(DE-605)HT017398609.json
@@ -17,14 +17,16 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990193094010206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990193094010206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991002994099706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991002994099706445"
   }, {
     "id" : "https://lobid.org/item/22195293920006445",
     "type" : [ "HOL" ],
@@ -46,7 +48,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT017398609#!",
   "language" : [ {
     "label" : "Englisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng"
@@ -93,7 +94,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T16:15:53",
+      "endTime" : "2021-05-18T14:59:32",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -113,5 +114,6 @@
       "id" : "http://creativecommons.org/publicdomain/zero/1.0",
       "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
     } ]
-  }
+  },
+  "id" : "http://lobid.org/resources/HT017398609#!"
 }

--- a/src/test/resources/alma/(DE-605)HT017411546.json
+++ b/src/test/resources/alma/(DE-605)HT017411546.json
@@ -6,7 +6,6 @@
   "oclcNumber" : "1073526105",
   "publication" : [ {
     "location" : "Münster",
-    "location" : "Münster",
     "publicationHistory" : "1951-2004",
     "type" : [ "PublicationEvent" ],
     "publishedBy" : "Regensberg. Historische Kommission, Landschaftsverband Westfalen-Lippe"
@@ -21,7 +20,8 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990193229450206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990193229450206441"
   }, {
     "id" : "https://lobid.org/item/53717168750006441",
     "type" : [ "POR" ],
@@ -64,7 +64,6 @@
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT017411546#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -126,7 +125,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-04T15:27:18",
+      "endTime" : "2021-05-18T14:59:29",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -223,5 +222,6 @@
       "label" : "Online-Publikation"
     } ]
   } ],
-  "subjectAltLabel" : [ "Provinz Westfalen", "Herzogtum Westfalen", "Westphalen", "Westphalie", "Ethnographie", "Volkskunde", "Ethnografie", "Europäische Ethnologie", "Folklore", "Gegenwartsvolkskunde", "Regionalkunde" ]
+  "subjectAltLabel" : [ "Provinz Westfalen", "Herzogtum Westfalen", "Westphalen", "Westphalie", "Ethnographie", "Volkskunde", "Ethnografie", "Europäische Ethnologie", "Folklore", "Gegenwartsvolkskunde", "Regionalkunde" ],
+  "id" : "http://lobid.org/resources/HT017411546#!"
 }

--- a/src/test/resources/alma/(DE-605)HT017664407.json
+++ b/src/test/resources/alma/(DE-605)HT017664407.json
@@ -15,7 +15,8 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990197023370206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990197023370206441"
   }, {
     "id" : "https://lobid.org/item/53723408330006441",
     "type" : [ "POR" ],
@@ -42,7 +43,6 @@
   } ],
   "type" : [ "Periodical", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT017664407#!",
   "language" : [ {
     "label" : "Ägyptisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/egy"
@@ -80,7 +80,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-18T14:59:28",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -101,5 +101,6 @@
       "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
     } ]
   },
-  "subjectAltLabel" : [ "<<al->> Qāhira", "Miṣr al-Qāhira", "AlQāhira", "Al-Qāhira", "Misr el-Kahira", "Al Kahira", "<<Al>> Kahira", "LeCaire", "Le Caire", "Qahîr", "<<al->> Kahira", "al-Kahira", "Il Cairo", "Alkeir", "<<al->>Qāhira", "Cairo", "<<Le>> Caire", "قاهرة", "مصر القاهرة", "مصر" ]
+  "subjectAltLabel" : [ "<<al->> Qāhira", "Miṣr al-Qāhira", "AlQāhira", "Al-Qāhira", "Misr el-Kahira", "Al Kahira", "<<Al>> Kahira", "LeCaire", "Le Caire", "Qahîr", "<<al->> Kahira", "al-Kahira", "Il Cairo", "Alkeir", "<<al->>Qāhira", "Cairo", "<<Le>> Caire", "قاهرة", "مصر القاهرة", "مصر" ],
+  "id" : "http://lobid.org/resources/HT017664407#!"
 }

--- a/src/test/resources/alma/(DE-605)HT019246898.json
+++ b/src/test/resources/alma/(DE-605)HT019246898.json
@@ -16,21 +16,24 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990217478660206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990217478660206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991006917309706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991006917309706445"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-468#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990015137670206447",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990015137670206447"
   }, {
     "id" : "https://lobid.org/item/22194214360006445",
     "type" : [ "HOL" ],
@@ -236,7 +239,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT019246898#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -323,7 +325,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-07T14:03:53",
+      "endTime" : "2021-05-18T14:59:30",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -379,5 +381,6 @@
       "gndIdentifier" : "4112587-3"
     } ]
   } ],
-  "subjectAltLabel" : [ "Architektur", "Perzeption", "Sensorischer Prozess", "Sinnesmodalität", "Sinneswahrnehmung", "Sinnliche Wahrnehmung", "Aisthesis", "Aisthetik", "Wahrnehmungsprozess", "Sensation", "Philosophie", "Baukunst" ]
+  "subjectAltLabel" : [ "Architektur", "Perzeption", "Sensorischer Prozess", "Sinnesmodalität", "Sinneswahrnehmung", "Sinnliche Wahrnehmung", "Aisthesis", "Aisthetik", "Wahrnehmungsprozess", "Sensation", "Philosophie", "Baukunst" ],
+  "id" : "http://lobid.org/resources/HT019246898#!"
 }

--- a/src/test/resources/alma/(DE-605)HT020202475.json
+++ b/src/test/resources/alma/(DE-605)HT020202475.json
@@ -16,14 +16,16 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990363946050206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990363946050206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-290#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991009604019706445",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991009604019706445"
   }, {
     "id" : "https://lobid.org/item/53209365020006445",
     "type" : [ "POR" ],
@@ -44,7 +46,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT020202475#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -93,7 +94,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:50",
+      "endTime" : "2021-05-18T14:59:29",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -129,5 +130,6 @@
       "id" : "https://www.wikidata.org/wiki/Q47524318"
     }
   } ],
-  "subjectAltLabel" : [ "Brojer, Štefan", "Breuer, S." ]
+  "subjectAltLabel" : [ "Brojer, Štefan", "Breuer, S." ],
+  "id" : "http://lobid.org/resources/HT020202475#!"
 }

--- a/src/test/resources/alma/(DE-605)HT020391499.json
+++ b/src/test/resources/alma/(DE-605)HT020391499.json
@@ -15,7 +15,8 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990365842280206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990365842280206441"
   }, {
     "id" : "https://lobid.org/item/53706734800006441",
     "type" : [ "POR" ],
@@ -42,7 +43,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/HT020391499#!",
   "language" : [ {
     "label" : "Französisch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/fre"
@@ -92,7 +92,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-04-30T10:28:49",
+      "endTime" : "2021-05-18T14:59:29",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -112,5 +112,6 @@
       "id" : "http://creativecommons.org/publicdomain/zero/1.0",
       "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
     } ]
-  }
+  },
+  "id" : "http://lobid.org/resources/HT020391499#!"
 }

--- a/src/test/resources/alma/(DE-605)TT003907920.json
+++ b/src/test/resources/alma/(DE-605)TT003907920.json
@@ -18,11 +18,11 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990225056670206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990225056670206441"
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/TT003907920#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -40,7 +40,8 @@
     "type" : "IsPartOfRelation",
     "numbering" : "3",
     "hasSuperordinate" : [ {
-      "id" : "http://lobid.org/resources/HT006855611#!"
+      "id" : "http://lobid.org/resources/HT006855611#!",
+      "label" : "lobid Ressource"
     } ]
   } ],
   "contribution" : [ {
@@ -76,7 +77,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-07T14:03:52",
+      "endTime" : "2021-05-18T14:59:30",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -97,5 +98,6 @@
       "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
     } ]
   },
-  "subjectAltLabel" : [ "Borowski, Peter" ]
+  "subjectAltLabel" : [ "Borowski, Peter" ],
+  "id" : "http://lobid.org/resources/TT003907920#!"
 }

--- a/src/test/resources/alma/(DE-605)TT050421649.json
+++ b/src/test/resources/alma/(DE-605)TT050421649.json
@@ -18,14 +18,16 @@
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/990197293880206441",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "990197293880206441"
   }, {
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-361#!",
       "label" : "lobid Organisation"
     },
     "id" : "https://lobid.org/item/991009118459706442",
-    "type" : [ "MBD" ]
+    "type" : [ "MBD" ],
+    "label" : "991009118459706442"
   }, {
     "id" : "https://lobid.org/item/53717454420006441",
     "type" : [ "POR" ],
@@ -94,7 +96,6 @@
   } ],
   "type" : [ "Book", "BibliographicResource" ],
   "@context" : "http://lobid.org/resources/context.jsonld",
-  "id" : "http://lobid.org/resources/TT050421649#!",
   "language" : [ {
     "label" : "Deutsch",
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger"
@@ -149,7 +150,7 @@
     },
     "resultOf" : {
       "type" : [ "CreateAction" ],
-      "endTime" : "2021-05-03T14:36:40",
+      "endTime" : "2021-05-18T14:59:28",
       "instrument" : {
         "id" : "https://github.com/hbz/lobid-resources",
         "type" : [ "SoftwareApplication" ],
@@ -212,5 +213,6 @@
       },
       "gndIdentifier" : "4337730-0"
     } ]
-  } ]
+  } ],
+  "id" : "http://lobid.org/resources/TT050421649#!"
 }

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -170,6 +170,9 @@
     "geo" : {
       "@id" : "http://schema.org/geo"
     },
+    "almaIdMMS" : {
+      "@id" : "http://purl.org/lobid/lv#almaIdMMS"
+    },
     "zdbId" : {
       "@id" : "http://purl.org/lobid/lv#zdbID"
     },
@@ -458,6 +461,9 @@
     },
     "EditedVolume" : {
       "@id" : "http://purl.org/lobid/lv#EditedVolume"
+    },
+    "currentLocation" : {
+      "@id" : "http://purl.org/lobid/lv#currentLocation"
     },
     "Series" : {
       "@id" : "http://purl.org/ontology/bibo/Series"


### PR DESCRIPTION
This utilizes the EtikettMaker:
the files in the "labels" directory will be used to ensure all ids of all json objects
have a label. It also creates the context.jsonld residing in
web/conf/context.jsonld.

- add almaIdMMS to labels
- add currentLocation to labels
- add newly created context

See #1257.