### PR TITLE
Update metafacture-core dependency to 5.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,72 +16,72 @@
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-io</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-json</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-biblio</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-formeta</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-monitoring</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-strings</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-formatting</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-triples</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-flowcontrol</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metamorph</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-plumbing</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metamorph-test</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-xml</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.metafacture</groupId>
 			<artifactId>metafacture-mangling</artifactId>
-			<version>5.2.0</version>
+			<version>5.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jena</groupId>

--- a/src/main/java/org/lobid/resources/RdfModelFileWriter.java
+++ b/src/main/java/org/lobid/resources/RdfModelFileWriter.java
@@ -61,37 +61,37 @@ public final class RdfModelFileWriter extends DefaultObjectReceiver<Model>
 
 	@Override
 	public String getEncoding() {
-		return filenameUtil.encoding;
+		return filenameUtil.getEncoding();
 	}
 
 	@Override
 	public void setEncoding(final String encoding) {
-		filenameUtil.encoding = encoding;
+		filenameUtil.setEncoding(encoding);
 	}
 
 	@Override
 	public void setTarget(final String target) {
-		filenameUtil.target = target;
+		filenameUtil.setTarget(target);
 	}
 
 	@Override
 	public void setProperty(final String property) {
-		filenameUtil.property = property;
+		filenameUtil.setProperty(property);
 	}
 
 	@Override
 	public void setFileSuffix(final String fileSuffix) {
-		filenameUtil.fileSuffix = fileSuffix;
+		filenameUtil.setFileSuffix(fileSuffix);
 	}
 
 	@Override
 	public void setStartIndex(final int startIndex) {
-		filenameUtil.startIndex = startIndex;
+		filenameUtil.setStartIndex(startIndex);
 	}
 
 	@Override
 	public void setEndIndex(final int endIndex) {
-		filenameUtil.endIndex = endIndex;
+		filenameUtil.setEndIndex(endIndex);
 	}
 
 	/**
@@ -108,7 +108,7 @@ public final class RdfModelFileWriter extends DefaultObjectReceiver<Model>
 		String identifier = null;
 		try {
 			identifier = model
-					.listObjectsOfProperty(model.createProperty(filenameUtil.property))
+					.listObjectsOfProperty(model.createProperty(filenameUtil.getProperty()))
 					.next().toString();
 			LOG.debug("Going to store identifier=" + identifier);
 		} catch (NoSuchElementException e) {
@@ -118,19 +118,19 @@ public final class RdfModelFileWriter extends DefaultObjectReceiver<Model>
 		}
 
 		String directory = identifier;
-		if (directory.length() >= filenameUtil.endIndex) {
+		if (directory.length() >= filenameUtil.getEndIndex()) {
 			directory =
-					directory.substring(filenameUtil.startIndex, filenameUtil.endIndex);
+					directory.substring(filenameUtil.getStartIndex(), filenameUtil.getEndIndex());
 		}
-		final String file = FilenameUtils.concat(filenameUtil.target,
+		final String file = FilenameUtils.concat(filenameUtil.getTarget(),
 				FilenameUtils.concat(directory + File.separator,
-						identifier + "." + filenameUtil.fileSuffix));
+						identifier + "." + filenameUtil.getFileSuffix()));
 		LOG.debug("Write to " + file);
 		filenameUtil.ensurePathExists(new File(file));
 
 		try (
 				final Writer writer = new OutputStreamWriter(new FileOutputStream(file),
-						filenameUtil.encoding)) {
+						filenameUtil.getEncoding())) {
 			final StringWriter tripleWriter = new StringWriter();
 			RDFDataMgr.write(tripleWriter, model, this.serialization);
 			IOUtils.write(tripleWriter.toString(), writer);

--- a/src/main/resources/schemata/metamorph.xsd
+++ b/src/main/resources/schemata/metamorph.xsd
@@ -521,12 +521,17 @@ collector.
           <documentation>Unique name of the lookup table</documentation>
         </annotation>
       </attribute>
+      <attribute name="allowEmptyValues" type="boolean" use="optional" default="false">
+        <annotation>
+          <documentation>Allow empty values in Map.</documentation>
+        </annotation>
+      </attribute>
       <attribute name="files" type="string" use="required">
         <annotation>
           <documentation>Filenames</documentation>
         </annotation>
       </attribute>
-      <attribute name="separator" type="string" use="optional" default="\t">
+      <attribute name="separator" type="string" use="optional" default="&#09;">
         <annotation>
           <documentation>String used in the files to separate key from value.
 </documentation>


### PR DESCRIPTION
In order to be able to upgrade to metafacture-core 5.3.1:

- use getters/setters in RdfModelFileWriter
- define tabulator in own metamorph.xsd as in metafacture-core's metamorph.xsd