### PR TITLE
Update gitignore to exclude the alephTest for AlmaFix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ stats.*.csv
 java.log
 *log*.gz
 web/scripts/.secrets
+src/test/resources/alma-fix/alephFilesFromIdsOfAlmaTestFiles


### PR DESCRIPTION
Added this so that the corresponding ALEPH files are not tracked.