### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{fix,gradle,json,md,mwe2,sh,vim,xtext,yml}]
+indent_size = 2
+
+[*.tmLanguage]
+indent_style = tab


### PR DESCRIPTION
The .editorconfig is borrowed from https://github.com/metafacture/metafacture-fix/blob/master/.editorconfig.

It can help to share format and style conventions across diffrent editors.