### PR TITLE
Index related.[isbn|issn]

### DIFF
--- a/src/main/resources/index-config.json
+++ b/src/main/resources/index-config.json
@@ -199,6 +199,12 @@
                   "label" : {
                      "index" : "false",
                      "type" : "text"
+                  },
+                  "issn" : {
+                     "type" : "keyword"
+                  },
+                  "isbn" : {
+                     "type" : "keyword"
                   }
                }
             },


### PR DESCRIPTION
This makes these fields queryable, like:
http://alma.lobid.org/resources/search?q=related.issn:%220955-8810%22&format=json

See #1242.