### PR TITLE
Fix context.json by removing referenceType (#1317)

### DIFF
--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -54,7 +54,6 @@
       "name" : "publishedBy"
    },
    {
-      "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
       "label" : "Beginn",
       "uri" : "http://schema.org/startDate",
       "multilangLabel" : {},
@@ -65,15 +64,13 @@
       "name" : "endDate",
       "multilangLabel" : {},
       "label" : "Ende",
-      "uri" : "http://schema.org/endDate",
-      "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear"
+      "uri" : "http://schema.org/endDate"
    },
    {
       "name" : "endTime",
       "multilangLabel" : {},
       "label" : "Endzeitpunkt",
-      "uri" : "http://schema.org/endTime",
-      "referenceType" : "http://www.w3.org/2001/XMLSchema#dateTime"
+      "uri" : "http://schema.org/endTime"
    },
    {
       "container" : "@set",
@@ -167,7 +164,6 @@
    },
    {
       "multilangLabel" : {},
-      "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear",
       "label" : "Geboren am",
       "uri" : "https://d-nb.info/standards/elementset/gnd#dateOfBirth",
       "name" : "dateOfBirth"
@@ -176,8 +172,7 @@
       "name" : "dateOfDeath",
       "multilangLabel" : {},
       "label" : "Gestorben am",
-      "uri" : "https://d-nb.info/standards/elementset/gnd#dateOfDeath",
-      "referenceType" : "http://www.w3.org/2001/XMLSchema#gYear"
+      "uri" : "https://d-nb.info/standards/elementset/gnd#dateOfDeath"
    },
    {
       "name" : "dateOfBirthAndDeath",

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -4,8 +4,7 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/extent"
     },
     "endDate" : {
-      "@id" : "http://schema.org/endDate",
-      "type" : "http://www.w3.org/2001/XMLSchema#gYear"
+      "@id" : "http://schema.org/endDate"
     },
     "focus" : {
       "@id" : "http://xmlns.com/foaf/0.1/focus"
@@ -111,8 +110,7 @@
       "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfBirthAndDeath"
     },
     "startDate" : {
-      "@id" : "http://schema.org/startDate",
-      "type" : "http://www.w3.org/2001/XMLSchema#gYear"
+      "@id" : "http://schema.org/startDate"
     },
     "object" : {
       "@id" : "http://schema.org/object"
@@ -136,8 +134,7 @@
       "@container" : "@set"
     },
     "dateOfDeath" : {
-      "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfDeath",
-      "type" : "http://www.w3.org/2001/XMLSchema#gYear"
+      "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfDeath"
     },
     "Article" : {
       "@id" : "http://purl.org/ontology/bibo/Article"
@@ -206,8 +203,7 @@
       "@id" : "http://purl.org/lobid/lv#almaMmsId"
     },
     "dateOfBirth" : {
-      "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfBirth",
-      "type" : "http://www.w3.org/2001/XMLSchema#gYear"
+      "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfBirth"
     },
     "abstract" : {
       "@id" : "http://purl.org/dc/terms/abstract",
@@ -242,8 +238,7 @@
       "@container" : "@set"
     },
     "endTime" : {
-      "@id" : "http://schema.org/endTime",
-      "type" : "http://www.w3.org/2001/XMLSchema#dateTime"
+      "@id" : "http://schema.org/endTime"
     },
     "Bibliography" : {
       "@id" : "http://purl.org/lobid/lv#Bibliography"


### PR DESCRIPTION
Follows up  #1318.

Removing the "referenceType" in context-labels.json fixes
"jsonld.SyntaxError: Invalid JSON-LD syntax; a term definition must not contain type".

The types of the resources can be lookuped by following the uris of the fields
(aka predicates).