### PR TITLE
Add transformation for Articles in ALMA #1455 and #1314

### DIFF
--- a/src/main/resources/alma/fix/mediumAndType.fix
+++ b/src/main/resources/alma/fix/mediumAndType.fix
@@ -409,6 +409,9 @@ set_array("type[]","BibliographicResource")
 
 # TODO: Transformation needs to be added later.
 
+if any_match("@leaderPos06-07",".a")
+  add_field("type[].$append","Article")
+end
 
 # type: "Bibliography"
 

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -152,6 +152,6 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "Map", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Map", "Book" ],
   "id" : "http://lobid.org/resources/990110509950206441#!"
 }

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -114,7 +114,12 @@
   }, {
     "focus" : {
       "id" : "http://www.wikidata.org/entity/Q1374337",
-      "label" : "Euregio (Sitz: Gronau)"
+      "label" : "Euregio (Sitz: Gronau)",
+      "type" : [ "http://www.wikidata.org/entity/Q1374337" ],
+      "geo" : {
+        "lat" : "http://www.wikidata.org/entity/Q1374337",
+        "lon" : "http://www.wikidata.org/entity/Q1374337"
+      }
     }
   } ],
   "hasItem" : [ {
@@ -130,7 +135,7 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Book" ],
   "contribution" : [ {
     "agent" : {
       "label" : "Prause, Klaus",

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -106,7 +106,7 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Book" ],
   "contribution" : [ {
     "agent" : {
       "label" : "Altekamp, Heinrich",

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -75,7 +75,7 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "EditedVolume", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "EditedVolume", "Book" ],
   "responsibilityStatement" : [ "[hrsg. von] Heinz Lemmermann" ],
   "contribution" : [ {
     "agent" : {

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -85,7 +85,7 @@
     "label" : "Datenträger",
     "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
   } ],
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Book" ],
   "responsibilityStatement" : [ "Claude Debussy. [Text:] (Théodore de Banville)" ],
   "contribution" : [ {
     "agent" : {

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -141,7 +141,7 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Book" ],
   "responsibilityStatement" : [ "Borgmann, Richard" ],
   "contribution" : [ {
     "agent" : {

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -141,7 +141,7 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Book" ],
   "responsibilityStatement" : [ "Heinz Hohensee" ],
   "contribution" : [ {
     "agent" : {

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -121,7 +121,7 @@
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "Article", "Book" ],
   "responsibilityStatement" : [ "Claudia Hiepel" ],
   "contribution" : [ {
     "agent" : {


### PR DESCRIPTION
Related to #1455 and #1314 

@acka47 : Could you help with the TODOs:
```

# TODO: What is Aufsatz/Artikel intended for only monograph, serial or continues ressource component?
# TODO: What about `leader07 a `and `b`? https://www.loc.gov/marc/bibliographic/bdleader.html
```

I only took up  `leader07 a` which is     
a - Monographic component part
but did not transformed:
    b - Serial component part

Also have a look why `"type" : [ "BibliographicResource", "Article", "Book" ],` article seems always accompanied by other `types`