### PR TITLE
Add focus for spatial #1383

### DIFF
--- a/src/main/resources/alma/fix/subjects.fix
+++ b/src/main/resources/alma/fix/subjects.fix
@@ -204,8 +204,23 @@ do list(path:"084??", "var":"$i")
       set_array("spatial[].$last.type[]","Concept")
       add_field("spatial[].$last.source.id","https://nwbib.de/spatial")
       add_field("spatial[].$last.source.label","Raumsystematik der Nordrhein-Westfälischen Bibliographie")
+      copy_field("$j", "spatial[].$append.focus.id")
     end
   end
 end
 
-replace_all("spatial[].*.notation","https://nwbib.de/spatial#N(.*)$","$1")
+do list(path:"spatial[]", "var":"$i")
+  replace_all("$i.notation","https://nwbib.de/spatial#N(.*)$","$1")
+  lookup("$i.focus.id","src/main/resources/nwbib-spatial.tsv", sep_char:"\t")
+  copy_field("$i.focus.id","$i.focus.label")
+  replace_all("$i.focus.label","^(.*?)\\|.*\\|.*","$1")
+  replace_all("$i.focus.id","^.*\\|(http.*)","$1")
+  set_array("$i.focus.type[]")
+  copy_field("$i.focus.id","$i.focus.type[].$append")
+  lookup("$i.focus.type[].*","src/main/resources/wd_itemLabelTypesCoordinates.tsv", sep_char:"\t")
+  copy_field("$i.focus.type[].$last", "$i.focus.geo.lat")
+  copy_field("$i.focus.type[].$last", "$i.focus.geo.lon")
+  replace_all("$i.focus.type[].*","^.*,(http.*),Point.*","$1")
+  replace_all("$i.focus.geo.lat","^.*,Point\\((.*) .*\\)","$1")
+  replace_all("$i.focus.geo.lon","^.*,Point\\(.* (.*)\\)","$1")
+end

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -128,6 +128,16 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     }
+  }, {
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q1198",
+      "label" : "Nordrhein-Westfalen",
+      "type" : [ "http://www.wikidata.org/entity/Q1221156" ],
+      "geo" : {
+        "lat" : "7.55",
+        "lon" : "51.466666666"
+      }
+    }
   } ],
   "hasItem" : [ {
     "id" : "https://lobid.org/item/990110509950206441",

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -82,6 +82,16 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     }
+  }, {
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q6210",
+      "label" : "Kreis Coesfeld",
+      "type" : [ "http://www.wikidata.org/entity/Q106658" ],
+      "geo" : {
+        "lat" : "7.383333333",
+        "lon" : "51.866666666"
+      }
+    }
   } ],
   "hasItem" : [ {
     "id" : "https://lobid.org/item/990110881770206441",

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -100,12 +100,32 @@
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     }
   }, {
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q8614",
+      "label" : "Westfalen",
+      "type" : [ "http://www.wikidata.org/entity/Q82794" ],
+      "geo" : {
+        "lat" : "8.0",
+        "lon" : "52.0"
+      }
+    }
+  }, {
     "id" : "https://nwbib.de/spatial#Q2742",
     "label" : "Münster",
     "type" : [ "Concept" ],
     "source" : {
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
+    }
+  }, {
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q2742",
+      "label" : "Münster",
+      "type" : [ "Münster,\"http://www.wikidata.org/entity/Q707813, http://www.wikidata.org/entity/Q1549591, http://www.wikidata.org/entity/Q262166, http://www.wikidata.org/entity/Q22865, http://www.wikidata.org/entity/Q42744322\",Point(7.625555555 51.9625)" ],
+      "geo" : {
+        "lat" : "7.625555555",
+        "lon" : "51.9625"
+      }
     }
   } ],
   "hasItem" : [ {

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -117,6 +117,16 @@
       "id" : "https://nwbib.de/spatial",
       "label" : "Raumsystematik der Nordrhein-Westfälischen Bibliographie"
     }
+  }, {
+    "focus" : {
+      "id" : "http://www.wikidata.org/entity/Q2899",
+      "label" : "Mülheim an der Ruhr",
+      "type" : [ "Mülheim an der Ruhr,\"http://www.wikidata.org/entity/Q1549591, http://www.wikidata.org/entity/Q22865\",Point(6.878888888 51.428333333)" ],
+      "geo" : {
+        "lat" : "6.878888888",
+        "lon" : "51.428333333"
+      }
+    }
   } ],
   "hasItem" : [ {
     "id" : "https://lobid.org/item/990210312460206441",


### PR DESCRIPTION
Added the `focus` part of `spatial`.

@dr0i is there still something missing?
@acka47 could you have a look if this is okay like this.

One question I still have there are two `label`s one in `spatial`, one in `focus`. Do they have the same value.
 Also can someone explain `coverage` to me? 

Example of the old morph:
https://github.com/hbz/lobid-resources/blob/f290c597648a9c38c0be24b53779c57387856b2d/src/test/resources/jsonld/BT000113394.json#L53

The `label`s and `notation`s of spatial are not the same as the string-value of `coverage`.