### PR TITLE
Change "similar" to "sameAs" #1400

### DIFF
--- a/src/main/resources/alma/alma.fix
+++ b/src/main/resources/alma/alma.fix
@@ -56,7 +56,6 @@ retain(
   "sameAs[]",
   "seeAlso[]",
   "shortTitle[]",
-  "similar[]",
   "spatial[]",
   "subject[]",
   "subjectAltLabel[]",

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -435,16 +435,15 @@ end
 
 set_array("inCollection[].*.type[]","Collection")
 
-set_array("similar[]")
 
 do list(path:"doi[]", "var":"$i")
-  copy_field("$i", "similar[].$append.id")
-  replace_all("similar[].$last.id", "^(.*)$","http://dx.doi.org/$1")
+  copy_field("$i", "sameAs[].$append.id")
+  replace_all("sameAs[].$last.id", "^(.*)$","http://dx.doi.org/$1")
 end
 
 do list(path:"urn[]", "var":"$i")
-  copy_field("$i", "similar[].$append.id")
-  replace_all("similar[].$last.id", "^(.*)$","http://nbn-resolving.de/$1")
+  copy_field("$i", "sameAs[].$append.id")
+  replace_all("sameAs[].$last.id", "^(.*)$","http://nbn-resolving.de/$1")
 end
 
 # TODO: is this needed too?
@@ -454,6 +453,8 @@ end
 # 		  </data>
 # 		  <data source="776-1.i" name="http://id.loc.gov/ontologies/bibframe/note" />
 # 	  </entity>
+
+
 
 # predecessor
 

--- a/src/main/resources/labels/context-labels.json
+++ b/src/main/resources/labels/context-labels.json
@@ -689,7 +689,7 @@
       "name" : "sameAs",
       "multilangLabel" : {},
       "label" : "Identisch zu",
-      "uri" : "http://www.w3.org/2002/07/owl#sameAs"
+      "uri" : "http://schema.org/sameAs"
    },
    {
       "multilangLabel" : {},

--- a/src/main/resources/morph-hbz01-to-lobid.xml
+++ b/src/main/resources/morph-hbz01-to-lobid.xml
@@ -1433,7 +1433,7 @@
 		<!-- ####################### -->
 		<!-- ####### hbz ID sameAs ZDB ID -->
 		<!-- ####################### -->
-		<data source="@idzdb" name="http://www.w3.org/2002/07/owl#sameAs">
+		<data source="@idzdb" name="http://schema.org/sameAs">
 			<regexp match="(.*)" format="$[ns-zdb-services]${1}"/>
 		</data>
 		<data source="@idzdb" name="$[ns-lobid-vocab]zdbID"/>
@@ -1475,7 +1475,7 @@
 		<!-- ####################### -->
 		<!-- ####### Set owl:sameAs -->
 		<!-- ####################### -->
-		<data source="@id" name="http://www.w3.org/2002/07/owl#sameAs">
+		<data source="@id" name="http://schema.org/sameAs">
 			<regexp match="(.*)" format="http://hub.culturegraph.org/resource/HBZ-${1}"/>
 		</data>
 		<!-- ####################### -->
@@ -1489,7 +1489,7 @@
 			<regexp match="(.*)" format="$[ns-zdb-services]${1}"/>
 		</data>
 		<data source="025o[-12].a" name="@oclcNumber"/>
-		<data source="@oclcNumber" name="http://www.w3.org/2002/07/owl#sameAs">
+		<data source="@oclcNumber" name="http://schema.org/sameAs">
 			<regexp match="(.*)" format="http://worldcat.org/oclc/${1}"/>
 			<sanitizeUrl></sanitizeUrl>
 		</data>

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -65,6 +65,9 @@
   }, {
     "id" : "http://ld.zdb-services.de/resource/2594002-8",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:3-3091",
+    "label" : "urn:nbn:de:hbz:061:3-3091"
   } ],
   "fulltextOnline" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:3-3091",
@@ -81,10 +84,6 @@
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:3-3091",
-    "label" : "urn:nbn:de:hbz:061:3-3091"
   } ],
   "predecessor" : [ {
     "label" : "Wohnungsmarktbericht",

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -75,6 +75,9 @@
   }, {
     "id" : "http://ld.zdb-services.de/resource/2685248-2",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
+    "label" : "urn:nbn:de:hbz:6-85659520092"
   } ],
   "fulltextOnline" : [ {
     "label" : "Digitalisierung",
@@ -94,10 +97,6 @@
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
-    "label" : "urn:nbn:de:hbz:6-85659520092"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -52,6 +52,9 @@
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-CT003043468",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
+    "label" : "urn:nbn:de:hbz:061:1-249692"
   } ],
   "primaryForm" : [ {
     "id" : "(DE-605)HT017551955",
@@ -77,10 +80,6 @@
     "id" : "http://lobid.org/collections/vl-ulbd#!",
     "type" : [ "Collection" ],
     "label" : "vl-ulbd#!"
-  } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
-    "label" : "urn:nbn:de:hbz:061:1-249692"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -66,6 +66,9 @@
   }, {
     "id" : "http://worldcat.org/oclc/857645183",
     "label" : "OCLC Ressource"
+  }, {
+    "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8",
+    "label" : "978-3-642-32079-8"
   } ],
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
@@ -88,10 +91,6 @@
     "id" : "http://lobid.org/collections/Springer#!",
     "type" : [ "Collection" ],
     "label" : "Springer#!"
-  } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8",
-    "label" : "978-3-642-32079-8"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -60,6 +60,9 @@
   }, {
     "id" : "http://worldcat.org/oclc/1075919546",
     "label" : "OCLC Ressource"
+  }, {
+    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689",
+    "label" : "boehlau.9783412216689"
   } ],
   "description" : [ {
     "label" : "Inhaltstext",
@@ -82,10 +85,6 @@
     "id" : "http://lobid.org/organisations/ZDB-23-DGG#!",
     "label" : "eResource package",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689",
-    "label" : "boehlau.9783412216689"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -52,6 +52,9 @@
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018895767",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:70030352"
   } ],
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
@@ -65,10 +68,6 @@
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:70030352"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -62,6 +62,9 @@
   }, {
     "id" : "http://worldcat.org/oclc/1074423318",
     "label" : "OCLC Ressource"
+  }, {
+    "id" : "http://dx.doi.org/10.4126/FRL01-006399748",
+    "label" : "FRL01-006399748"
   } ],
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
@@ -75,10 +78,6 @@
     "id" : "http://repository.publisso.de",
     "label" : "Fachrepositorium Lebenswissenschaften",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006399748",
-    "label" : "FRL01-006399748"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -60,15 +60,14 @@
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019248596",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -56,6 +56,9 @@
   }, {
     "id" : "http://worldcat.org/oclc/1076035765",
     "label" : "OCLC Ressource"
+  }, {
+    "id" : "http://dx.doi.org/10.4126/FRL01-006410624",
+    "label" : "FRL01-006410624"
   } ],
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
@@ -69,10 +72,6 @@
     "id" : "http://repository.publisso.de",
     "label" : "Fachrepositorium Lebenswissenschaften",
     "type" : [ "Collection" ]
-  } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006410624",
-    "label" : "FRL01-006410624"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -66,8 +66,7 @@
   "sameAs" : [ {
     "id" : "http://worldcat.org/oclc/864921933",
     "label" : "OCLC Ressource"
-  } ],
-  "similar" : [ {
+  }, {
     "id" : "http://nbn-resolving.de/urn:nbn:de:bsz:14-qucosa2-386112",
     "label" : "urn:nbn:de:bsz:14-qucosa2-386112"
   } ],

--- a/src/test/resources/hbz01.es.nt
+++ b/src/test/resources/hbz01.es.nt
@@ -4834,9 +4834,9 @@
 <http://lobid.org/resources/BT000002852#!> <http://purl.org/lobid/lv#subjectAltLabel> "Zeitgeschichte" .
 <http://lobid.org/resources/BT000002852#!> <http://rdaregistry.info/Elements/u/P60493> "wechselvolle Geschichte" .
 <http://lobid.org/resources/BT000002852#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000002852#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000002852> .
 <http://lobid.org/resources/BT000002852#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000002852#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/BT000002852#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000002852> .
 <http://lobid.org/resources/BT000002852#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000002852> .
 <http://lobid.org/resources/BT000002852> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000002852> <http://purl.org/dc/terms/created> "19960513" .
@@ -4870,9 +4870,9 @@
 <http://lobid.org/resources/BT000003404#!> <http://purl.org/ontology/bibo/isbn> "9783575112088" .
 <http://lobid.org/resources/BT000003404#!> <http://rdaregistry.info/Elements/u/P60493> "mit Ortsverzeichnis" .
 <http://lobid.org/resources/BT000003404#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000003404#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000003404> .
 <http://lobid.org/resources/BT000003404#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000003404#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Map> .
-<http://lobid.org/resources/BT000003404#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000003404> .
 <http://lobid.org/resources/BT000003404#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000003404> .
 <http://lobid.org/resources/BT000003404> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000003404> <http://purl.org/dc/terms/created> "19940829" .
@@ -4897,9 +4897,9 @@
 <http://lobid.org/resources/BT000014215#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000014215#!> <http://rdaregistry.info/Elements/u/P60493> "urkundliche Festlegung ... über die 1794 erfolgte Translation der Reliquien der HLG. Drei Könige vom 5. August 1808" .
 <http://lobid.org/resources/BT000014215#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000014215#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000014215> .
 <http://lobid.org/resources/BT000014215#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000014215#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/BT000014215#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000014215> .
 <http://lobid.org/resources/BT000014215#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000014215> .
 <http://lobid.org/resources/BT000014215> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000014215> <http://purl.org/dc/terms/created> "19951023" .
@@ -4921,9 +4921,9 @@
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#hbzID> "BT000040377" .
 <http://lobid.org/resources/BT000040377#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000040377#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000040377#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000040377> .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/BT000040377#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000040377> .
 <http://lobid.org/resources/BT000040377#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000040377> .
 <http://lobid.org/resources/BT000040377> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000040377> <http://purl.org/dc/terms/created> "19960814" .
@@ -4946,9 +4946,9 @@
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/lobid/lv#hbzID> "BT000041593" .
 <http://lobid.org/resources/BT000041593#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000041593#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000041593#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000041593> .
 <http://lobid.org/resources/BT000041593#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000041593#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/BT000041593#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000041593> .
 <http://lobid.org/resources/BT000041593#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000041593> .
 <http://lobid.org/resources/BT000041593> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000041593> <http://purl.org/dc/terms/created> "19960814" .
@@ -4973,9 +4973,9 @@
 <http://lobid.org/resources/BT000067443#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000067443#!> <http://rdaregistry.info/Elements/u/P60493> "Vergleichsunters. zu e. Erfassung aus d. Jahre 1976." .
 <http://lobid.org/resources/BT000067443#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000067443#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000067443> .
 <http://lobid.org/resources/BT000067443#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000067443#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/BT000067443#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000067443> .
 <http://lobid.org/resources/BT000067443#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000067443> .
 <http://lobid.org/resources/BT000067443> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000067443> <http://purl.org/dc/terms/created> "19960816" .
@@ -5021,9 +5021,9 @@
 <http://lobid.org/resources/BT000071273#!> <http://purl.org/lobid/lv#subjectAltLabel> "al-Bābā (1920-2005)" .
 <http://lobid.org/resources/BT000071273#!> <http://rdaregistry.info/Elements/u/P60493> "seine Begegnungen mit d. Diözesen Köln, Münster, Essen, München, Augsburg, Speyer; seine Wallfahrt nach Kevelaer; d. Seligsprechungen von Edith Stein u. Pater Rupert Mayer." .
 <http://lobid.org/resources/BT000071273#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000071273#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000071273> .
 <http://lobid.org/resources/BT000071273#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000071273#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/BT000071273#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000071273> .
 <http://lobid.org/resources/BT000071273#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000071273> .
 <http://lobid.org/resources/BT000071273> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000071273> <http://purl.org/dc/terms/created> "19961211" .
@@ -5050,9 +5050,9 @@
 <http://lobid.org/resources/BT000103077#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000103077#!> <http://rdaregistry.info/Elements/u/P60493> "Schulprobleme u. Schulalltag in e. \"jungen\" Industriestadt vor d. ersten Weltkrieg (Herne)" .
 <http://lobid.org/resources/BT000103077#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000103077#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000103077> .
 <http://lobid.org/resources/BT000103077#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000103077#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/BT000103077#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000103077> .
 <http://lobid.org/resources/BT000103077#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000103077> .
 <http://lobid.org/resources/BT000103077> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000103077> <http://purl.org/dc/terms/created> "19960817" .
@@ -5077,9 +5077,9 @@
 <http://lobid.org/resources/BT000110055#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000110055#!> <http://rdaregistry.info/Elements/u/P60493> "wir schützen unsere Umwelt" .
 <http://lobid.org/resources/BT000110055#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000110055#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000110055> .
 <http://lobid.org/resources/BT000110055#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000110055#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/BT000110055#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000110055> .
 <http://lobid.org/resources/BT000110055#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000110055> .
 <http://lobid.org/resources/BT000110055> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000110055> <http://purl.org/dc/terms/created> "19960817" .
@@ -5105,9 +5105,9 @@
 <http://lobid.org/resources/BT000113394#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/BT000113394#!> <http://rdaregistry.info/Elements/u/P60493> "Arbeitsbücher für d. Sachunterricht im 3. u. 4. Schuljahr über d. Städte u. Kreise d. Ruhrgebiets" .
 <http://lobid.org/resources/BT000113394#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000113394#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000113394> .
 <http://lobid.org/resources/BT000113394#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000113394#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/BT000113394#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000113394> .
 <http://lobid.org/resources/BT000113394#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000113394> .
 <http://lobid.org/resources/BT000113394> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000113394> <http://purl.org/dc/terms/created> "19960905" .
@@ -5141,9 +5141,9 @@
 <http://lobid.org/resources/BT000128754#!> <http://purl.org/lobid/lv#subjectAltLabel> "VfL Borussia Mönchengladbach" .
 <http://lobid.org/resources/BT000128754#!> <http://rdaregistry.info/Elements/u/P60493> "Jugend zwischen zwei Magnetpolen ; nur Animosität gebiert große Spiele" .
 <http://lobid.org/resources/BT000128754#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000128754#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000128754> .
 <http://lobid.org/resources/BT000128754#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000128754#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/BT000128754#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000128754> .
 <http://lobid.org/resources/BT000128754#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000128754> .
 <http://lobid.org/resources/BT000128754> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/BT000128754> <http://purl.org/dc/terms/created> "19970106" .
@@ -5177,9 +5177,9 @@
 <http://lobid.org/resources/BT000168595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Weibliche Erwachsene" .
 <http://lobid.org/resources/BT000168595#!> <http://rdaregistry.info/Elements/u/P60493> "frauenpolitische Konzeptionen im Kulturbetrieb ; Dokumentation einer Anhörung vom 16. Mai 1998" .
 <http://lobid.org/resources/BT000168595#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/BT000168595#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000168595> .
 <http://lobid.org/resources/BT000168595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/BT000168595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/BT000168595#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-BT000168595> .
 <http://lobid.org/resources/BT000168595#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/BT000168595> .
 <http://lobid.org/resources/BT000168595> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/BT000168595> <http://purl.org/dc/terms/created> "19990804" .
@@ -5211,11 +5211,11 @@
 <http://lobid.org/resources/CT001004829#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:0128-1-37874" .
 <http://lobid.org/resources/CT001004829#!> <http://rdaregistry.info/Elements/u/P60493> "Trauerspiel in 5 Akten" .
 <http://lobid.org/resources/CT001004829#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/CT001004829#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-CT001004829> .
 <http://lobid.org/resources/CT001004829#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:0128-1-37874> .
 <http://lobid.org/resources/CT001004829#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/CT001004829#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/CT001004829#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/CT001004829#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-CT001004829> .
 <http://lobid.org/resources/CT001004829#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/CT001004829> .
 <http://lobid.org/resources/CT001004829> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/CT001004829> <http://purl.org/dc/terms/created> "20130528" .
@@ -5244,10 +5244,10 @@
 <http://lobid.org/resources/CT003012479#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:061:2-46125" .
 <http://lobid.org/resources/CT003012479#!> <http://rdaregistry.info/Elements/u/P60493> "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzuführen ; Abonnement suspendu ; eine ganz neue große komische Oper in 2 Aufzügen" .
 <http://lobid.org/resources/CT003012479#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/CT003012479#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-CT003012479> .
 <http://lobid.org/resources/CT003012479#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125> .
 <http://lobid.org/resources/CT003012479#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/CT003012479#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resources/CT003012479#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-CT003012479> .
 <http://lobid.org/resources/CT003012479#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/CT003012479> .
 <http://lobid.org/resources/CT003012479> <http://purl.org/dc/terms/created> "20150420" .
 <http://lobid.org/resources/CT003012479> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -5316,12 +5316,12 @@
 <http://lobid.org/resources/HT000009600#!> <http://rdaregistry.info/Elements/u/P60493> "Der Angestellte" .
 <http://lobid.org/resources/HT000009600#!> <http://rdaregistry.info/Elements/u/P60493> "Zeitschrift der Deutschen Angestellten-Gewerkschaft" .
 <http://lobid.org/resources/HT000009600#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT000009600#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000009600> .
+<http://lobid.org/resources/HT000009600#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/6211-x> .
+<http://lobid.org/resources/HT000009600#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/263589870> .
 <http://lobid.org/resources/HT000009600#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT000009600#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT000009600#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT000009600#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000009600> .
-<http://lobid.org/resources/HT000009600#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/6211-x> .
-<http://lobid.org/resources/HT000009600#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/263589870> .
 <http://lobid.org/resources/HT000009600#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT000009600> .
 <http://lobid.org/resources/HT000009600> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT000009600> <http://purl.org/dc/terms/created> "19991118" .
@@ -5417,9 +5417,9 @@
 <http://lobid.org/resources/HT000052280#!> <http://purl.org/ontology/bibo/isbn> "9780521292658" .
 <http://lobid.org/resources/HT000052280#!> <http://rdaregistry.info/Elements/u/P60493> "an introduction" .
 <http://lobid.org/resources/HT000052280#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT000052280#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000052280> .
 <http://lobid.org/resources/HT000052280#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT000052280#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT000052280#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000052280> .
 <http://lobid.org/resources/HT000052280#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT000052280> .
 <http://lobid.org/resources/HT000052280> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-385#!> .
 <http://lobid.org/resources/HT000052280> <http://purl.org/dc/terms/created> "20020315" .
@@ -5441,10 +5441,10 @@
 <http://lobid.org/resources/HT000290078#!> <http://purl.org/ontology/bibo/isbn> "9783209001733" .
 <http://lobid.org/resources/HT000290078#!> <http://rdaregistry.info/Elements/u/P60493> "NEUE GRAMMATIK IM DEUTSCHUNTERRICHT FUER 10 - 15JAEHRIGE : E. HANDBUCH FUER D. LEHRER ; FACHLICHE ANREGUNGEN U. PRAKTISCHE BEISPIELE MIT VERWENDUNG D. SATZFIGUREN / VERF. VON E. ARBEITSGEMEINSCHAFT IM RAHMEN D. OESTERR. VERSUCHSSCHULWESENS: JOHANN AIGNER .." .
 <http://lobid.org/resources/HT000290078#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT000290078#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000290078> .
 <http://lobid.org/resources/HT000290078#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT000290078#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT000290078#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT000290078#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT000290078> .
 <http://lobid.org/resources/HT000290078#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT000290078> .
 <http://lobid.org/resources/HT000290078> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-290#!> .
 <http://lobid.org/resources/HT000290078> <http://purl.org/dc/terms/created> "19840831" .
@@ -5480,11 +5480,11 @@
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/isbn> "3410104356" .
 <http://lobid.org/resources/HT001039253#!> <http://purl.org/ontology/bibo/isbn> "9783410104353" .
 <http://lobid.org/resources/HT001039253#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT001039253#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001039253> .
 <http://lobid.org/resources/HT001039253#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT001039253#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT001039253#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Standard> .
 <http://lobid.org/resources/HT001039253#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT001039253#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001039253> .
 <http://lobid.org/resources/HT001039253#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT001039253> .
 <http://lobid.org/resources/HT001039253> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-386#!> .
 <http://lobid.org/resources/HT001039253> <http://purl.org/dc/terms/created> "19980615" .
@@ -5508,10 +5508,10 @@
 <http://lobid.org/resources/HT001310215#!> <http://purl.org/lobid/lv#hbzID> "HT001310215" .
 <http://lobid.org/resources/HT001310215#!> <http://rdaregistry.info/Elements/u/P60493> "THE JOURNAL OF THE AMERICAN DENTAL ASSOCIATION / ED.: ROGER H. SCHOLLE" .
 <http://lobid.org/resources/HT001310215#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT001310215#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001310215> .
 <http://lobid.org/resources/HT001310215#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT001310215#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT001310215#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT001310215#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001310215> .
 <http://lobid.org/resources/HT001310215#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT001310215> .
 <http://lobid.org/resources/HT001310215> <http://purl.org/dc/terms/created> "19950206" .
 <http://lobid.org/resources/HT001310215> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -5558,11 +5558,11 @@
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuhochdeutsch" .
 <http://lobid.org/resources/HT001898812#!> <http://purl.org/lobid/lv#subjectAltLabel> "Polnische Sprache" .
 <http://lobid.org/resources/HT001898812#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT001898812#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001898812> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/ReferenceSource> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT001898812#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT001898812> .
 <http://lobid.org/resources/HT001898812#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT001898812> .
 <http://lobid.org/resources/HT001898812> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT001898812> <http://purl.org/dc/terms/created> "19970903" .
@@ -5607,12 +5607,12 @@
 <http://lobid.org/resources/HT002619538#!> <http://rdaregistry.info/Elements/u/P60261> <http://lobid.org/resources/HT007026410#!> .
 <http://lobid.org/resources/HT002619538#!> <http://rdaregistry.info/Elements/u/P60278> <http://lobid.org/resources/HT014419735#!> .
 <http://lobid.org/resources/HT002619538#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT002619538#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT002619538> .
+<http://lobid.org/resources/HT002619538#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/1257-9> .
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Statistics> .
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT002619538#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT002619538> .
-<http://lobid.org/resources/HT002619538#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1257-9> .
 <http://lobid.org/resources/HT002619538#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT002619538> .
 <http://lobid.org/resources/HT002619538> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT002619538> <http://purl.org/dc/terms/created> "19991118" .
@@ -5649,11 +5649,11 @@
 <http://lobid.org/resources/HT003160768#!> <http://purl.org/lobid/lv#subjectAltLabel> "Münster (Westf) (Bezirk)" .
 <http://lobid.org/resources/HT003160768#!> <http://rdaregistry.info/Elements/u/P60327> "Regierungsbezirk Münster" .
 <http://lobid.org/resources/HT003160768#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT003160768#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003160768> .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/MultiVolumeBook> .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT003160768#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003160768> .
 <http://lobid.org/resources/HT003160768#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT003160768> .
 <http://lobid.org/resources/HT003160768> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-385#!> .
 <http://lobid.org/resources/HT003160768> <http://purl.org/dc/terms/created> "19931111" .
@@ -5679,11 +5679,11 @@
 <http://lobid.org/resources/HT003536695#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:bvb:12-bsb10057885-8" .
 <http://lobid.org/resources/HT003536695#!> <http://rdaregistry.info/Elements/u/P60493> "Henrici Regii Ultrajectini Fundamenta physices" .
 <http://lobid.org/resources/HT003536695#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT003536695#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003536695> .
 <http://lobid.org/resources/HT003536695#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:bvb:12-bsb10057885-8> .
 <http://lobid.org/resources/HT003536695#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT003536695#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT003536695#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT003536695#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003536695> .
 <http://lobid.org/resources/HT003536695#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT003536695> .
 <http://lobid.org/resources/HT003536695> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT003536695> <http://purl.org/dc/terms/created> "19900611" .
@@ -5724,10 +5724,10 @@
 <http://lobid.org/resources/HT003651380#!> <http://purl.org/ontology/bibo/isbn> "0889461007" .
 <http://lobid.org/resources/HT003651380#!> <http://purl.org/ontology/bibo/isbn> "9780889461000" .
 <http://lobid.org/resources/HT003651380#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT003651380#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003651380> .
 <http://lobid.org/resources/HT003651380#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT003651380#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#EditedVolume> .
 <http://lobid.org/resources/HT003651380#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT003651380#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003651380> .
 <http://lobid.org/resources/HT003651380#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT003651380> .
 <http://lobid.org/resources/HT003651380> <http://purl.org/dc/terms/created> "19930810" .
 <http://lobid.org/resources/HT003651380> <http://purl.org/dc/terms/modified> "20070127" .
@@ -5752,14 +5752,14 @@
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/ontology/bibo/oclcnum> "224546401" .
 <http://lobid.org/resources/HT003654516#!> <http://purl.org/ontology/bibo/oclcnum> "84927101" .
 <http://lobid.org/resources/HT003654516#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT003654516#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003654516> .
+<http://lobid.org/resources/HT003654516#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/224546401> .
+<http://lobid.org/resources/HT003654516#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/84927101> .
 <http://lobid.org/resources/HT003654516#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT003654516#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT003654516#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Report> .
 <http://lobid.org/resources/HT003654516#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/HT003654516#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT003654516#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT003654516> .
-<http://lobid.org/resources/HT003654516#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/224546401> .
-<http://lobid.org/resources/HT003654516#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/84927101> .
 <http://lobid.org/resources/HT003654516#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT003654516> .
 <http://lobid.org/resources/HT003654516> <http://purl.org/dc/terms/created> "19901130" .
 <http://lobid.org/resources/HT003654516> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -5798,10 +5798,10 @@
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalentwicklungsplan" .
 <http://lobid.org/resources/HT004381366#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionaler Raumordnungsplan" .
 <http://lobid.org/resources/HT004381366#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT004381366#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT004381366> .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT004381366#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT004381366> .
 <http://lobid.org/resources/HT004381366#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT004381366> .
 <http://lobid.org/resources/HT004381366> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT004381366> <http://purl.org/dc/terms/created> "19921203" .
@@ -5828,11 +5828,11 @@
 <http://lobid.org/resources/HT004944075#!> <http://purl.org/ontology/bibo/isbn> "9210162765" .
 <http://lobid.org/resources/HT004944075#!> <http://purl.org/ontology/bibo/isbn> "9789210162760" .
 <http://lobid.org/resources/HT004944075#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT004944075#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT004944075> .
 <http://lobid.org/resources/HT004944075#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT004944075#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT004944075#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/HT004944075#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT004944075#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT004944075> .
 <http://lobid.org/resources/HT004944075#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT004944075> .
 <http://lobid.org/resources/HT004944075> <http://purl.org/dc/terms/created> "19930816" .
 <http://lobid.org/resources/HT004944075> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -5862,11 +5862,11 @@
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sprachkunst" .
 <http://lobid.org/resources/HT005944358#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wortkunst" .
 <http://lobid.org/resources/HT005944358#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT005944358#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT005944358> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT005944358#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT005944358> .
 <http://lobid.org/resources/HT005944358#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT005944358> .
 <http://lobid.org/resources/HT005944358> <http://purl.org/dc/terms/created> "19931226" .
 <http://lobid.org/resources/HT005944358> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -5888,10 +5888,10 @@
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT006266886#!> <http://purl.org/lobid/lv#titleKeyword> "Finzi Contini" .
 <http://lobid.org/resources/HT006266886#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT006266886#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006266886> .
 <http://lobid.org/resources/HT006266886#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT006266886#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT006266886#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT006266886#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006266886> .
 <http://lobid.org/resources/HT006266886#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006266886> .
 <http://lobid.org/resources/HT006266886> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT006266886> <http://purl.org/dc/terms/created> "19981218" .
@@ -5919,10 +5919,10 @@
 <http://lobid.org/resources/HT006698544#!> <http://purl.org/lobid/lv#subjectAltLabel> "Regionalkunde" .
 <http://lobid.org/resources/HT006698544#!> <http://rdaregistry.info/Elements/u/P60493> "mit besonderer Rücksicht auf deutsche Auswanderung und die physischen Verhältnisse des Landes ; mit einem naturwissenschaftlichen Anhange und einer topographisch-geognostisschen Karte von Texas" .
 <http://lobid.org/resources/HT006698544#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT006698544#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006698544> .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT006698544#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006698544> .
 <http://lobid.org/resources/HT006698544#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006698544> .
 <http://lobid.org/resources/HT006698544> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT006698544> <http://purl.org/dc/terms/created> "19950904" .
@@ -5986,9 +5986,9 @@
 <http://lobid.org/resources/HT006699267#!> <http://purl.org/ontology/bibo/isbn> "9783860930762" .
 <http://lobid.org/resources/HT006699267#!> <http://rdaregistry.info/Elements/u/P60493> "Die Āl Sa\u02bfūd und die Folgen des zweiten Golfkrieges" .
 <http://lobid.org/resources/HT006699267#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT006699267#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006699267> .
 <http://lobid.org/resources/HT006699267#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT006699267#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT006699267#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006699267> .
 <http://lobid.org/resources/HT006699267#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006699267> .
 <http://lobid.org/resources/HT006699267> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-294#!> .
 <http://lobid.org/resources/HT006699267> <http://purl.org/dc/terms/created> "19950809" .
@@ -6029,10 +6029,10 @@
 <http://lobid.org/resources/HT006853428#!> <http://purl.org/ontology/bibo/isbn> "9783825303280" .
 <http://lobid.org/resources/HT006853428#!> <http://rdaregistry.info/Elements/u/P60261> _:bnodeDummy .
 <http://lobid.org/resources/HT006853428#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT006853428#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006853428> .
 <http://lobid.org/resources/HT006853428#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT006853428#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT006853428#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT006853428#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006853428> .
 <http://lobid.org/resources/HT006853428#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006853428> .
 <http://lobid.org/resources/HT006853428> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-468#!> .
 <http://lobid.org/resources/HT006853428> <http://purl.org/dc/terms/created> "19960125" .
@@ -6059,11 +6059,11 @@
 <http://lobid.org/resources/HT006926058#!> <http://rdaregistry.info/Elements/u/P60327> "Eisenacher Konferenz" .
 <http://lobid.org/resources/HT006926058#!> <http://rdaregistry.info/Elements/u/P60493> "nach den stenographischen Protokollen hrsg. im Auftr. des Ausschusses der Konferenz" .
 <http://lobid.org/resources/HT006926058#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT006926058#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006926058> .
+<http://lobid.org/resources/HT006926058#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/305133-x> .
 <http://lobid.org/resources/HT006926058#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT006926058#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT006926058#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Proceedings> .
-<http://lobid.org/resources/HT006926058#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006926058> .
-<http://lobid.org/resources/HT006926058#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/305133-x> .
 <http://lobid.org/resources/HT006926058#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006926058> .
 <http://lobid.org/resources/HT006926058> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT006926058> <http://purl.org/dc/terms/created> "19991119" .
@@ -6093,11 +6093,11 @@
 <http://lobid.org/resources/HT006987933#!> <http://purl.org/ontology/bibo/issn> "00129038" .
 <http://lobid.org/resources/HT006987933#!> <http://rdaregistry.info/Elements/u/P60493> "órgano de la Dirección Central de la Acción Católica Española" .
 <http://lobid.org/resources/HT006987933#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT006987933#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006987933> .
+<http://lobid.org/resources/HT006987933#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/626580-7> .
 <http://lobid.org/resources/HT006987933#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT006987933#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Newspaper> .
 <http://lobid.org/resources/HT006987933#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT006987933#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT006987933> .
-<http://lobid.org/resources/HT006987933#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/626580-7> .
 <http://lobid.org/resources/HT006987933#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT006987933> .
 <http://lobid.org/resources/HT006987933> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT006987933> <http://purl.org/dc/terms/created> "19991120" .
@@ -6126,10 +6126,10 @@
 <http://lobid.org/resources/HT007015768#!> <http://rdaregistry.info/Elements/u/P60493> "Dokumentationsbulletin" .
 <http://lobid.org/resources/HT007015768#!> <http://rdaregistry.info/Elements/u/P60517> "A. Sondernummer" .
 <http://lobid.org/resources/HT007015768#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT007015768#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT007015768> .
+<http://lobid.org/resources/HT007015768#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/796481-x> .
 <http://lobid.org/resources/HT007015768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT007015768#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
-<http://lobid.org/resources/HT007015768#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT007015768> .
-<http://lobid.org/resources/HT007015768#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/796481-x> .
 <http://lobid.org/resources/HT007015768#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT007015768> .
 <http://lobid.org/resources/HT007015768> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-16#!> .
 <http://lobid.org/resources/HT007015768> <http://purl.org/dc/terms/created> "19991120" .
@@ -6168,10 +6168,10 @@
 <http://lobid.org/resources/HT007331917#!> <http://purl.org/ontology/bibo/isbn> "3922406661" .
 <http://lobid.org/resources/HT007331917#!> <http://purl.org/ontology/bibo/isbn> "9783922406662" .
 <http://lobid.org/resources/HT007331917#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT007331917#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT007331917> .
 <http://lobid.org/resources/HT007331917#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT007331917#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT007331917#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT007331917#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT007331917> .
 <http://lobid.org/resources/HT007331917#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT007331917> .
 <http://lobid.org/resources/HT007331917> <http://purl.org/dc/terms/created> "19970502" .
 <http://lobid.org/resources/HT007331917> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6192,10 +6192,10 @@
 <http://lobid.org/resources/HT007847893#!> <http://purl.org/lobid/lv#exampleOfWork> _:bnodeDummy .
 <http://lobid.org/resources/HT007847893#!> <http://purl.org/lobid/lv#hbzID> "HT007847893" .
 <http://lobid.org/resources/HT007847893#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT007847893#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT007847893> .
 <http://lobid.org/resources/HT007847893#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT007847893#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT007847893#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT007847893#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT007847893> .
 <http://lobid.org/resources/HT007847893#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT007847893> .
 <http://lobid.org/resources/HT007847893> <http://purl.org/dc/terms/created> "19980105" .
 <http://lobid.org/resources/HT007847893> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6221,9 +6221,9 @@
 <http://lobid.org/resources/HT008359420#!> <http://purl.org/lobid/lv#subjectAltLabel> "Nachwirkung (Rezeption)" .
 <http://lobid.org/resources/HT008359420#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wirkungsgeschichte" .
 <http://lobid.org/resources/HT008359420#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT008359420#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT008359420> .
 <http://lobid.org/resources/HT008359420#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT008359420#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT008359420#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT008359420> .
 <http://lobid.org/resources/HT008359420#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT008359420> .
 <http://lobid.org/resources/HT008359420> <http://purl.org/dc/terms/created> "19980422" .
 <http://lobid.org/resources/HT008359420> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6250,10 +6250,10 @@
 <http://lobid.org/resources/HT008733617#!> <http://purl.org/lobid/lv#hbzID> "HT008733617" .
 <http://lobid.org/resources/HT008733617#!> <http://purl.org/ontology/bibo/edition> "[Mikrofiche-Ausg.]" .
 <http://lobid.org/resources/HT008733617#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT008733617#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT008733617> .
 <http://lobid.org/resources/HT008733617#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT008733617#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT008733617#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT008733617#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT008733617> .
 <http://lobid.org/resources/HT008733617#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT008733617> .
 <http://lobid.org/resources/HT008733617> <http://purl.org/dc/terms/created> "19980716" .
 <http://lobid.org/resources/HT008733617> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6285,9 +6285,9 @@
 <http://lobid.org/resources/HT009054973#!> <http://purl.org/ontology/bibo/isbn> "3454128013" .
 <http://lobid.org/resources/HT009054973#!> <http://purl.org/ontology/bibo/isbn> "9783454128018" .
 <http://lobid.org/resources/HT009054973#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT009054973#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009054973> .
 <http://lobid.org/resources/HT009054973#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT009054973#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT009054973#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009054973> .
 <http://lobid.org/resources/HT009054973#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT009054973> .
 <http://lobid.org/resources/HT009054973> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6-123#!> .
 <http://lobid.org/resources/HT009054973> <http://purl.org/dc/terms/created> "20170331" .
@@ -6309,10 +6309,10 @@
 <http://lobid.org/resources/HT009719670#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT009719670#!> <http://rdaregistry.info/Elements/u/P60493> "extraits de films de Eric Rohmer" .
 <http://lobid.org/resources/HT009719670#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT009719670#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009719670> .
 <http://lobid.org/resources/HT009719670#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT009719670#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/MultiVolumeBook> .
 <http://lobid.org/resources/HT009719670#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT009719670#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009719670> .
 <http://lobid.org/resources/HT009719670#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT009719670> .
 <http://lobid.org/resources/HT009719670> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT009719670> <http://purl.org/dc/terms/created> "19990222" .
@@ -6333,10 +6333,10 @@
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/dc/terms/title> "500 Jahre Bruderschaften Reusrath" .
 <http://lobid.org/resources/HT009993506#!> <http://purl.org/lobid/lv#hbzID> "HT009993506" .
 <http://lobid.org/resources/HT009993506#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT009993506#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009993506> .
 <http://lobid.org/resources/HT009993506#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT009993506#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT009993506#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT009993506#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT009993506> .
 <http://lobid.org/resources/HT009993506#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT009993506> .
 <http://lobid.org/resources/HT009993506> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-Sol1#!> .
 <http://lobid.org/resources/HT009993506> <http://purl.org/dc/terms/created> "19990316" .
@@ -6357,10 +6357,10 @@
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/dc/terms/title> "The Common man in the great Civil War" .
 <http://lobid.org/resources/HT010662586#!> <http://purl.org/lobid/lv#hbzID> "HT010662586" .
 <http://lobid.org/resources/HT010662586#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT010662586#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010662586> .
 <http://lobid.org/resources/HT010662586#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT010662586#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT010662586#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT010662586#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010662586> .
 <http://lobid.org/resources/HT010662586#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT010662586> .
 <http://lobid.org/resources/HT010662586> <http://purl.org/dc/terms/created> "19990818" .
 <http://lobid.org/resources/HT010662586> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6432,11 +6432,11 @@
 <http://lobid.org/resources/HT010726584#!> <http://rdaregistry.info/Elements/u/P60261> <http://lobid.org/resources/HT013889657#!> .
 <http://lobid.org/resources/HT010726584#!> <http://rdaregistry.info/Elements/u/P60493> "devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases" .
 <http://lobid.org/resources/HT010726584#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT010726584#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010726584> .
+<http://lobid.org/resources/HT010726584#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/1472746-8> .
 <http://lobid.org/resources/HT010726584#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT010726584#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT010726584#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT010726584#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT010726584> .
-<http://lobid.org/resources/HT010726584#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1472746-8> .
 <http://lobid.org/resources/HT010726584#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT010726584> .
 <http://lobid.org/resources/HT010726584> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-8007#!> .
 <http://lobid.org/resources/HT010726584> <http://purl.org/dc/terms/created> "19991122" .
@@ -6461,12 +6461,12 @@
 <http://lobid.org/resources/HT012237361#!> <http://rdaregistry.info/Elements/u/P60493> "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz" .
 <http://lobid.org/resources/HT012237361#!> <http://rdaregistry.info/Elements/u/P60517> "L, Finanzen und Steuern. IV. 6, Einheitswerte des Grundvermögens nach der Hauptfeststellung : Gemeindeergebnisse" .
 <http://lobid.org/resources/HT012237361#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012237361#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012237361> .
+<http://lobid.org/resources/HT012237361#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/590016-5> .
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Statistics> .
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012237361#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012237361> .
-<http://lobid.org/resources/HT012237361#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/590016-5> .
 <http://lobid.org/resources/HT012237361#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012237361> .
 <http://lobid.org/resources/HT012237361> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT012237361> <http://purl.org/dc/terms/created> "19991120" .
@@ -6505,12 +6505,12 @@
 <http://lobid.org/resources/HT012734833#!> <http://purl.org/ontology/bibo/shortTitle> "Behav Pharmacol" .
 <http://lobid.org/resources/HT012734833#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4067488-5> .
 <http://lobid.org/resources/HT012734833#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012734833#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012734833> .
+<http://lobid.org/resources/HT012734833#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/1500025-4> .
+<http://lobid.org/resources/HT012734833#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/863021596> .
 <http://lobid.org/resources/HT012734833#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012734833#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT012734833#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012734833#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012734833> .
-<http://lobid.org/resources/HT012734833#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1500025-4> .
-<http://lobid.org/resources/HT012734833#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/863021596> .
 <http://lobid.org/resources/HT012734833#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012734833> .
 <http://lobid.org/resources/HT012734833> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT012734833> <http://purl.org/dc/terms/created> "19991116" .
@@ -6534,11 +6534,11 @@
 <http://lobid.org/resources/HT012796134#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wen-yen" .
 <http://lobid.org/resources/HT012796134#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wenyan" .
 <http://lobid.org/resources/HT012796134#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012796134#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012796134> .
 <http://lobid.org/resources/HT012796134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012796134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT012796134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/ReferenceSource> .
 <http://lobid.org/resources/HT012796134#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012796134#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012796134> .
 <http://lobid.org/resources/HT012796134#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012796134> .
 <http://lobid.org/resources/HT012796134> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-385#!> .
 <http://lobid.org/resources/HT012796134> <http://purl.org/dc/terms/created> "20000823" .
@@ -6560,10 +6560,10 @@
 <http://lobid.org/resources/HT012841230#!> <http://purl.org/lobid/lv#hbzID> "HT012841230" .
 <http://lobid.org/resources/HT012841230#!> <http://rdaregistry.info/Elements/u/P60493> "vom 26. April 1744" .
 <http://lobid.org/resources/HT012841230#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012841230#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012841230> .
 <http://lobid.org/resources/HT012841230#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012841230#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT012841230#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012841230#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012841230> .
 <http://lobid.org/resources/HT012841230#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012841230> .
 <http://lobid.org/resources/HT012841230> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-605#!> .
 <http://lobid.org/resources/HT012841230> <http://purl.org/dc/terms/created> "20001025" .
@@ -6589,10 +6589,10 @@
 <http://lobid.org/resources/HT012895751#!> <http://purl.org/lobid/lv#subjectAltLabel> "Heimatgeschichte" .
 <http://lobid.org/resources/HT012895751#!> <http://rdaregistry.info/Elements/u/P60493> "Informationen für Bürger, Neubürger & Gäste" .
 <http://lobid.org/resources/HT012895751#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012895751#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012895751> .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012895751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012895751> .
 <http://lobid.org/resources/HT012895751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012895751> .
 <http://lobid.org/resources/HT012895751> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT012895751> <http://purl.org/dc/terms/created> "20010111" .
@@ -6682,10 +6682,10 @@
 <http://lobid.org/resources/HT012926727#!> <http://purl.org/ontology/bibo/isbn> "9783642631948" .
 <http://lobid.org/resources/HT012926727#!> <http://rdaregistry.info/Elements/u/P60493> "technische, wirtschaftliche und rechtliche Grundlagen" .
 <http://lobid.org/resources/HT012926727#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012926727#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012926727> .
 <http://lobid.org/resources/HT012926727#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012926727#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT012926727#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012926727#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012926727> .
 <http://lobid.org/resources/HT012926727#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012926727> .
 <http://lobid.org/resources/HT012926727> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-468#!> .
 <http://lobid.org/resources/HT012926727> <http://purl.org/dc/terms/created> "20010220" .
@@ -6736,11 +6736,11 @@
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/lobid/lv#zdbID> "2013112-4" .
 <http://lobid.org/resources/HT012989088#!> <http://purl.org/ontology/bibo/issn> "18758363" .
 <http://lobid.org/resources/HT012989088#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012989088#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012989088> .
+<http://lobid.org/resources/HT012989088#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2013112-4> .
 <http://lobid.org/resources/HT012989088#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012989088#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT012989088#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012989088#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012989088> .
-<http://lobid.org/resources/HT012989088#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2013112-4> .
 <http://lobid.org/resources/HT012989088#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012989088> .
 <http://lobid.org/resources/HT012989088> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6999#!> .
 <http://lobid.org/resources/HT012989088> <http://purl.org/dc/terms/created> "20000515" .
@@ -6769,11 +6769,11 @@
 <http://lobid.org/resources/HT012990825#!> <http://rdaregistry.info/Elements/u/P60261> _:bnodeDummy .
 <http://lobid.org/resources/HT012990825#!> <http://rdaregistry.info/Elements/u/P60493> "international journal on recorded information" .
 <http://lobid.org/resources/HT012990825#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012990825#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012990825> .
+<http://lobid.org/resources/HT012990825#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2014924-4> .
 <http://lobid.org/resources/HT012990825#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012990825#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT012990825#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012990825#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012990825> .
-<http://lobid.org/resources/HT012990825#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2014924-4> .
 <http://lobid.org/resources/HT012990825#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012990825> .
 <http://lobid.org/resources/HT012990825> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT012990825> <http://purl.org/dc/terms/created> "20000530" .
@@ -6803,11 +6803,11 @@
 <http://lobid.org/resources/HT012996101#!> <http://purl.org/lobid/lv#subjectAltLabel> "Universitätsstudium" .
 <http://lobid.org/resources/HT012996101#!> <http://rdaregistry.info/Elements/u/P60517> "Uni-Spiegel" .
 <http://lobid.org/resources/HT012996101#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT012996101#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012996101> .
 <http://lobid.org/resources/HT012996101#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT012996101#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT012996101#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/HT012996101#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT012996101#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT012996101> .
 <http://lobid.org/resources/HT012996101#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT012996101> .
 <http://lobid.org/resources/HT012996101> <http://purl.org/dc/terms/created> "20010504" .
 <http://lobid.org/resources/HT012996101> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6848,13 +6848,13 @@
 <http://lobid.org/resources/HT013056453#!> <http://rdaregistry.info/Elements/u/P60278> <http://lobid.org/resources/HT016084461#!> .
 <http://lobid.org/resources/HT013056453#!> <http://rdaregistry.info/Elements/u/P60493> "internationale Beiträge des Institutes für Spielforschung und Spielpädagogik der Universität Mozarteum Salzburg" .
 <http://lobid.org/resources/HT013056453#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013056453#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013056453> .
+<http://lobid.org/resources/HT013056453#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/1125458-0> .
+<http://lobid.org/resources/HT013056453#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/183350230> .
 <http://lobid.org/resources/HT013056453#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013056453#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT013056453#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
 <http://lobid.org/resources/HT013056453#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013056453#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013056453> .
-<http://lobid.org/resources/HT013056453#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/1125458-0> .
-<http://lobid.org/resources/HT013056453#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/183350230> .
 <http://lobid.org/resources/HT013056453#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013056453> .
 <http://lobid.org/resources/HT013056453> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT013056453> <http://purl.org/dc/terms/created> "19991121" .
@@ -6908,10 +6908,10 @@
 <http://lobid.org/resources/HT013077595#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtdirektor (Coesfeld)" .
 <http://lobid.org/resources/HT013077595#!> <http://rdaregistry.info/Elements/u/P60493> "Kirsten Balke. [Hrsg.: Kreisheimatverein Coesfeld e.V. Red.: Hans-Peter Boer ...]" .
 <http://lobid.org/resources/HT013077595#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013077595#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013077595> .
 <http://lobid.org/resources/HT013077595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013077595#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT013077595#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013077595#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013077595> .
 <http://lobid.org/resources/HT013077595#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013077595> .
 <http://lobid.org/resources/HT013077595> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT013077595> <http://purl.org/dc/terms/created> "20010705" .
@@ -6928,9 +6928,9 @@
 <http://lobid.org/resources/HT013220743#!> <http://purl.org/dc/terms/title> "Oxford European Convention on Human Rights series" .
 <http://lobid.org/resources/HT013220743#!> <http://purl.org/lobid/lv#hbzID> "HT013220743" .
 <http://lobid.org/resources/HT013220743#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013220743#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013220743> .
 <http://lobid.org/resources/HT013220743#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013220743#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
-<http://lobid.org/resources/HT013220743#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013220743> .
 <http://lobid.org/resources/HT013220743#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013220743> .
 <http://lobid.org/resources/HT013220743> <http://purl.org/dc/terms/created> "20011214" .
 <http://lobid.org/resources/HT013220743> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -6960,12 +6960,12 @@
 <http://lobid.org/resources/HT013304490#!> <http://purl.org/ontology/bibo/oclcnum> "635743319" .
 <http://lobid.org/resources/HT013304490#!> <http://rdaregistry.info/Elements/u/P60493> "Magazin für Frauen, Kultur & Luxus" .
 <http://lobid.org/resources/HT013304490#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013304490#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013304490> .
+<http://lobid.org/resources/HT013304490#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2073588-1> .
+<http://lobid.org/resources/HT013304490#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/635743319> .
 <http://lobid.org/resources/HT013304490#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013304490#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT013304490#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013304490#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013304490> .
-<http://lobid.org/resources/HT013304490#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2073588-1> .
-<http://lobid.org/resources/HT013304490#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/635743319> .
 <http://lobid.org/resources/HT013304490#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013304490> .
 <http://lobid.org/resources/HT013304490> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT013304490> <http://purl.org/dc/terms/created> "20020301" .
@@ -7001,10 +7001,10 @@
 <http://lobid.org/resources/HT013480902#!> <http://purl.org/ontology/bibo/isbn> "9781565925090" .
 <http://lobid.org/resources/HT013480902#!> <http://rdaregistry.info/Elements/u/P60493> "the definitive guide" .
 <http://lobid.org/resources/HT013480902#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013480902#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013480902> .
 <http://lobid.org/resources/HT013480902#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013480902#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT013480902#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013480902#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013480902> .
 <http://lobid.org/resources/HT013480902#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013480902> .
 <http://lobid.org/resources/HT013480902> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/HT013480902> <http://purl.org/dc/terms/created> "20021024" .
@@ -7051,11 +7051,11 @@
 <http://lobid.org/resources/HT013532539#!> <http://purl.org/lobid/lv#subjectAltLabel> "Spruchpraxis" .
 <http://lobid.org/resources/HT013532539#!> <http://purl.org/ontology/bibo/edition> "[Mikrofiche-Ausg.]" .
 <http://lobid.org/resources/HT013532539#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013532539#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013532539> .
 <http://lobid.org/resources/HT013532539#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013532539#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT013532539#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/HT013532539#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013532539#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013532539> .
 <http://lobid.org/resources/HT013532539#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013532539> .
 <http://lobid.org/resources/HT013532539> <http://purl.org/dc/terms/created> "20021217" .
 <http://lobid.org/resources/HT013532539> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7086,9 +7086,9 @@
 <http://lobid.org/resources/HT013577568#!> <http://purl.org/lobid/lv#subjectAltLabel> "Römische Zeit" .
 <http://lobid.org/resources/HT013577568#!> <http://rdaregistry.info/Elements/u/P60493> "Mittel- und Niederrhein ca. 70 - 71 v. Chr. anhand germanischer Münzen" .
 <http://lobid.org/resources/HT013577568#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013577568#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013577568> .
 <http://lobid.org/resources/HT013577568#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013577568#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resources/HT013577568#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013577568> .
 <http://lobid.org/resources/HT013577568#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013577568> .
 <http://lobid.org/resources/HT013577568> <http://purl.org/dc/terms/created> "20030212" .
 <http://lobid.org/resources/HT013577568> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7111,10 +7111,10 @@
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/lobid/lv#hbzID> "HT013798403" .
 <http://lobid.org/resources/HT013798403#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT013798403#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013798403#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013798403> .
 <http://lobid.org/resources/HT013798403#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013798403#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT013798403#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013798403#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013798403> .
 <http://lobid.org/resources/HT013798403#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013798403> .
 <http://lobid.org/resources/HT013798403> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-294-18#!> .
 <http://lobid.org/resources/HT013798403> <http://purl.org/dc/terms/created> "20030930" .
@@ -7145,10 +7145,10 @@
 <http://lobid.org/resources/HT013911008#!> <http://purl.org/ontology/bibo/isbn> "3936547041" .
 <http://lobid.org/resources/HT013911008#!> <http://purl.org/ontology/bibo/isbn> "9783936547047" .
 <http://lobid.org/resources/HT013911008#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013911008#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013911008> .
 <http://lobid.org/resources/HT013911008#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013911008#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT013911008#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT013911008#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013911008> .
 <http://lobid.org/resources/HT013911008#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013911008> .
 <http://lobid.org/resources/HT013911008> <http://purl.org/dc/terms/created> "20040202" .
 <http://lobid.org/resources/HT013911008> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7178,9 +7178,9 @@
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Kunstwerk / Restaurierung" .
 <http://lobid.org/resources/HT013925945#!> <http://purl.org/lobid/lv#subjectAltLabel> "Restauration (Bestandserhaltung)" .
 <http://lobid.org/resources/HT013925945#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT013925945#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013925945> .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resources/HT013925945#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT013925945> .
 <http://lobid.org/resources/HT013925945#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT013925945> .
 <http://lobid.org/resources/HT013925945> <http://purl.org/dc/terms/created> "20040216" .
 <http://lobid.org/resources/HT013925945> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7211,12 +7211,12 @@
 <http://lobid.org/resources/HT014015351#!> <http://purl.org/ontology/bibo/isbn> "9783770538478" .
 <http://lobid.org/resources/HT014015351#!> <http://rdaregistry.info/Elements/u/P60493> "Praktiken des Symbolischen ; [Festschrift für Ludwig Jäger zum 60. Geburtstag]" .
 <http://lobid.org/resources/HT014015351#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014015351#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014015351> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#EditedVolume> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Festschrift> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014015351#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014015351> .
 <http://lobid.org/resources/HT014015351#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014015351> .
 <http://lobid.org/resources/HT014015351> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-468#!> .
 <http://lobid.org/resources/HT014015351> <http://purl.org/dc/terms/created> "20040511" .
@@ -7239,10 +7239,10 @@
 <http://lobid.org/resources/HT014046679#!> <http://purl.org/lobid/lv#hbzID> "HT014046679" .
 <http://lobid.org/resources/HT014046679#!> <http://rdaregistry.info/Elements/u/P60493> "das Kommunikationsspiel zur Bewertung weiblichen Verhaltens für 2 - 8 Spielerinnen" .
 <http://lobid.org/resources/HT014046679#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014046679#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014046679> .
 <http://lobid.org/resources/HT014046679#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014046679#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Game> .
 <http://lobid.org/resources/HT014046679#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014046679#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014046679> .
 <http://lobid.org/resources/HT014046679#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014046679> .
 <http://lobid.org/resources/HT014046679> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-Bi10#!> .
 <http://lobid.org/resources/HT014046679> <http://purl.org/dc/terms/created> "20040615" .
@@ -7283,12 +7283,12 @@
 <http://lobid.org/resources/HT014078228#!> <http://rdaregistry.info/Elements/u/P60278> _:bnodeDummy .
 <http://lobid.org/resources/HT014078228#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4067488-5> .
 <http://lobid.org/resources/HT014078228#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014078228#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014078228> .
+<http://lobid.org/resources/HT014078228#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2151120-2> .
+<http://lobid.org/resources/HT014078228#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/1071459233> .
 <http://lobid.org/resources/HT014078228#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014078228#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT014078228#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014078228#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014078228> .
-<http://lobid.org/resources/HT014078228#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2151120-2> .
-<http://lobid.org/resources/HT014078228#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/1071459233> .
 <http://lobid.org/resources/HT014078228#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014078228> .
 <http://lobid.org/resources/HT014078228> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT014078228> <http://purl.org/dc/terms/created> "20040709" .
@@ -7327,13 +7327,13 @@
 <http://lobid.org/resources/HT014176012#!> <http://purl.org/lobid/lv#zdbID> "2163340-X" .
 <http://lobid.org/resources/HT014176012#!> <http://rdaregistry.info/Elements/u/P60493> "Regionale Literaturdokumentation ab Berichtsjahr  ..." .
 <http://lobid.org/resources/HT014176012#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014176012#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014176012> .
+<http://lobid.org/resources/HT014176012#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2163340-X> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Bibliography> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/2000/01/rdf-schema#label> "Nordrhein-Westfälische Bibliographie (NWBib)" .
-<http://lobid.org/resources/HT014176012#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014176012> .
-<http://lobid.org/resources/HT014176012#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2163340-X> .
 <http://lobid.org/resources/HT014176012#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014176012> .
 <http://lobid.org/resources/HT014176012> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT014176012> <http://purl.org/dc/terms/created> "20041006" .
@@ -7376,9 +7376,9 @@
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "le Grand (747-814)" .
 <http://lobid.org/resources/HT014215912#!> <http://purl.org/lobid/lv#subjectAltLabel> "the Great (747-814)" .
 <http://lobid.org/resources/HT014215912#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014215912#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014215912> .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT014215912#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014215912> .
 <http://lobid.org/resources/HT014215912#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014215912> .
 <http://lobid.org/resources/HT014215912> <http://purl.org/dc/terms/created> "20041208" .
 <http://lobid.org/resources/HT014215912> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7412,10 +7412,10 @@
 <http://lobid.org/resources/HT014319164#!> <http://purl.org/lobid/lv#subjectAltLabel> "Skulpturen" .
 <http://lobid.org/resources/HT014319164#!> <http://rdaregistry.info/Elements/u/P60493> "Bildhauer" .
 <http://lobid.org/resources/HT014319164#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014319164#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014319164> .
 <http://lobid.org/resources/HT014319164#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014319164#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT014319164#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014319164#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014319164> .
 <http://lobid.org/resources/HT014319164#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014319164> .
 <http://lobid.org/resources/HT014319164> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT014319164> <http://purl.org/dc/terms/created> "20050322" .
@@ -7439,10 +7439,10 @@
 <http://lobid.org/resources/HT014525099#!> <http://purl.org/lobid/lv#hbzID> "HT014525099" .
 <http://lobid.org/resources/HT014525099#!> <http://rdaregistry.info/Elements/u/P60493> "Christ lag in Todesbanden BWV 4 ; Ein Herz, da seinen Jesum lebend weiß BWV 134 ; Erschallet, ihr Lieder BWV 172 ; Also hat Gott die Welt geliebt BWV 68" .
 <http://lobid.org/resources/HT014525099#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014525099#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014525099> .
 <http://lobid.org/resources/HT014525099#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014525099#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT014525099#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014525099#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014525099> .
 <http://lobid.org/resources/HT014525099#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014525099> .
 <http://lobid.org/resources/HT014525099> <http://purl.org/dc/terms/created> "20051020" .
 <http://lobid.org/resources/HT014525099> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7472,11 +7472,11 @@
 <http://lobid.org/resources/HT014555885#!> <http://purl.org/lobid/lv#zdbID> "2208853-2" .
 <http://lobid.org/resources/HT014555885#!> <http://rdaregistry.info/Elements/u/P60493> "inny wymiar historii" .
 <http://lobid.org/resources/HT014555885#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014555885#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014555885> .
+<http://lobid.org/resources/HT014555885#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2208853-2> .
 <http://lobid.org/resources/HT014555885#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014555885#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT014555885#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014555885#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014555885> .
-<http://lobid.org/resources/HT014555885#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2208853-2> .
 <http://lobid.org/resources/HT014555885#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014555885> .
 <http://lobid.org/resources/HT014555885> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-12#!> .
 <http://lobid.org/resources/HT014555885> <http://purl.org/dc/terms/created> "20051104" .
@@ -7507,11 +7507,11 @@
 <http://lobid.org/resources/HT014681992#!> <http://purl.org/lobid/lv#subjectAltLabel> "Neuss-Selikum (Neuss-Selikum)" .
 <http://lobid.org/resources/HT014681992#!> <http://rdaregistry.info/Elements/u/P60493> "vom 3. bis 4. September" .
 <http://lobid.org/resources/HT014681992#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014681992#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014681992> .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Proceedings> .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT014681992#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014681992> .
 <http://lobid.org/resources/HT014681992#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014681992> .
 <http://lobid.org/resources/HT014681992> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT014681992> <http://purl.org/dc/terms/created> "20060323" .
@@ -7539,12 +7539,12 @@
 <http://lobid.org/resources/HT014846970#!> <http://purl.org/ontology/bibo/issn> "21982597" .
 <http://lobid.org/resources/HT014846970#!> <http://rdaregistry.info/Elements/u/P60493> "(ZDB)" .
 <http://lobid.org/resources/HT014846970#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014846970#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014846970> .
+<http://lobid.org/resources/HT014846970#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2250528-3> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/2000/01/rdf-schema#label> "Zeitschriftendatenbank (ZDB)" .
-<http://lobid.org/resources/HT014846970#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014846970> .
-<http://lobid.org/resources/HT014846970#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2250528-3> .
 <http://lobid.org/resources/HT014846970#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014846970> .
 <http://lobid.org/resources/HT014846970> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT014846970> <http://purl.org/dc/terms/created> "20060911" .
@@ -7576,11 +7576,11 @@
 <http://lobid.org/resources/HT014997977#!> <http://purl.org/ontology/bibo/edition> "1. Aufl." .
 <http://lobid.org/resources/HT014997977#!> <http://rdaregistry.info/Elements/u/P60493> "Leitfaden für den Geschäftsbereich des Landesbetriebes Straßen und Verkehr" .
 <http://lobid.org/resources/HT014997977#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT014997977#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014997977> .
 <http://lobid.org/resources/HT014997977#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:17507513> .
 <http://lobid.org/resources/HT014997977#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT014997977#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT014997977#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
-<http://lobid.org/resources/HT014997977#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT014997977> .
 <http://lobid.org/resources/HT014997977#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT014997977> .
 <http://lobid.org/resources/HT014997977> <http://purl.org/dc/terms/created> "20070222" .
 <http://lobid.org/resources/HT014997977> <http://purl.org/dc/terms/modified> "20180218" .
@@ -7601,11 +7601,11 @@
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/lobid/lv#subjectAltLabel> "Staat Holland" .
 <http://lobid.org/resources/HT015082724#!> <http://purl.org/lobid/lv#subjectAltLabel> "Vereinigte Niederlande" .
 <http://lobid.org/resources/HT015082724#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015082724#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015082724> .
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015082724#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015082724> .
 <http://lobid.org/resources/HT015082724#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015082724> .
 <http://lobid.org/resources/HT015082724> <http://purl.org/dc/terms/created> "20070508" .
 <http://lobid.org/resources/HT015082724> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7637,10 +7637,10 @@
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/lobid/lv#subjectAltLabel> "Goethe, Johann Wolfgang von (Faust et le second Faust)" .
 <http://lobid.org/resources/HT015090208#!> <http://purl.org/ontology/bibo/edition> "DVD-Fassung" .
 <http://lobid.org/resources/HT015090208#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015090208#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015090208> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015090208> .
 <http://lobid.org/resources/HT015090208#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015090208> .
 <http://lobid.org/resources/HT015090208> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT015090208> <http://purl.org/dc/terms/created> "20070511" .
@@ -7664,10 +7664,10 @@
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/ontology/bibo/isbn> "0521402301" .
 <http://lobid.org/resources/HT015183529#!> <http://purl.org/ontology/bibo/isbn> "9780521402309" .
 <http://lobid.org/resources/HT015183529#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015183529#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015183529> .
 <http://lobid.org/resources/HT015183529#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015183529#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015183529#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015183529#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015183529> .
 <http://lobid.org/resources/HT015183529#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015183529> .
 <http://lobid.org/resources/HT015183529> <http://purl.org/dc/terms/created> "20070618" .
 <http://lobid.org/resources/HT015183529> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7717,11 +7717,11 @@
 <http://lobid.org/resources/HT015373288#!> <http://purl.org/lobid/lv#subjectAltLabel> "Veloverkehr" .
 <http://lobid.org/resources/HT015373288#!> <http://purl.org/ontology/bibo/edition> "Stand: Juni 2007" .
 <http://lobid.org/resources/HT015373288#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015373288#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015373288> .
 <http://lobid.org/resources/HT015373288#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015373288#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015373288#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Map> .
 <http://lobid.org/resources/HT015373288#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015373288#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015373288> .
 <http://lobid.org/resources/HT015373288#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015373288> .
 <http://lobid.org/resources/HT015373288> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT015373288> <http://purl.org/dc/terms/created> "20071210" .
@@ -7743,10 +7743,10 @@
 <http://lobid.org/resources/HT015414894#!> <http://purl.org/lobid/lv#hbzID> "HT015414894" .
 <http://lobid.org/resources/HT015414894#!> <http://rdaregistry.info/Elements/u/P60493> "Internationale Krisenkommunikation - eine Herausforderung im 21. Jahrhundert" .
 <http://lobid.org/resources/HT015414894#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015414894#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015414894> .
 <http://lobid.org/resources/HT015414894#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015414894#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT015414894#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015414894#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015414894> .
 <http://lobid.org/resources/HT015414894#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015414894> .
 <http://lobid.org/resources/HT015414894> <http://purl.org/dc/terms/created> "20080125" .
 <http://lobid.org/resources/HT015414894> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7797,9 +7797,9 @@
 <http://lobid.org/resources/HT015425967#!> <http://purl.org/ontology/bibo/isbn> "9979774096" .
 <http://lobid.org/resources/HT015425967#!> <http://purl.org/ontology/bibo/isbn> "997977410X" .
 <http://lobid.org/resources/HT015425967#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015425967#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015425967> .
 <http://lobid.org/resources/HT015425967#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015425967#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT015425967#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015425967> .
 <http://lobid.org/resources/HT015425967#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015425967> .
 <http://lobid.org/resources/HT015425967> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT015425967> <http://purl.org/dc/terms/created> "20080207" .
@@ -7848,10 +7848,10 @@
 <http://lobid.org/resources/HT015440386#!> <http://purl.org/ontology/bibo/isbn> "9783499223921" .
 <http://lobid.org/resources/HT015440386#!> <http://rdaregistry.info/Elements/u/P60493> "Comic ; [nach Motiven aus den Dramen Othello, Macbeth, Romeo & Julia und Ein Sommernachtstraum von William Shakespeare]" .
 <http://lobid.org/resources/HT015440386#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015440386#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015440386> .
 <http://lobid.org/resources/HT015440386#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015440386#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015440386#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015440386#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015440386> .
 <http://lobid.org/resources/HT015440386#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015440386> .
 <http://lobid.org/resources/HT015440386> <http://purl.org/dc/terms/created> "20080220" .
 <http://lobid.org/resources/HT015440386> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -7887,10 +7887,10 @@
 <http://lobid.org/resources/HT015455455#!> <http://purl.org/ontology/bibo/isbn> "9783205776390" .
 <http://lobid.org/resources/HT015455455#!> <http://rdaregistry.info/Elements/u/P60493> "Rivalen bis zur Fusion ; die frühen Jahre des Ferdinand Porsche" .
 <http://lobid.org/resources/HT015455455#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015455455#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015455455> .
 <http://lobid.org/resources/HT015455455#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015455455#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015455455#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015455455#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015455455> .
 <http://lobid.org/resources/HT015455455#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015455455> .
 <http://lobid.org/resources/HT015455455> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-82#!> .
 <http://lobid.org/resources/HT015455455> <http://purl.org/dc/terms/created> "20080304" .
@@ -7926,12 +7926,12 @@
 <http://lobid.org/resources/HT015865114#!> <http://purl.org/lobid/lv#titleKeyword> "Schulbuch Buchner" .
 <http://lobid.org/resources/HT015865114#!> <http://rdaregistry.info/Elements/u/P60493> "die Welt nach 1945" .
 <http://lobid.org/resources/HT015865114#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015865114#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015865114> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Schoolbook> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/MultiVolumeBook> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015865114#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015865114> .
 <http://lobid.org/resources/HT015865114#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015865114> .
 <http://lobid.org/resources/HT015865114> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT015865114> <http://purl.org/dc/terms/created> "20090317" .
@@ -7968,10 +7968,10 @@
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectAltLabel> "Adenauer, ... (1876-1967)" .
 <http://lobid.org/resources/HT015891797#!> <http://purl.org/lobid/lv#subjectAltLabel> "Adenauer, Konrad Hermann Joseph (1876-1967)" .
 <http://lobid.org/resources/HT015891797#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015891797#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015891797> .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015891797#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015891797> .
 <http://lobid.org/resources/HT015891797#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015891797> .
 <http://lobid.org/resources/HT015891797> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-468#!> .
 <http://lobid.org/resources/HT015891797> <http://purl.org/dc/terms/created> "20090407" .
@@ -8022,11 +8022,11 @@
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/ontology/bibo/doi> "10.1787/9789264273085-fr" .
 <http://lobid.org/resources/HT015894164#!> <http://purl.org/ontology/bibo/isbn> "9789264273085" .
 <http://lobid.org/resources/HT015894164#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT015894164#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015894164> .
 <http://lobid.org/resources/HT015894164#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.1787/9789264273085-fr> .
 <http://lobid.org/resources/HT015894164#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT015894164#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT015894164#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT015894164#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT015894164> .
 <http://lobid.org/resources/HT015894164#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT015894164> .
 <http://lobid.org/resources/HT015894164> <http://purl.org/dc/terms/created> "20090408" .
 <http://lobid.org/resources/HT015894164> <http://purl.org/dc/terms/modified> "20120815" .
@@ -8053,10 +8053,10 @@
 <http://lobid.org/resources/HT016135351#!> <http://purl.org/lobid/lv#subjectAltLabel> "Mühle Roberg (Harsewinkel)" .
 <http://lobid.org/resources/HT016135351#!> <http://rdaregistry.info/Elements/u/P60493> "Zeitzeuge und Kleinod in Harsewinkel" .
 <http://lobid.org/resources/HT016135351#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016135351#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016135351> .
 <http://lobid.org/resources/HT016135351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016135351#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT016135351#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016135351#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016135351> .
 <http://lobid.org/resources/HT016135351#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016135351> .
 <http://lobid.org/resources/HT016135351> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT016135351> <http://purl.org/dc/terms/created> "20091118" .
@@ -8097,13 +8097,13 @@
 <http://lobid.org/resources/HT016138627#!> <http://rdaregistry.info/Elements/u/P60278> <http://lobid.org/resources/HT019402953#!> .
 <http://lobid.org/resources/HT016138627#!> <http://rdaregistry.info/Elements/u/P60517> "A. I. AII, AIII - vj, Bevölkerungsvorgänge : im ... Vierteljahr ; (Vorläufige Ergebnisse), Elektronische Ressource" .
 <http://lobid.org/resources/HT016138627#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016138627#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016138627> .
+<http://lobid.org/resources/HT016138627#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2524920-4> .
 <http://lobid.org/resources/HT016138627#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:52061113> .
 <http://lobid.org/resources/HT016138627#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016138627#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Statistics> .
 <http://lobid.org/resources/HT016138627#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT016138627#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016138627#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016138627> .
-<http://lobid.org/resources/HT016138627#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2524920-4> .
 <http://lobid.org/resources/HT016138627#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016138627> .
 <http://lobid.org/resources/HT016138627> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT016138627> <http://purl.org/dc/terms/created> "20091112" .
@@ -8154,11 +8154,11 @@
 <http://lobid.org/resources/HT016382441#!> <http://purl.org/ontology/bibo/isbn> "9783527706495" .
 <http://lobid.org/resources/HT016382441#!> <http://rdaregistry.info/Elements/u/P60493> "[frei wie ein Pinguin ; auf einen Blick: Linux schnell und sicher installieren, KDE, GNOME und GUI geschickt einsetzen, OpenOffice clever nutzen ; alles für Ihr Rendezvous mit dem Pinguin]" .
 <http://lobid.org/resources/HT016382441#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016382441#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer> .
-<http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016382441> .
 <http://lobid.org/resources/HT016382441#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016382441> .
 <http://lobid.org/resources/HT016382441> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-51#!> .
 <http://lobid.org/resources/HT016382441> <http://purl.org/dc/terms/created> "20100607" .
@@ -8183,9 +8183,9 @@
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT016545462#!> <http://purl.org/lobid/lv#subjectAltLabel> "Haus (im weiteren Sinn)" .
 <http://lobid.org/resources/HT016545462#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016545462#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016545462> .
 <http://lobid.org/resources/HT016545462#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016545462#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT016545462#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016545462> .
 <http://lobid.org/resources/HT016545462#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016545462> .
 <http://lobid.org/resources/HT016545462> <http://purl.org/dc/terms/created> "20101012" .
 <http://lobid.org/resources/HT016545462> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -8207,10 +8207,10 @@
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/dc/terms/title> "Jabberwocky" .
 <http://lobid.org/resources/HT016556189#!> <http://purl.org/lobid/lv#hbzID> "HT016556189" .
 <http://lobid.org/resources/HT016556189#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016556189#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016556189> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016556189> .
 <http://lobid.org/resources/HT016556189#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016556189> .
 <http://lobid.org/resources/HT016556189> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT016556189> <http://purl.org/dc/terms/created> "20101019" .
@@ -8239,12 +8239,12 @@
 <http://lobid.org/resources/HT016604323#!> <http://purl.org/lobid/lv#zdbID> "2581964-1" .
 <http://lobid.org/resources/HT016604323#!> <http://rdaregistry.info/Elements/u/P60493> "für das Jahr ..." .
 <http://lobid.org/resources/HT016604323#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016604323#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016604323> .
+<http://lobid.org/resources/HT016604323#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2581964-1> .
 <http://lobid.org/resources/HT016604323#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016604323#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT016604323#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Report> .
 <http://lobid.org/resources/HT016604323#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016604323#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016604323> .
-<http://lobid.org/resources/HT016604323#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2581964-1> .
 <http://lobid.org/resources/HT016604323#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016604323> .
 <http://lobid.org/resources/HT016604323> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT016604323> <http://purl.org/dc/terms/created> "20101116" .
@@ -8269,10 +8269,10 @@
 <http://lobid.org/resources/HT016608165#!> <http://purl.org/lobid/lv#hbzID> "HT016608165" .
 <http://lobid.org/resources/HT016608165#!> <http://rdaregistry.info/Elements/u/P60493> "[L 15]" .
 <http://lobid.org/resources/HT016608165#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016608165#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016608165> .
 <http://lobid.org/resources/HT016608165#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016608165#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016608165#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016608165#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016608165> .
 <http://lobid.org/resources/HT016608165#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016608165> .
 <http://lobid.org/resources/HT016608165> <http://purl.org/dc/terms/created> "20101130" .
 <http://lobid.org/resources/HT016608165> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -8296,12 +8296,12 @@
 <http://lobid.org/resources/HT016618741#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:061-20101201-135613-9" .
 <http://lobid.org/resources/HT016618741#!> <http://rdaregistry.info/Elements/u/P60489> "Düsseldorf, Univ., Diss., 2010" .
 <http://lobid.org/resources/HT016618741#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016618741#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016618741> .
 <http://lobid.org/resources/HT016618741#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:061-20101201-135613-9> .
 <http://lobid.org/resources/HT016618741#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016618741#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT016618741#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
 <http://lobid.org/resources/HT016618741#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016618741#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016618741> .
 <http://lobid.org/resources/HT016618741#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016618741> .
 <http://lobid.org/resources/HT016618741> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT016618741> <http://purl.org/dc/terms/created> "20101207" .
@@ -8324,10 +8324,10 @@
 <http://lobid.org/resources/HT016675714#!> <http://purl.org/ontology/bibo/isbn> "9785999904331" .
 <http://lobid.org/resources/HT016675714#!> <http://rdaregistry.info/Elements/u/P60493> "\u0443\u0447\u0435\u0431\u043d\u043e\u0435 \u043f\u043e\u0441\u043e\u0431\u0438\u0435" .
 <http://lobid.org/resources/HT016675714#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016675714#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016675714> .
 <http://lobid.org/resources/HT016675714#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016675714#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT016675714#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016675714#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016675714> .
 <http://lobid.org/resources/HT016675714#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016675714> .
 <http://lobid.org/resources/HT016675714> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-1116#!> .
 <http://lobid.org/resources/HT016675714> <http://purl.org/dc/terms/created> "20110125" .
@@ -8352,10 +8352,10 @@
 <http://lobid.org/resources/HT016791198#!> <http://purl.org/lobid/lv#hbzID> "HT016791198" .
 <http://lobid.org/resources/HT016791198#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT016791198#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016791198#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016791198> .
 <http://lobid.org/resources/HT016791198#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016791198#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT016791198#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016791198#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016791198> .
 <http://lobid.org/resources/HT016791198#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016791198> .
 <http://lobid.org/resources/HT016791198> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-Kn41#!> .
 <http://lobid.org/resources/HT016791198> <http://purl.org/dc/terms/created> "20110425" .
@@ -8378,12 +8378,12 @@
 <http://lobid.org/resources/HT016925914#!> <http://purl.org/lobid/lv#zdbID> "2621309-6" .
 <http://lobid.org/resources/HT016925914#!> <http://rdaregistry.info/Elements/u/P60493> "Archivserver für elektronische Dokumente und Websites aus Rheinland-Pfalz" .
 <http://lobid.org/resources/HT016925914#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016925914#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016925914> .
+<http://lobid.org/resources/HT016925914#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2621309-6> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.loc.gov/ontologies/bibframe/Collection> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/2000/01/rdf-schema#label> "Edoweb Rheinland-Pfalz" .
-<http://lobid.org/resources/HT016925914#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016925914> .
-<http://lobid.org/resources/HT016925914#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2621309-6> .
 <http://lobid.org/resources/HT016925914#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016925914> .
 <http://lobid.org/resources/HT016925914> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT016925914> <http://purl.org/dc/terms/created> "20110802" .
@@ -8444,13 +8444,13 @@
 <http://lobid.org/resources/HT016987148#!> <http://purl.org/ontology/bibo/doi> "10.4126/38m-000000463" .
 <http://lobid.org/resources/HT016987148#!> <http://rdaregistry.info/Elements/u/P60489> "Köln, Univ., Diss., 2011" .
 <http://lobid.org/resources/HT016987148#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT016987148#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016987148> .
 <http://lobid.org/resources/HT016987148#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.4126/38m-000000463> .
 <http://lobid.org/resources/HT016987148#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000004639> .
 <http://lobid.org/resources/HT016987148#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT016987148#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT016987148#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
 <http://lobid.org/resources/HT016987148#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT016987148#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT016987148> .
 <http://lobid.org/resources/HT016987148#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT016987148> .
 <http://lobid.org/resources/HT016987148> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT016987148> <http://purl.org/dc/terms/created> "20111007" .
@@ -8474,10 +8474,10 @@
 <http://lobid.org/resources/HT017028573#!> <http://purl.org/lobid/lv#zdbID> "2635665-X" .
 <http://lobid.org/resources/HT017028573#!> <http://rdaregistry.info/Elements/u/P60493> "Kösliner allgemeine Zeitung" .
 <http://lobid.org/resources/HT017028573#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017028573#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017028573> .
+<http://lobid.org/resources/HT017028573#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2635665-X> .
 <http://lobid.org/resources/HT017028573#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017028573#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Newspaper> .
-<http://lobid.org/resources/HT017028573#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017028573> .
-<http://lobid.org/resources/HT017028573#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2635665-X> .
 <http://lobid.org/resources/HT017028573#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017028573> .
 <http://lobid.org/resources/HT017028573> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT017028573> <http://purl.org/dc/terms/created> "20111103" .
@@ -8516,10 +8516,10 @@
 <http://lobid.org/resources/HT017066705#!> <http://purl.org/lobid/lv#subjectAltLabel> "Schokoladeindustrie" .
 <http://lobid.org/resources/HT017066705#!> <http://rdaregistry.info/Elements/u/P60493> "Schokoküsse aus Herxheim" .
 <http://lobid.org/resources/HT017066705#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017066705#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017066705> .
 <http://lobid.org/resources/HT017066705#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017066705#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Image> .
 <http://lobid.org/resources/HT017066705#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017066705#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017066705> .
 <http://lobid.org/resources/HT017066705#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017066705> .
 <http://lobid.org/resources/HT017066705> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT017066705> <http://purl.org/dc/terms/created> "20111209" .
@@ -8546,9 +8546,9 @@
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectAltLabel> "Münster (Westf) / Fachbereich Praktische Denkmalpflege und Baukultur" .
 <http://lobid.org/resources/HT017150239#!> <http://purl.org/lobid/lv#subjectAltLabel> "Westfalen-Lippe. Fachbereich Praktische Denkmalpflege" .
 <http://lobid.org/resources/HT017150239#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017150239#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017150239> .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT017150239#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017150239> .
 <http://lobid.org/resources/HT017150239#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017150239> .
 <http://lobid.org/resources/HT017150239> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017150239> <http://purl.org/dc/terms/created> "20120228" .
@@ -8594,12 +8594,12 @@
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:6-85659520092" .
 <http://lobid.org/resources/HT017411546#!> <http://purl.org/lobid/lv#zdbID> "2685248-2" .
 <http://lobid.org/resources/HT017411546#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017411546#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017411546> .
+<http://lobid.org/resources/HT017411546#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2685248-2> .
 <http://lobid.org/resources/HT017411546#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092> .
 <http://lobid.org/resources/HT017411546#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017411546#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT017411546#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017411546#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017411546> .
-<http://lobid.org/resources/HT017411546#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2685248-2> .
 <http://lobid.org/resources/HT017411546#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017411546> .
 <http://lobid.org/resources/HT017411546> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9001#!> .
 <http://lobid.org/resources/HT017411546> <http://purl.org/dc/terms/created> "20121008" .
@@ -8633,10 +8633,10 @@
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Online-Ressource" .
 <http://lobid.org/resources/HT017437638#!> <http://purl.org/ontology/bibo/edition> "1. Aufl." .
 <http://lobid.org/resources/HT017437638#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017437638#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017437638> .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017437638#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017437638> .
 <http://lobid.org/resources/HT017437638#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017437638> .
 <http://lobid.org/resources/HT017437638> <http://purl.org/dc/terms/created> "20121030" .
 <http://lobid.org/resources/HT017437638> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -8659,10 +8659,10 @@
 <http://lobid.org/resources/HT017451384#!> <http://purl.org/lobid/lv#zdbID> "2690442-1" .
 <http://lobid.org/resources/HT017451384#!> <http://rdaregistry.info/Elements/u/P60493> "die ... besten Reisemobil-Stellplätze" .
 <http://lobid.org/resources/HT017451384#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017451384#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017451384> .
+<http://lobid.org/resources/HT017451384#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2690442-1> .
 <http://lobid.org/resources/HT017451384#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017451384#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
-<http://lobid.org/resources/HT017451384#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017451384> .
-<http://lobid.org/resources/HT017451384#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2690442-1> .
 <http://lobid.org/resources/HT017451384#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017451384> .
 <http://lobid.org/resources/HT017451384> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-1241#!> .
 <http://lobid.org/resources/HT017451384> <http://purl.org/dc/terms/created> "20121112" .
@@ -8685,11 +8685,11 @@
 <http://lobid.org/resources/HT017468042#!> <http://purl.org/lobid/lv#hbzID> "HT017468042" .
 <http://lobid.org/resources/HT017468042#!> <http://rdaregistry.info/Elements/u/P60345> "E 006 26 -E 008 47 /N 053 11 -N 051 37" .
 <http://lobid.org/resources/HT017468042#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017468042#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017468042> .
 <http://lobid.org/resources/HT017468042#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017468042#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT017468042#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Map> .
 <http://lobid.org/resources/HT017468042#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017468042#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017468042> .
 <http://lobid.org/resources/HT017468042#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017468042> .
 <http://lobid.org/resources/HT017468042> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017468042> <http://purl.org/dc/terms/created> "20121126" .
@@ -8714,9 +8714,9 @@
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT014176012#!> .
 <http://lobid.org/resources/HT017472134#!> <http://purl.org/lobid/lv#subjectAltLabel> "Familie (Familie)" .
 <http://lobid.org/resources/HT017472134#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017472134#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017472134> .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT017472134#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017472134> .
 <http://lobid.org/resources/HT017472134#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017472134> .
 <http://lobid.org/resources/HT017472134> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT017472134> <http://purl.org/dc/terms/created> "20121129" .
@@ -8745,13 +8745,13 @@
 <http://lobid.org/resources/HT017480009#!> <http://purl.org/ontology/bibo/doi> "10.4126/38m-004826540" .
 <http://lobid.org/resources/HT017480009#!> <http://rdaregistry.info/Elements/u/P60489> "Köln, Univ., Diss., 2012" .
 <http://lobid.org/resources/HT017480009#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017480009#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017480009> .
 <http://lobid.org/resources/HT017480009#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.4126/38m-004826540> .
 <http://lobid.org/resources/HT017480009#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293> .
 <http://lobid.org/resources/HT017480009#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017480009#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT017480009#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
 <http://lobid.org/resources/HT017480009#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017480009#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017480009> .
 <http://lobid.org/resources/HT017480009#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017480009> .
 <http://lobid.org/resources/HT017480009> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT017480009> <http://purl.org/dc/terms/created> "20121206" .
@@ -8805,10 +8805,10 @@
 <http://lobid.org/resources/HT017529028#!> <http://purl.org/ontology/bibo/isbn> "9783451273889" .
 <http://lobid.org/resources/HT017529028#!> <http://rdaregistry.info/Elements/u/P60493> "Studie über Johannes vom Kreuz" .
 <http://lobid.org/resources/HT017529028#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017529028#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017529028> .
 <http://lobid.org/resources/HT017529028#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017529028#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT017529028#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017529028#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017529028> .
 <http://lobid.org/resources/HT017529028#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017529028> .
 <http://lobid.org/resources/HT017529028> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-1032#!> .
 <http://lobid.org/resources/HT017529028> <http://purl.org/dc/terms/created> "20130131" .
@@ -8846,9 +8846,9 @@
 <http://lobid.org/resources/HT017536715#!> <http://purl.org/lobid/lv#subjectAltLabel> "Mülheim, Ruhr" .
 <http://lobid.org/resources/HT017536715#!> <http://rdaregistry.info/Elements/u/P60493> "Luthers Erben an der Ruhr" .
 <http://lobid.org/resources/HT017536715#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017536715#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017536715> .
 <http://lobid.org/resources/HT017536715#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017536715#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT017536715#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017536715> .
 <http://lobid.org/resources/HT017536715#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017536715> .
 <http://lobid.org/resources/HT017536715> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT017536715> <http://purl.org/dc/terms/created> "20130206" .
@@ -8879,11 +8879,11 @@
 <http://lobid.org/resources/HT017642656#!> <http://rdaregistry.info/Elements/u/P60261> _:bnodeDummy .
 <http://lobid.org/resources/HT017642656#!> <http://rdaregistry.info/Elements/u/P60493> "revue semestrielle" .
 <http://lobid.org/resources/HT017642656#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017642656#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017642656> .
+<http://lobid.org/resources/HT017642656#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2716332-5> .
 <http://lobid.org/resources/HT017642656#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017642656#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT017642656#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017642656#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017642656> .
-<http://lobid.org/resources/HT017642656#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2716332-5> .
 <http://lobid.org/resources/HT017642656#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017642656> .
 <http://lobid.org/resources/HT017642656> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-8007#!> .
 <http://lobid.org/resources/HT017642656> <http://purl.org/dc/terms/created> "20130515" .
@@ -8913,9 +8913,9 @@
 <http://lobid.org/resources/HT017749491#!> <http://purl.org/ontology/bibo/isbn> "9783829310864" .
 <http://lobid.org/resources/HT017749491#!> <http://rdaregistry.info/Elements/u/P60493> "(LHundG NRW) ; Kommentar" .
 <http://lobid.org/resources/HT017749491#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017749491#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017749491> .
 <http://lobid.org/resources/HT017749491#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017749491#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT017749491#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017749491> .
 <http://lobid.org/resources/HT017749491#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017749491> .
 <http://lobid.org/resources/HT017749491> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-708#!> .
 <http://lobid.org/resources/HT017749491> <http://purl.org/dc/terms/created> "20130826" .
@@ -8951,10 +8951,10 @@
 <http://lobid.org/resources/HT017894012#!> <http://purl.org/ontology/bibo/issn> "02704013" .
 <http://lobid.org/resources/HT017894012#!> <http://rdaregistry.info/Elements/u/P60493> "a research annual" .
 <http://lobid.org/resources/HT017894012#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT017894012#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017894012> .
 <http://lobid.org/resources/HT017894012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT017894012#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
 <http://lobid.org/resources/HT017894012#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT017894012#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT017894012> .
 <http://lobid.org/resources/HT017894012#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT017894012> .
 <http://lobid.org/resources/HT017894012> <http://purl.org/dc/terms/created> "20131119" .
 <http://lobid.org/resources/HT017894012> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9008,9 +9008,9 @@
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverordnetenversammlung (Düsseldorf)" .
 <http://lobid.org/resources/HT018131501#!> <http://purl.org/lobid/lv#subjectAltLabel> "Stadtverwaltung (Düsseldorf)" .
 <http://lobid.org/resources/HT018131501#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018131501#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018131501> .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT018131501#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018131501> .
 <http://lobid.org/resources/HT018131501#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018131501> .
 <http://lobid.org/resources/HT018131501> <http://purl.org/dc/terms/created> "20140115" .
 <http://lobid.org/resources/HT018131501> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9047,12 +9047,12 @@
 <http://lobid.org/resources/HT018138676#!> <http://rdaregistry.info/Elements/u/P60278> _:bnodeDummy .
 <http://lobid.org/resources/HT018138676#!> <http://rdaregistry.info/Elements/u/P60493> "für Politik, Handel und Literatur" .
 <http://lobid.org/resources/HT018138676#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018138676#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018138676> .
+<http://lobid.org/resources/HT018138676#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2751526-6> .
 <http://lobid.org/resources/HT018138676#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:gbv:46:1-6622> .
 <http://lobid.org/resources/HT018138676#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018138676#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Newspaper> .
 <http://lobid.org/resources/HT018138676#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018138676#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018138676> .
-<http://lobid.org/resources/HT018138676#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2751526-6> .
 <http://lobid.org/resources/HT018138676#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018138676> .
 <http://lobid.org/resources/HT018138676> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-12#!> .
 <http://lobid.org/resources/HT018138676> <http://purl.org/dc/terms/created> "20140120" .
@@ -9074,10 +9074,10 @@
 <http://lobid.org/resources/HT018147158#!> <http://purl.org/lobid/lv#zdbID> "2754074-1" .
 <http://lobid.org/resources/HT018147158#!> <http://rdaregistry.info/Elements/u/P60327> "Die Ehrenfelder, Gemeinnützige Wohnungsgenossenschaft eG" .
 <http://lobid.org/resources/HT018147158#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018147158#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018147158> .
+<http://lobid.org/resources/HT018147158#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2754074-1> .
 <http://lobid.org/resources/HT018147158#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018147158#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
-<http://lobid.org/resources/HT018147158#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018147158> .
-<http://lobid.org/resources/HT018147158#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2754074-1> .
 <http://lobid.org/resources/HT018147158#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018147158> .
 <http://lobid.org/resources/HT018147158> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-9999#!> .
 <http://lobid.org/resources/HT018147158> <http://purl.org/dc/terms/created> "20140127" .
@@ -9098,10 +9098,10 @@
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/lobid/lv#hbzID> "HT018187026" .
 <http://lobid.org/resources/HT018187026#!> <http://purl.org/ontology/bibo/issn> "21955131" .
 <http://lobid.org/resources/HT018187026#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018187026#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018187026> .
 <http://lobid.org/resources/HT018187026#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018187026#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
 <http://lobid.org/resources/HT018187026#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018187026#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018187026> .
 <http://lobid.org/resources/HT018187026#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018187026> .
 <http://lobid.org/resources/HT018187026> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-361#!> .
 <http://lobid.org/resources/HT018187026> <http://purl.org/dc/terms/created> "20140304" .
@@ -9149,12 +9149,12 @@
 <http://lobid.org/resources/HT018239864#!> <http://rdaregistry.info/Elements/u/P60489> "Zugl., Göttingen, Univ., Diss., 2013" .
 <http://lobid.org/resources/HT018239864#!> <http://rdaregistry.info/Elements/u/P60493> "narrative Verfahren und literarische Autorschaft im Gesamtwerk" .
 <http://lobid.org/resources/HT018239864#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018239864#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018239864> .
 <http://lobid.org/resources/HT018239864#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018239864#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018239864#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
 <http://lobid.org/resources/HT018239864#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
 <http://lobid.org/resources/HT018239864#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764418&custom_att_2=simple_viewer> .
-<http://lobid.org/resources/HT018239864#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018239864> .
 <http://lobid.org/resources/HT018239864#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018239864> .
 <http://lobid.org/resources/HT018239864> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/HT018239864> <http://purl.org/dc/terms/created> "20140423" .
@@ -9189,13 +9189,13 @@
 <http://lobid.org/resources/HT018260267#!> <http://purl.org/ontology/bibo/oclcnum> "1075956736" .
 <http://lobid.org/resources/HT018260267#!> <http://rdaregistry.info/Elements/u/P60345> "E 007 30 -E 007 40 /N 052 36 -N 052 30" .
 <http://lobid.org/resources/HT018260267#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018260267#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018260267> .
+<http://lobid.org/resources/HT018260267#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/1067791026> .
+<http://lobid.org/resources/HT018260267#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/1075956736> .
 <http://lobid.org/resources/HT018260267#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018260267#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018260267#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Map> .
 <http://lobid.org/resources/HT018260267#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018260267#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018260267> .
-<http://lobid.org/resources/HT018260267#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/1067791026> .
-<http://lobid.org/resources/HT018260267#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/1075956736> .
 <http://lobid.org/resources/HT018260267#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018260267> .
 <http://lobid.org/resources/HT018260267> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT018260267> <http://purl.org/dc/terms/created> "20140514" .
@@ -9280,10 +9280,10 @@
 <http://lobid.org/resources/HT018290299#!> <http://purl.org/ontology/bibo/isbn> "9783954513673" .
 <http://lobid.org/resources/HT018290299#!> <http://rdaregistry.info/Elements/u/P60493> "Auszüge aus 500 Interviews mit ehemaligen Zwangsarbeiterinnen und Zwangsarbeitern" .
 <http://lobid.org/resources/HT018290299#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018290299#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018290299> .
 <http://lobid.org/resources/HT018290299#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018290299#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018290299#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018290299#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018290299> .
 <http://lobid.org/resources/HT018290299#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018290299> .
 <http://lobid.org/resources/HT018290299> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT018290299> <http://purl.org/dc/terms/created> "20140610" .
@@ -9322,13 +9322,13 @@
 <http://lobid.org/resources/HT018295975#!> <http://purl.org/ontology/bibo/isbn> "9783943539233" .
 <http://lobid.org/resources/HT018295975#!> <http://rdaregistry.info/Elements/u/P60493> "Bonn - Koblenz - Weimar - Meiningen ; Festschrift für Johannes Mötsch zum 65. Geburtstag" .
 <http://lobid.org/resources/HT018295975#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018295975#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018295975> .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#EditedVolume> .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Festschrift> .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852708&custom_att_2=simple_viewer> .
-<http://lobid.org/resources/HT018295975#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018295975> .
 <http://lobid.org/resources/HT018295975#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018295975> .
 <http://lobid.org/resources/HT018295975> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT018295975> <http://purl.org/dc/terms/created> "20140616" .
@@ -9350,9 +9350,9 @@
 <http://lobid.org/resources/HT018305016#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT018305016#!> <http://rdaregistry.info/Elements/u/P60493> "Sonnabend, den 31. Januar ; Sonntag, den 1. Februar ; abends 7 Uhr ; Dramatische Chronik in 6 Scenen und einem Epilog" .
 <http://lobid.org/resources/HT018305016#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018305016#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018305016> .
 <http://lobid.org/resources/HT018305016#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018305016#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT018305016#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018305016> .
 <http://lobid.org/resources/HT018305016#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018305016> .
 <http://lobid.org/resources/HT018305016> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018305016> <http://purl.org/dc/terms/created> "20140625" .
@@ -9383,9 +9383,9 @@
 <http://lobid.org/resources/HT018312899#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wirkungsgeschichte" .
 <http://lobid.org/resources/HT018312899#!> <http://rdaregistry.info/Elements/u/P60493> "der Cid als Zeit- und Gattungskritik" .
 <http://lobid.org/resources/HT018312899#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018312899#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018312899> .
 <http://lobid.org/resources/HT018312899#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018312899#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT018312899#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018312899> .
 <http://lobid.org/resources/HT018312899#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018312899> .
 <http://lobid.org/resources/HT018312899> <http://purl.org/dc/terms/created> "20140702" .
 <http://lobid.org/resources/HT018312899> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9417,10 +9417,10 @@
 <http://lobid.org/resources/HT018454638#!> <http://purl.org/lobid/lv#subjectAltLabel> "Pfarrgemeinderat Sankt Antonius Abbas Herkenrath" .
 <http://lobid.org/resources/HT018454638#!> <http://rdaregistry.info/Elements/u/P60493> "Festschrift zum Jubiläum 2014 in St. Antonius Abbas, Herkenrath ; Ausstellungsbegleiter" .
 <http://lobid.org/resources/HT018454638#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018454638#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018454638> .
 <http://lobid.org/resources/HT018454638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018454638#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018454638#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018454638#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018454638> .
 <http://lobid.org/resources/HT018454638#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018454638> .
 <http://lobid.org/resources/HT018454638> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018454638> <http://purl.org/dc/terms/created> "20141111" .
@@ -9480,12 +9480,12 @@
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/ontology/bibo/doi> "10.7788/boehlau.9783412216689" .
 <http://lobid.org/resources/HT018468645#!> <http://purl.org/ontology/bibo/isbn> "9783412216689" .
 <http://lobid.org/resources/HT018468645#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018468645#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018468645> .
 <http://lobid.org/resources/HT018468645#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.7788/boehlau.9783412216689> .
 <http://lobid.org/resources/HT018468645#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018468645#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#EditedVolume> .
 <http://lobid.org/resources/HT018468645#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018468645#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018468645#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018468645> .
 <http://lobid.org/resources/HT018468645#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018468645> .
 <http://lobid.org/resources/HT018468645> <http://purl.org/dc/terms/created> "20141125" .
 <http://lobid.org/resources/HT018468645> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9520,11 +9520,11 @@
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#subjectAltLabel> "Oberrheinlande" .
 <http://lobid.org/resources/HT018585406#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:02-edoweb:70000475" .
 <http://lobid.org/resources/HT018585406#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018585406#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018585406> .
 <http://lobid.org/resources/HT018585406#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70000475> .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018585406#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018585406> .
 <http://lobid.org/resources/HT018585406#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018585406> .
 <http://lobid.org/resources/HT018585406> <http://purl.org/dc/terms/created> "20150319" .
 <http://lobid.org/resources/HT018585406> <http://purl.org/dc/terms/modified> "20180227" .
@@ -9662,12 +9662,12 @@
 <http://lobid.org/resources/HT018612706#!> <http://rdaregistry.info/Elements/u/P60493> "[... anlässlich der gleichnamigen Ausstellung auf der ART COLOGNE 16. - 19.4.2015, und im ZADIK, 4.5. - 28.8.2015]" .
 <http://lobid.org/resources/HT018612706#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4135467-9> .
 <http://lobid.org/resources/HT018612706#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018612706#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018612706> .
+<http://lobid.org/resources/HT018612706#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/907939649> .
 <http://lobid.org/resources/HT018612706#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018612706#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018612706#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Proceedings> .
 <http://lobid.org/resources/HT018612706#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018612706#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018612706> .
-<http://lobid.org/resources/HT018612706#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/907939649> .
 <http://lobid.org/resources/HT018612706#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018612706> .
 <http://lobid.org/resources/HT018612706> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018612706> <http://purl.org/dc/terms/created> "20150421" .
@@ -9723,11 +9723,11 @@
 <http://lobid.org/resources/HT018617137#!> <http://purl.org/ontology/bibo/isbn> "9783981642216" .
 <http://lobid.org/resources/HT018617137#!> <http://rdaregistry.info/Elements/u/P60493> "Forschung gestaltet unsere Lebenswelten" .
 <http://lobid.org/resources/HT018617137#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018617137#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018617137> .
 <http://lobid.org/resources/HT018617137#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128> .
 <http://lobid.org/resources/HT018617137#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018617137#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018617137#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018617137#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018617137> .
 <http://lobid.org/resources/HT018617137#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018617137> .
 <http://lobid.org/resources/HT018617137> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT018617137> <http://purl.org/dc/terms/created> "20150424" .
@@ -9758,13 +9758,13 @@
 <http://lobid.org/resources/HT018700720#!> <http://purl.org/ontology/bibo/isbn> "9783942816618" .
 <http://lobid.org/resources/HT018700720#!> <http://rdaregistry.info/Elements/u/P60493> "Expertise zur Lebenslage von Menschen im Alter über 80 Jahren" .
 <http://lobid.org/resources/HT018700720#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018700720#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018700720> .
 <http://lobid.org/resources/HT018700720#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.4126/38m-006326817> .
 <http://lobid.org/resources/HT018700720#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:5:2-135798> .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Report> .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018700720#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018700720> .
 <http://lobid.org/resources/HT018700720#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018700720> .
 <http://lobid.org/resources/HT018700720> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/HT018700720> <http://purl.org/dc/terms/created> "20150716" .
@@ -9791,11 +9791,11 @@
 <http://lobid.org/resources/HT018703339#!> <http://purl.org/lobid/lv#inCollection> <http://repository.publisso.de> .
 <http://lobid.org/resources/HT018703339#!> <http://purl.org/ontology/bibo/doi> "10.17629/www.diagnosticpathology.eu-2015-1:14" .
 <http://lobid.org/resources/HT018703339#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018703339#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018703339> .
 <http://lobid.org/resources/HT018703339#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.17629/www.diagnosticpathology.eu-2015-1:14> .
 <http://lobid.org/resources/HT018703339#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018703339#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT018703339#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018703339#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018703339> .
 <http://lobid.org/resources/HT018703339#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018703339> .
 <http://lobid.org/resources/HT018703339> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018703339> <http://purl.org/dc/terms/created> "20150720" .
@@ -9815,11 +9815,11 @@
 <http://lobid.org/resources/HT018722247#!> <http://purl.org/lobid/lv#hbzID> "HT018722247" .
 <http://lobid.org/resources/HT018722247#!> <http://purl.org/lobid/lv#inCollection> <http://repository.publisso.de> .
 <http://lobid.org/resources/HT018722247#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018722247#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018722247> .
 <http://lobid.org/resources/HT018722247#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018722247#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Statistics> .
 <http://lobid.org/resources/HT018722247#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Periodical> .
 <http://lobid.org/resources/HT018722247#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018722247#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018722247> .
 <http://lobid.org/resources/HT018722247#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018722247> .
 <http://lobid.org/resources/HT018722247> <http://purl.org/dc/terms/created> "20150810" .
 <http://lobid.org/resources/HT018722247> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9845,9 +9845,9 @@
 <http://lobid.org/resources/HT018726005#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT016356466#!> .
 <http://lobid.org/resources/HT018726005#!> <http://rdaregistry.info/Elements/u/P60493> "die Parallelwelten des Ingolf Lück" .
 <http://lobid.org/resources/HT018726005#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018726005#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018726005> .
 <http://lobid.org/resources/HT018726005#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018726005#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT018726005#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018726005> .
 <http://lobid.org/resources/HT018726005#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018726005> .
 <http://lobid.org/resources/HT018726005> <http://purl.org/dc/terms/created> "20150813" .
 <http://lobid.org/resources/HT018726005> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9874,11 +9874,11 @@
 <http://lobid.org/resources/HT018770176#!> <http://rdaregistry.info/Elements/u/P60493> "zugleich ein Beitrag zur Strafzumessungsrelevanz des Vor- und Nachtatverhaltens" .
 <http://lobid.org/resources/HT018770176#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4113937-9> .
 <http://lobid.org/resources/HT018770176#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018770176#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018770176> .
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018770176#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018770176> .
 <http://lobid.org/resources/HT018770176#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018770176> .
 <http://lobid.org/resources/HT018770176> <http://purl.org/dc/terms/created> "20151002" .
 <http://lobid.org/resources/HT018770176> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9905,10 +9905,10 @@
 <http://lobid.org/resources/HT018771475#!> <http://purl.org/lobid/lv#subjectAltLabel> "7. Schloss Bensberg Classics" .
 <http://lobid.org/resources/HT018771475#!> <http://rdaregistry.info/Elements/u/P60493> "17. bis 19. Juli 2015" .
 <http://lobid.org/resources/HT018771475#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018771475#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018771475> .
 <http://lobid.org/resources/HT018771475#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018771475#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018771475#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Proceedings> .
-<http://lobid.org/resources/HT018771475#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018771475> .
 <http://lobid.org/resources/HT018771475#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018771475> .
 <http://lobid.org/resources/HT018771475> <http://purl.org/dc/terms/created> "20151005" .
 <http://lobid.org/resources/HT018771475> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9927,10 +9927,10 @@
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/lobid/lv#hbzID> "HT018779822" .
 <http://lobid.org/resources/HT018779822#!> <http://purl.org/ontology/bibo/isbn> "9781138816503" .
 <http://lobid.org/resources/HT018779822#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018779822#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018779822> .
 <http://lobid.org/resources/HT018779822#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018779822#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018779822#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018779822#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018779822> .
 <http://lobid.org/resources/HT018779822#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018779822> .
 <http://lobid.org/resources/HT018779822> <http://purl.org/dc/terms/created> "20151014" .
 <http://lobid.org/resources/HT018779822> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9954,10 +9954,10 @@
 <http://lobid.org/resources/HT018781534#!> <http://purl.org/ontology/mo/ismn> "9790001200165" .
 <http://lobid.org/resources/HT018781534#!> <http://rdaregistry.info/Elements/u/P60493> "for violin, French horn (in F) and piano ; (1969)" .
 <http://lobid.org/resources/HT018781534#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018781534#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018781534> .
 <http://lobid.org/resources/HT018781534#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018781534#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
 <http://lobid.org/resources/HT018781534#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018781534#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018781534> .
 <http://lobid.org/resources/HT018781534#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018781534> .
 <http://lobid.org/resources/HT018781534> <http://purl.org/dc/terms/created> "20151016" .
 <http://lobid.org/resources/HT018781534> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -9989,10 +9989,10 @@
 <http://lobid.org/resources/HT018782520#!> <http://purl.org/ontology/bibo/isbn> "9783522304146" .
 <http://lobid.org/resources/HT018782520#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4006604-6> .
 <http://lobid.org/resources/HT018782520#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018782520#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018782520> .
 <http://lobid.org/resources/HT018782520#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018782520#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018782520#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018782520#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018782520> .
 <http://lobid.org/resources/HT018782520#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018782520> .
 <http://lobid.org/resources/HT018782520> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/HT018782520> <http://purl.org/dc/terms/created> "20151019" .
@@ -10023,10 +10023,10 @@
 <http://lobid.org/resources/HT018786244#!> <http://purl.org/ontology/bibo/isbn> "9783957860415" .
 <http://lobid.org/resources/HT018786244#!> <http://rdaregistry.info/Elements/u/P60493> "Subjektentwicklung zwischen Nähe und Distanz" .
 <http://lobid.org/resources/HT018786244#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018786244#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018786244> .
 <http://lobid.org/resources/HT018786244#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018786244#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018786244#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018786244#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018786244> .
 <http://lobid.org/resources/HT018786244#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018786244> .
 <http://lobid.org/resources/HT018786244> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-1156#!> .
 <http://lobid.org/resources/HT018786244> <http://purl.org/dc/terms/created> "20151022" .
@@ -10053,11 +10053,11 @@
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/lobid/lv#inCollection> <http://repository.publisso.de> .
 <http://lobid.org/resources/HT018801101#!> <http://purl.org/ontology/bibo/doi> "10.4126/FRL01-006399387" .
 <http://lobid.org/resources/HT018801101#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018801101#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018801101> .
 <http://lobid.org/resources/HT018801101#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.4126/FRL01-006399387> .
 <http://lobid.org/resources/HT018801101#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018801101#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT018801101#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018801101#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018801101> .
 <http://lobid.org/resources/HT018801101#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018801101> .
 <http://lobid.org/resources/HT018801101> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT018801101> <http://purl.org/dc/terms/created> "20151109" .
@@ -10090,12 +10090,12 @@
 <http://lobid.org/resources/HT018839495#!> <http://purl.org/ontology/bibo/issn> "2366374X" .
 <http://lobid.org/resources/HT018839495#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4179998-7> .
 <http://lobid.org/resources/HT018839495#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018839495#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018839495> .
+<http://lobid.org/resources/HT018839495#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2842926-6> .
 <http://lobid.org/resources/HT018839495#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018839495#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
 <http://lobid.org/resources/HT018839495#!> <http://www.w3.org/2000/01/rdf-schema#label> "Classics in linguistics" .
 <http://lobid.org/resources/HT018839495#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018839495#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018839495> .
-<http://lobid.org/resources/HT018839495#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2842926-6> .
 <http://lobid.org/resources/HT018839495#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018839495> .
 <http://lobid.org/resources/HT018839495> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-8#!> .
 <http://lobid.org/resources/HT018839495> <http://purl.org/dc/terms/created> "20151216" .
@@ -10120,10 +10120,10 @@
 <http://lobid.org/resources/HT018848722#!> <http://purl.org/lobid/lv#hbzID> "HT018848722" .
 <http://lobid.org/resources/HT018848722#!> <http://purl.org/ontology/bibo/edition> "First englisch edition" .
 <http://lobid.org/resources/HT018848722#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018848722#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018848722> .
 <http://lobid.org/resources/HT018848722#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018848722#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018848722#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018848722#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018848722> .
 <http://lobid.org/resources/HT018848722#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018848722> .
 <http://lobid.org/resources/HT018848722> <http://purl.org/dc/terms/created> "20160105" .
 <http://lobid.org/resources/HT018848722> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10145,11 +10145,11 @@
 <http://lobid.org/resources/HT018848736#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT018848736#!> <http://rdaregistry.info/Elements/u/P60493> "abhinava Adhyātma anuyoga vibhū\u1e63ita" .
 <http://lobid.org/resources/HT018848736#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018848736#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018848736> .
 <http://lobid.org/resources/HT018848736#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018848736#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018848736#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/MultiVolumeBook> .
 <http://lobid.org/resources/HT018848736#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018848736#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018848736> .
 <http://lobid.org/resources/HT018848736#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018848736> .
 <http://lobid.org/resources/HT018848736> <http://purl.org/dc/terms/created> "20160105" .
 <http://lobid.org/resources/HT018848736> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10173,9 +10173,9 @@
 <http://lobid.org/resources/HT018853619#!> <http://rdaregistry.info/Elements/u/P60493> "für 16 Stimmen : (1983)" .
 <http://lobid.org/resources/HT018853619#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4173447-6> .
 <http://lobid.org/resources/HT018853619#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018853619#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018853619> .
 <http://lobid.org/resources/HT018853619#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018853619#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/mo/PublishedScore> .
-<http://lobid.org/resources/HT018853619#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018853619> .
 <http://lobid.org/resources/HT018853619#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018853619> .
 <http://lobid.org/resources/HT018853619> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-1156#!> .
 <http://lobid.org/resources/HT018853619> <http://purl.org/dc/terms/created> "20160111" .
@@ -10209,10 +10209,10 @@
 <http://lobid.org/resources/HT018857620#!> <http://purl.org/lobid/lv#containsExampleOfWork> <https://d-nb.info/gnd/300170602> .
 <http://lobid.org/resources/HT018857620#!> <http://purl.org/lobid/lv#hbzID> "HT018857620" .
 <http://lobid.org/resources/HT018857620#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018857620#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018857620> .
 <http://lobid.org/resources/HT018857620#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018857620#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT018857620#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018857620#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018857620> .
 <http://lobid.org/resources/HT018857620#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018857620> .
 <http://lobid.org/resources/HT018857620> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-Kn38#!> .
 <http://lobid.org/resources/HT018857620> <http://purl.org/dc/terms/created> "20160114" .
@@ -10251,11 +10251,11 @@
 <http://lobid.org/resources/HT018895767#!> <http://rdaregistry.info/Elements/u/P60493> "der Schulstreit in Rheinhessen und seine Folgen" .
 <http://lobid.org/resources/HT018895767#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4142300-8> .
 <http://lobid.org/resources/HT018895767#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018895767#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018895767> .
 <http://lobid.org/resources/HT018895767#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352> .
 <http://lobid.org/resources/HT018895767#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018895767#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018895767#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018895767#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018895767> .
 <http://lobid.org/resources/HT018895767#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018895767> .
 <http://lobid.org/resources/HT018895767> <http://purl.org/dc/terms/created> "20160225" .
 <http://lobid.org/resources/HT018895767> <http://purl.org/dc/terms/modified> "20180218" .
@@ -10279,10 +10279,10 @@
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/lobid/lv#inCollection> <http://repository.publisso.de> .
 <http://lobid.org/resources/HT018907266#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT018907266#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018907266#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018907266> .
 <http://lobid.org/resources/HT018907266#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018907266#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT018907266#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018907266#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018907266> .
 <http://lobid.org/resources/HT018907266#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018907266> .
 <http://lobid.org/resources/HT018907266> <http://purl.org/dc/terms/created> "20160307" .
 <http://lobid.org/resources/HT018907266> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10311,10 +10311,10 @@
 <http://lobid.org/resources/HT018924091#!> <http://rdaregistry.info/Elements/u/P60493> "die Cartoon-Sammlung" .
 <http://lobid.org/resources/HT018924091#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4145395-5> .
 <http://lobid.org/resources/HT018924091#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018924091#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018924091> .
 <http://lobid.org/resources/HT018924091#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018924091#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018924091#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018924091#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018924091> .
 <http://lobid.org/resources/HT018924091#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018924091> .
 <http://lobid.org/resources/HT018924091> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT018924091> <http://purl.org/dc/terms/created> "20160323" .
@@ -10349,12 +10349,12 @@
 <http://lobid.org/resources/HT018939763#!> <http://purl.org/ontology/bibo/isbn> "9783653052657" .
 <http://lobid.org/resources/HT018939763#!> <http://rdaregistry.info/Elements/u/P60493> "língua(s) e história(s)" .
 <http://lobid.org/resources/HT018939763#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018939763#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
 <http://lobid.org/resources/HT018939763#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.3726/978-3-653-05265-7> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer> .
-<http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018939763> .
 <http://lobid.org/resources/HT018939763#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018939763> .
 <http://lobid.org/resources/HT018939763> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38#!> .
 <http://lobid.org/resources/HT018939763> <http://purl.org/dc/terms/created> "20160412" .
@@ -10379,11 +10379,11 @@
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/lobid/lv#titleKeyword> "Erzählung Leichenpredigten Kaiser Kurfürsten Römischen Reiches tödlichem samt Lebenswandel und Bildnisse Ephitaphiis" .
 <http://lobid.org/resources/HT018998891#!> <http://purl.org/ontology/bibo/oclcnum> "VD16 S 9000" .
 <http://lobid.org/resources/HT018998891#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT018998891#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018998891> .
+<http://lobid.org/resources/HT018998891#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/VD16%20S%209000> .
 <http://lobid.org/resources/HT018998891#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT018998891#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT018998891#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT018998891#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT018998891> .
-<http://lobid.org/resources/HT018998891#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/VD16%20S%209000> .
 <http://lobid.org/resources/HT018998891#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT018998891> .
 <http://lobid.org/resources/HT018998891> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT018998891> <http://purl.org/dc/terms/created> "20160613" .
@@ -10407,11 +10407,11 @@
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/ontology/bibo/doi> "10.17169/langsci.b91.109" .
 <http://lobid.org/resources/HT019011249#!> <http://purl.org/ontology/bibo/isbn> "9783946234081" .
 <http://lobid.org/resources/HT019011249#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019011249#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019011249> .
 <http://lobid.org/resources/HT019011249#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.17169/langsci.b91.109> .
 <http://lobid.org/resources/HT019011249#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019011249#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019011249#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019011249#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019011249> .
 <http://lobid.org/resources/HT019011249#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019011249> .
 <http://lobid.org/resources/HT019011249> <http://purl.org/dc/terms/created> "20160623" .
 <http://lobid.org/resources/HT019011249> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10434,11 +10434,11 @@
 <http://lobid.org/resources/HT019054687#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:101:1-201602092139" .
 <http://lobid.org/resources/HT019054687#!> <http://purl.org/ontology/bibo/isbn> "9783939230397" .
 <http://lobid.org/resources/HT019054687#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019054687#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019054687> .
 <http://lobid.org/resources/HT019054687#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:101:1-201602092139> .
 <http://lobid.org/resources/HT019054687#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019054687#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019054687#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019054687#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019054687> .
 <http://lobid.org/resources/HT019054687#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019054687> .
 <http://lobid.org/resources/HT019054687> <http://purl.org/dc/terms/created> "20160805" .
 <http://lobid.org/resources/HT019054687> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10495,10 +10495,10 @@
 <http://lobid.org/resources/HT019093814#!> <http://rdaregistry.info/Elements/u/P60493> "junge Fotografie, Ruhrtriennale 2016 : Meisterkurse Daniel Josefson und Julian Römer; Louisa Boeszoermeny, Jakob Ganslmeier, Gregro Schmidt, Julian Slagman" .
 <http://lobid.org/resources/HT019093814#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/1071861417> .
 <http://lobid.org/resources/HT019093814#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019093814#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019093814> .
 <http://lobid.org/resources/HT019093814#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019093814#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019093814#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019093814#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019093814> .
 <http://lobid.org/resources/HT019093814#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019093814> .
 <http://lobid.org/resources/HT019093814> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT019093814> <http://purl.org/dc/terms/created> "20160915" .
@@ -10540,11 +10540,11 @@
 <http://lobid.org/resources/HT019149667#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4048476-2> .
 <http://lobid.org/resources/HT019149667#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4142300-8> .
 <http://lobid.org/resources/HT019149667#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019149667#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019149667> .
 <http://lobid.org/resources/HT019149667#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70052615> .
 <http://lobid.org/resources/HT019149667#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019149667#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019149667#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019149667#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019149667> .
 <http://lobid.org/resources/HT019149667#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019149667> .
 <http://lobid.org/resources/HT019149667> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019149667> <http://purl.org/dc/terms/created> "20161111" .
@@ -10579,11 +10579,11 @@
 <http://lobid.org/resources/HT019248596#!> <http://rdaregistry.info/Elements/u/P60493> "Kartographisch aufbereitete Klimainformationen über Koblenz" .
 <http://lobid.org/resources/HT019248596#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4596172-4> .
 <http://lobid.org/resources/HT019248596#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019248596#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019248596> .
 <http://lobid.org/resources/HT019248596#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887> .
 <http://lobid.org/resources/HT019248596#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019248596#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#ArchivedWebPage> .
 <http://lobid.org/resources/HT019248596#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019248596#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019248596> .
 <http://lobid.org/resources/HT019248596#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019248596> .
 <http://lobid.org/resources/HT019248596> <http://purl.org/dc/terms/created> "20170222" .
 <http://lobid.org/resources/HT019248596> <http://purl.org/dc/terms/modified> "20170426" .
@@ -10605,10 +10605,10 @@
 <http://lobid.org/resources/HT019322941#!> <http://purl.org/ontology/bibo/isbn> "9783863952594" .
 <http://lobid.org/resources/HT019322941#!> <http://rdaregistry.info/Elements/u/P60493> "Beiträge des 7. Erhard-Weigel-Kolloquiums 2014" .
 <http://lobid.org/resources/HT019322941#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019322941#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019322941> .
 <http://lobid.org/resources/HT019322941#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019322941#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019322941#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019322941#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019322941> .
 <http://lobid.org/resources/HT019322941#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019322941> .
 <http://lobid.org/resources/HT019322941> <http://purl.org/dc/terms/created> "20170510" .
 <http://lobid.org/resources/HT019322941> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10633,10 +10633,10 @@
 <http://lobid.org/resources/HT019357035#!> <http://purl.org/ontology/bibo/edition> "First edition" .
 <http://lobid.org/resources/HT019357035#!> <http://purl.org/ontology/bibo/isbn> "9780128138793" .
 <http://lobid.org/resources/HT019357035#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019357035#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019357035> .
 <http://lobid.org/resources/HT019357035#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019357035#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019357035#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019357035#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019357035> .
 <http://lobid.org/resources/HT019357035#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019357035> .
 <http://lobid.org/resources/HT019357035> <http://purl.org/dc/terms/created> "20170614" .
 <http://lobid.org/resources/HT019357035> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10675,12 +10675,12 @@
 <http://lobid.org/resources/HT019440025#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/1071861417> .
 <http://lobid.org/resources/HT019440025#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4142300-8> .
 <http://lobid.org/resources/HT019440025#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019440025#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019440025> .
 <http://lobid.org/resources/HT019440025#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70119907> .
 <http://lobid.org/resources/HT019440025#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019440025#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019440025#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Proceedings> .
 <http://lobid.org/resources/HT019440025#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019440025#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019440025> .
 <http://lobid.org/resources/HT019440025#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019440025> .
 <http://lobid.org/resources/HT019440025> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/HT019440025> <http://purl.org/dc/terms/created> "20170905" .
@@ -10704,12 +10704,12 @@
 <http://lobid.org/resources/HT019474284#!> <http://rdaregistry.info/Elements/u/P60493> "9th International Symposium" .
 <http://lobid.org/resources/HT019474284#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/1071861417> .
 <http://lobid.org/resources/HT019474284#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019474284#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019474284> .
 <http://lobid.org/resources/HT019474284#!> <http://umbel.org/umbel#isLike> _:bnodeDummy .
 <http://lobid.org/resources/HT019474284#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019474284#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019474284#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Proceedings> .
 <http://lobid.org/resources/HT019474284#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019474284#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019474284> .
 <http://lobid.org/resources/HT019474284#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019474284> .
 <http://lobid.org/resources/HT019474284> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT019474284> <http://purl.org/dc/terms/created> "20171012" .
@@ -10736,11 +10736,11 @@
 <http://lobid.org/resources/HT019488427#!> <http://rdaregistry.info/Elements/u/P60493> "Vortrag im Rahmen der Open-Access-Tage 2017, Dresden 12.09.2017" .
 <http://lobid.org/resources/HT019488427#!> <http://schema.org/license> <https://creativecommons.org/licenses/by/4.0/> .
 <http://lobid.org/resources/HT019488427#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019488427#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019488427> .
 <http://lobid.org/resources/HT019488427#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.4126/FRL01-006405231> .
 <http://lobid.org/resources/HT019488427#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019488427#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT019488427#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019488427#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019488427> .
 <http://lobid.org/resources/HT019488427#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019488427> .
 <http://lobid.org/resources/HT019488427> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-38M#!> .
 <http://lobid.org/resources/HT019488427> <http://purl.org/dc/terms/created> "20171027" .
@@ -10774,11 +10774,11 @@
 <http://lobid.org/resources/HT019552585#!> <http://purl.org/lobid/lv#zdbID> "2915820-5" .
 <http://lobid.org/resources/HT019552585#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4179998-7> .
 <http://lobid.org/resources/HT019552585#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019552585#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019552585> .
+<http://lobid.org/resources/HT019552585#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/2915820-5> .
 <http://lobid.org/resources/HT019552585#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019552585#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Series> .
 <http://lobid.org/resources/HT019552585#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019552585#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019552585> .
-<http://lobid.org/resources/HT019552585#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/2915820-5> .
 <http://lobid.org/resources/HT019552585#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019552585> .
 <http://lobid.org/resources/HT019552585> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-18#!> .
 <http://lobid.org/resources/HT019552585> <http://purl.org/dc/terms/created> "20180104" .
@@ -10800,11 +10800,11 @@
 <http://lobid.org/resources/HT019578856#!> <http://purl.org/lobid/lv#hbzID> "HT019578856" .
 <http://lobid.org/resources/HT019578856#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/HT019578856#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019578856#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019578856> .
 <http://lobid.org/resources/HT019578856#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019578856#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019578856#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/MultiVolumeBook> .
 <http://lobid.org/resources/HT019578856#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019578856#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019578856> .
 <http://lobid.org/resources/HT019578856#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019578856> .
 <http://lobid.org/resources/HT019578856> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-5-141#!> .
 <http://lobid.org/resources/HT019578856> <http://purl.org/dc/terms/created> "20180131" .
@@ -10864,11 +10864,11 @@
 <http://lobid.org/resources/HT019582722#!> <http://purl.org/ontology/bibo/oclcnum> "956518475" .
 <http://lobid.org/resources/HT019582722#!> <http://rdaregistry.info/Elements/u/P60493> "public libraries in the age of Jim Crow" .
 <http://lobid.org/resources/HT019582722#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019582722#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019582722> .
+<http://lobid.org/resources/HT019582722#!> <http://schema.org/sameAs> <http://worldcat.org/oclc/956518475> .
 <http://lobid.org/resources/HT019582722#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019582722#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019582722#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019582722#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019582722> .
-<http://lobid.org/resources/HT019582722#!> <http://www.w3.org/2002/07/owl#sameAs> <http://worldcat.org/oclc/956518475> .
 <http://lobid.org/resources/HT019582722#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019582722> .
 <http://lobid.org/resources/HT019582722> <http://purl.org/dc/terms/created> "20180205" .
 <http://lobid.org/resources/HT019582722> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10895,12 +10895,12 @@
 <http://lobid.org/resources/HT019838800#!> <http://purl.org/ontology/bibo/doi> "10.4126/FRL01-006410624" .
 <http://lobid.org/resources/HT019838800#!> <http://rdaregistry.info/Elements/u/P60493> "Relevanz von Suffizienz in der Modellierung, Übersicht über die aktuelle Modellierungspraxis und Ableitung methodischer Empfehlungen : Zwischenbericht zu AP 2.1 \u201eMöglichkeiten der Instrumentierung von Energieverbrauchsreduktion durch Verhaltensänderung\u201c" .
 <http://lobid.org/resources/HT019838800#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019838800#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019838800> .
 <http://lobid.org/resources/HT019838800#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.4126/FRL01-006410624> .
 <http://lobid.org/resources/HT019838800#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019838800#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019838800#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Report> .
 <http://lobid.org/resources/HT019838800#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019838800#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019838800> .
 <http://lobid.org/resources/HT019838800#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019838800> .
 <http://lobid.org/resources/HT019838800> <http://purl.org/dc/terms/created> "20181016" .
 <http://lobid.org/resources/HT019838800> <http://purl.org/dc/terms/modified> "20181018" .
@@ -10930,9 +10930,9 @@
 <http://lobid.org/resources/HT019868557#!> <http://purl.org/lobid/lv#subjectAltLabel> "Grenzüberschreitende Zusammenarbeit" .
 <http://lobid.org/resources/HT019868557#!> <http://rdaregistry.info/Elements/u/P60493> "zur \"Relativierung\" der Grenze durch grenzüberschreitende Zusammenarbeit" .
 <http://lobid.org/resources/HT019868557#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019868557#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019868557> .
 <http://lobid.org/resources/HT019868557#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019868557#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT019868557#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019868557> .
 <http://lobid.org/resources/HT019868557#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019868557> .
 <http://lobid.org/resources/HT019868557> <http://purl.org/dc/terms/created> "20181113" .
 <http://lobid.org/resources/HT019868557> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -10972,9 +10972,9 @@
 <http://lobid.org/resources/HT019965834#!> <http://purl.org/lobid/lv#subjectAltLabel> "Wirtschaftsstrukturpolitik" .
 <http://lobid.org/resources/HT019965834#!> <http://rdaregistry.info/Elements/u/P60493> "innovative Formate in der Stadt- und Regionalentwicklung" .
 <http://lobid.org/resources/HT019965834#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019965834#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019965834> .
 <http://lobid.org/resources/HT019965834#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019965834#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT019965834#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019965834> .
 <http://lobid.org/resources/HT019965834#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019965834> .
 <http://lobid.org/resources/HT019965834> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT019965834> <http://purl.org/dc/terms/created> "20190211" .
@@ -11009,10 +11009,10 @@
 <http://lobid.org/resources/HT019996406#!> <http://purl.org/ontology/bibo/isbn> "9780691091716" .
 <http://lobid.org/resources/HT019996406#!> <http://rdaregistry.info/Elements/u/P60493> "Buddhism, purity, and gender" .
 <http://lobid.org/resources/HT019996406#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT019996406#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019996406> .
 <http://lobid.org/resources/HT019996406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT019996406#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT019996406#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT019996406#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT019996406> .
 <http://lobid.org/resources/HT019996406#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT019996406> .
 <http://lobid.org/resources/HT019996406> <http://purl.org/dc/terms/created> "20190308" .
 <http://lobid.org/resources/HT019996406> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11035,10 +11035,10 @@
 <http://lobid.org/resources/HT020008571#!> <http://purl.org/ontology/bibo/edition> "1. Auflage" .
 <http://lobid.org/resources/HT020008571#!> <http://rdaregistry.info/Elements/u/P60493> "eine Bestandsaufnahme nach ausgewählten Branchen im Land Bremen" .
 <http://lobid.org/resources/HT020008571#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT020008571#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020008571> .
 <http://lobid.org/resources/HT020008571#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT020008571#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT020008571#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT020008571#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020008571> .
 <http://lobid.org/resources/HT020008571#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT020008571> .
 <http://lobid.org/resources/HT020008571> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-290#!> .
 <http://lobid.org/resources/HT020008571> <http://purl.org/dc/terms/created> "20190320" .
@@ -11068,10 +11068,10 @@
 <http://lobid.org/resources/HT020015895#!> <http://purl.org/ontology/bibo/isbn> "9783839224274" .
 <http://lobid.org/resources/HT020015895#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4155569-7> .
 <http://lobid.org/resources/HT020015895#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT020015895#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020015895> .
 <http://lobid.org/resources/HT020015895#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT020015895#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT020015895#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT020015895#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020015895> .
 <http://lobid.org/resources/HT020015895#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT020015895> .
 <http://lobid.org/resources/HT020015895> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-61#!> .
 <http://lobid.org/resources/HT020015895> <http://purl.org/dc/terms/created> "20190328" .
@@ -11118,11 +11118,11 @@
 <http://lobid.org/resources/HT020163348#!> <http://rdaregistry.info/Elements/u/P60489> "Universität Siegen, Dissertation, 2019" .
 <http://lobid.org/resources/HT020163348#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4113937-9> .
 <http://lobid.org/resources/HT020163348#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT020163348#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020163348> .
 <http://lobid.org/resources/HT020163348#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT020163348#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/HT020163348#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Thesis> .
 <http://lobid.org/resources/HT020163348#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT020163348#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020163348> .
 <http://lobid.org/resources/HT020163348#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT020163348> .
 <http://lobid.org/resources/HT020163348> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-6#!> .
 <http://lobid.org/resources/HT020163348> <http://purl.org/dc/terms/created> "20190819" .
@@ -11157,9 +11157,9 @@
 <http://lobid.org/resources/HT020297152#!> <http://purl.org/lobid/lv#subjectAltLabel> "Teenager" .
 <http://lobid.org/resources/HT020297152#!> <http://rdaregistry.info/Elements/u/P60493> "ein praxeologischer Blick auf das Soester \"Karussell der Jugend\" 1959-1971" .
 <http://lobid.org/resources/HT020297152#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT020297152#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020297152> .
 <http://lobid.org/resources/HT020297152#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT020297152#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/HT020297152#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT020297152> .
 <http://lobid.org/resources/HT020297152#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT020297152> .
 <http://lobid.org/resources/HT020297152> <http://purl.org/dc/terms/created> "20191128" .
 <http://lobid.org/resources/HT020297152> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11186,11 +11186,11 @@
 <http://lobid.org/resources/HT021282447#!> <http://purl.org/lobid/lv#zdbID> "3112826-9" .
 <http://lobid.org/resources/HT021282447#!> <http://rdaregistry.info/Elements/u/P60584> <https://d-nb.info/gnd/4596172-4> .
 <http://lobid.org/resources/HT021282447#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT021282447#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT021282447> .
+<http://lobid.org/resources/HT021282447#!> <http://schema.org/sameAs> <http://ld.zdb-services.de/resource/3112826-9> .
 <http://lobid.org/resources/HT021282447#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT021282447#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/HT021282447#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/HT021282447#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT021282447> .
-<http://lobid.org/resources/HT021282447#!> <http://www.w3.org/2002/07/owl#sameAs> <http://ld.zdb-services.de/resource/3112826-9> .
 <http://lobid.org/resources/HT021282447#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT021282447> .
 <http://lobid.org/resources/HT021282447> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-18#!> .
 <http://lobid.org/resources/HT021282447> <http://purl.org/dc/terms/created> "20220311" .
@@ -11211,9 +11211,9 @@
 <http://lobid.org/resources/HT021519082#!> <http://purl.org/lobid/lv#hbzID> "HT021519082" .
 <http://lobid.org/resources/HT021519082#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/organisations/ZDB-94-OAB#!> .
 <http://lobid.org/resources/HT021519082#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/HT021519082#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-HT021519082> .
 <http://lobid.org/resources/HT021519082#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/HT021519082#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/HT021519082#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-HT021519082> .
 <http://lobid.org/resources/HT021519082#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/HT021519082> .
 <http://lobid.org/resources/HT021519082> <http://purl.org/dc/terms/created> "20220506" .
 <http://lobid.org/resources/HT021519082> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11226,9 +11226,9 @@
 <http://lobid.org/resources/PCHBZ000001#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/PCHBZ000001#!> <http://purl.org/dc/terms/title> "Dirigenten-Erziehung" .
 <http://lobid.org/resources/PCHBZ000001#!> <http://purl.org/lobid/lv#hbzID> "PCHBZ000001" .
+<http://lobid.org/resources/PCHBZ000001#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-PCHBZ000001> .
 <http://lobid.org/resources/PCHBZ000001#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/PCHBZ000001#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/PCHBZ000001#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-PCHBZ000001> .
 <http://lobid.org/resources/PCHBZ000001#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/PCHBZ000001> .
 <http://lobid.org/resources/PCHBZ000001> <http://purl.org/dc/terms/created> "00010101" .
 <http://lobid.org/resources/PCHBZ000001> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11240,9 +11240,9 @@
 <http://lobid.org/resources/PCHBZ000002#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/PCHBZ000002#!> <http://purl.org/dc/terms/title> "Entenhausen-Erziehung" .
 <http://lobid.org/resources/PCHBZ000002#!> <http://purl.org/lobid/lv#hbzID> "PCHBZ000002" .
+<http://lobid.org/resources/PCHBZ000002#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-PCHBZ000002> .
 <http://lobid.org/resources/PCHBZ000002#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/PCHBZ000002#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/PCHBZ000002#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-PCHBZ000002> .
 <http://lobid.org/resources/PCHBZ000002#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/PCHBZ000002> .
 <http://lobid.org/resources/PCHBZ000002> <http://purl.org/dc/terms/created> "00010101" .
 <http://lobid.org/resources/PCHBZ000002> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11253,9 +11253,9 @@
 <http://lobid.org/resources/PCHBZ000003#!> <http://purl.org/dc/terms/medium> <http://rdaregistry.info/termList/RDAproductionMethod/1010> .
 <http://lobid.org/resources/PCHBZ000003#!> <http://purl.org/dc/terms/title> "copy paste date error" .
 <http://lobid.org/resources/PCHBZ000003#!> <http://purl.org/lobid/lv#hbzID> "PCHBZ000003" .
+<http://lobid.org/resources/PCHBZ000003#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-PCHBZ000003> .
 <http://lobid.org/resources/PCHBZ000003#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/PCHBZ000003#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/PCHBZ000003#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-PCHBZ000003> .
 <http://lobid.org/resources/PCHBZ000003#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/PCHBZ000003> .
 <http://lobid.org/resources/PCHBZ000003> <http://purl.org/dc/terms/created> "00010101" .
 <http://lobid.org/resources/PCHBZ000003> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11272,9 +11272,9 @@
 <http://lobid.org/resources/TT000000489#!> <http://purl.org/dc/terms/title> "Play Hockey Slazenger Style" .
 <http://lobid.org/resources/TT000000489#!> <http://purl.org/lobid/lv#hbzID> "TT000000489" .
 <http://lobid.org/resources/TT000000489#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT000000489#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000000489> .
 <http://lobid.org/resources/TT000000489#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT000000489#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
-<http://lobid.org/resources/TT000000489#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000000489> .
 <http://lobid.org/resources/TT000000489#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000000489> .
 <http://lobid.org/resources/TT000000489> <http://purl.org/dc/terms/created> "20010221" .
 <http://lobid.org/resources/TT000000489> <http://purl.org/dc/terms/modified> "20010314" .
@@ -11293,10 +11293,10 @@
 <http://lobid.org/resources/TT000075751#!> <http://purl.org/lobid/lv#exampleOfWork> _:bnodeDummy .
 <http://lobid.org/resources/TT000075751#!> <http://purl.org/lobid/lv#hbzID> "TT000075751" .
 <http://lobid.org/resources/TT000075751#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT000075751#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000075751> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000075751> .
 <http://lobid.org/resources/TT000075751#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000075751> .
 <http://lobid.org/resources/TT000075751> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-467#!> .
 <http://lobid.org/resources/TT000075751> <http://purl.org/dc/terms/created> "19990816" .
@@ -11318,10 +11318,10 @@
 <http://lobid.org/resources/TT000136775#!> <http://purl.org/lobid/lv#hbzID> "TT000136775" .
 <http://lobid.org/resources/TT000136775#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/TT000136775#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT000136775#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000136775> .
 <http://lobid.org/resources/TT000136775#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT000136775#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT000136775#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT000136775#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT000136775> .
 <http://lobid.org/resources/TT000136775#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT000136775> .
 <http://lobid.org/resources/TT000136775> <http://purl.org/dc/terms/created> "19980518" .
 <http://lobid.org/resources/TT000136775> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11340,11 +11340,11 @@
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/lobid/lv#hbzID> "TT001210514" .
 <http://lobid.org/resources/TT001210514#!> <http://purl.org/ontology/bibo/edition> "Ausgabe in Blindenschrift" .
 <http://lobid.org/resources/TT001210514#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT001210514#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001210514> .
 <http://lobid.org/resources/TT001210514#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT001210514#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT001210514#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/MultiVolumeBook> .
 <http://lobid.org/resources/TT001210514#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT001210514#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001210514> .
 <http://lobid.org/resources/TT001210514#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001210514> .
 <http://lobid.org/resources/TT001210514> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-107#!> .
 <http://lobid.org/resources/TT001210514> <http://purl.org/dc/terms/created> "20051110" .
@@ -11371,10 +11371,10 @@
 <http://lobid.org/resources/TT001230001#!> <http://rdaregistry.info/Elements/u/P60493> "Cvm Manfredi Regis additionibus" .
 <http://lobid.org/resources/TT001230001#!> <http://rdaregistry.info/Elements/u/P60493> "Reliqva Librorvm Friderici II. Imperatoris, De arte venandi cum auibus" .
 <http://lobid.org/resources/TT001230001#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT001230001#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001230001> .
 <http://lobid.org/resources/TT001230001#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT001230001#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT001230001#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT001230001#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001230001> .
 <http://lobid.org/resources/TT001230001#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001230001> .
 <http://lobid.org/resources/TT001230001> <http://purl.org/dc/terms/created> "20051110" .
 <http://lobid.org/resources/TT001230001> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11397,9 +11397,9 @@
 <http://lobid.org/resources/TT001451033#!> <http://rdaregistry.info/Elements/u/P60278> _:bnodeDummy .
 <http://lobid.org/resources/TT001451033#!> <http://rdaregistry.info/Elements/u/P60493> "Nov. 16, 1970, Houston, Texas" .
 <http://lobid.org/resources/TT001451033#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT001451033#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001451033> .
 <http://lobid.org/resources/TT001451033#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT001451033#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/TT001451033#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001451033> .
 <http://lobid.org/resources/TT001451033#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001451033> .
 <http://lobid.org/resources/TT001451033> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-386#!> .
 <http://lobid.org/resources/TT001451033> <http://purl.org/dc/terms/created> "20060407" .
@@ -11435,11 +11435,11 @@
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/ontology/bibo/isbn> "3402061740" .
 <http://lobid.org/resources/TT001671747#!> <http://purl.org/ontology/bibo/isbn> "9783402061749" .
 <http://lobid.org/resources/TT001671747#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT001671747#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001671747> .
 <http://lobid.org/resources/TT001671747#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT001671747#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT001671747#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Map> .
 <http://lobid.org/resources/TT001671747#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT001671747#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001671747> .
 <http://lobid.org/resources/TT001671747#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001671747> .
 <http://lobid.org/resources/TT001671747> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-290#!> .
 <http://lobid.org/resources/TT001671747> <http://purl.org/dc/terms/created> "20060407" .
@@ -11463,10 +11463,10 @@
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/dc/terms/title> "Critique Du Jesuite Secularisé" .
 <http://lobid.org/resources/TT001726537#!> <http://purl.org/lobid/lv#hbzID> "TT001726537" .
 <http://lobid.org/resources/TT001726537#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT001726537#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001726537> .
 <http://lobid.org/resources/TT001726537#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT001726537#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT001726537#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT001726537#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001726537> .
 <http://lobid.org/resources/TT001726537#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001726537> .
 <http://lobid.org/resources/TT001726537> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-Kn28#!> .
 <http://lobid.org/resources/TT001726537> <http://purl.org/dc/terms/created> "20060512" .
@@ -11487,11 +11487,11 @@
 <http://lobid.org/resources/TT001966831#!> <http://purl.org/lobid/lv#hbzID> "TT001966831" .
 <http://lobid.org/resources/TT001966831#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/TT001966831#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT001966831#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001966831> .
 <http://lobid.org/resources/TT001966831#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT001966831#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT001966831#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/TT001966831#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT001966831#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT001966831> .
 <http://lobid.org/resources/TT001966831#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT001966831> .
 <http://lobid.org/resources/TT001966831> <http://purl.org/dc/terms/created> "20060512" .
 <http://lobid.org/resources/TT001966831> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11528,10 +11528,10 @@
 <http://lobid.org/resources/TT002001222#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Tarsus, Apostel, Heiliger (von Tarsus, Apostel, Heiliger)" .
 <http://lobid.org/resources/TT002001222#!> <http://purl.org/ontology/bibo/edition> "2. verb. und verm. Aufl." .
 <http://lobid.org/resources/TT002001222#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002001222#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002001222> .
 <http://lobid.org/resources/TT002001222#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002001222#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT002001222#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002001222#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002001222> .
 <http://lobid.org/resources/TT002001222#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002001222> .
 <http://lobid.org/resources/TT002001222> <http://purl.org/dc/terms/created> "20060512" .
 <http://lobid.org/resources/TT002001222> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11565,10 +11565,10 @@
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Laodicea (310-390)" .
 <http://lobid.org/resources/TT002001274#!> <http://purl.org/lobid/lv#subjectAltLabel> "von Laodikeia (310-390)" .
 <http://lobid.org/resources/TT002001274#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002001274#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002001274> .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002001274#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002001274> .
 <http://lobid.org/resources/TT002001274#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002001274> .
 <http://lobid.org/resources/TT002001274> <http://purl.org/dc/terms/created> "20060512" .
 <http://lobid.org/resources/TT002001274> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11587,10 +11587,10 @@
 <http://lobid.org/resources/TT002165019#!> <http://purl.org/lobid/lv#hbzID> "TT002165019" .
 <http://lobid.org/resources/TT002165019#!> <http://rdaregistry.info/Elements/u/P60493> "Jüdisches Schicksal in Paderborn" .
 <http://lobid.org/resources/TT002165019#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002165019#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002165019> .
 <http://lobid.org/resources/TT002165019#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002165019#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT002165019#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002165019#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002165019> .
 <http://lobid.org/resources/TT002165019#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002165019> .
 <http://lobid.org/resources/TT002165019> <http://purl.org/dc/terms/created> "20060718" .
 <http://lobid.org/resources/TT002165019> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11615,11 +11615,11 @@
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT016925914#!> .
 <http://lobid.org/resources/TT002234042#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:02-1513" .
 <http://lobid.org/resources/TT002234042#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002234042#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002234042> .
 <http://lobid.org/resources/TT002234042#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:02-1513> .
 <http://lobid.org/resources/TT002234042#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002234042#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
 <http://lobid.org/resources/TT002234042#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002234042#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002234042> .
 <http://lobid.org/resources/TT002234042#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002234042> .
 <http://lobid.org/resources/TT002234042> <http://purl.org/dc/terms/created> "20030707" .
 <http://lobid.org/resources/TT002234042> <http://purl.org/dc/terms/modified> "20160609" .
@@ -11646,12 +11646,12 @@
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#subjectAltLabel> "Sternenweg" .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:01-2079" .
 <http://lobid.org/resources/TT002234459#!> <http://purl.org/lobid/lv#webPageArchived> <http://www.rhein-lahn-info.de/jakobsweg/> .
+<http://lobid.org/resources/TT002234459#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002234459> .
 <http://lobid.org/resources/TT002234459#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079> .
 <http://lobid.org/resources/TT002234459#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002234459#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#ArchivedWebPage> .
 <http://lobid.org/resources/TT002234459#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Map> .
 <http://lobid.org/resources/TT002234459#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002234459#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002234459> .
 <http://lobid.org/resources/TT002234459#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002234459> .
 <http://lobid.org/resources/TT002234459> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234459> <http://purl.org/dc/terms/created> "20030718" .
@@ -11678,11 +11678,11 @@
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/lobid/lv#inCollection> <http://lobid.org/resources/HT016925914#!> .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/lobid/lv#urn> "urn:nbn:de:hbz:929:01-8578" .
 <http://lobid.org/resources/TT002234858#!> <http://purl.org/lobid/lv#webPageArchived> <http://cmswebserver10.icteam.net/stk/> .
+<http://lobid.org/resources/TT002234858#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002234858> .
 <http://lobid.org/resources/TT002234858#!> <http://umbel.org/umbel#isLike> <http://nbn-resolving.de/urn:nbn:de:hbz:929:01-8578> .
 <http://lobid.org/resources/TT002234858#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002234858#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#ArchivedWebPage> .
 <http://lobid.org/resources/TT002234858#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002234858#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002234858> .
 <http://lobid.org/resources/TT002234858#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002234858> .
 <http://lobid.org/resources/TT002234858> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-929#!> .
 <http://lobid.org/resources/TT002234858> <http://purl.org/dc/terms/created> "20040312" .
@@ -11701,9 +11701,9 @@
 <http://lobid.org/resources/TT002303245#!> <http://purl.org/lobid/lv#containedIn> <http://lobid.org/resources/HT001967154#!> .
 <http://lobid.org/resources/TT002303245#!> <http://purl.org/lobid/lv#hbzID> "TT002303245" .
 <http://lobid.org/resources/TT002303245#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002303245#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002303245> .
 <http://lobid.org/resources/TT002303245#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002303245#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Article> .
-<http://lobid.org/resources/TT002303245#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002303245> .
 <http://lobid.org/resources/TT002303245#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002303245> .
 <http://lobid.org/resources/TT002303245> <http://open-services.net/ns/core#modifiedBy> <http://lobid.org/organisations/DE-5#!> .
 <http://lobid.org/resources/TT002303245> <http://purl.org/dc/terms/created> "20070615" .
@@ -11726,9 +11726,9 @@
 <http://lobid.org/resources/TT002815323#!> <http://purl.org/ontology/bibo/isbn> "0406259305" .
 <http://lobid.org/resources/TT002815323#!> <http://purl.org/ontology/bibo/isbn> "9780406259301" .
 <http://lobid.org/resources/TT002815323#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002815323#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002815323> .
 <http://lobid.org/resources/TT002815323#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002815323#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/TT002815323#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002815323> .
 <http://lobid.org/resources/TT002815323#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002815323> .
 <http://lobid.org/resources/TT002815323> <http://purl.org/dc/terms/created> "20081212" .
 <http://lobid.org/resources/TT002815323> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11764,10 +11764,10 @@
 <http://lobid.org/resources/TT002881480#!> <http://purl.org/lobid/lv#subjectAltLabel> "Öffentliche Unternehmung" .
 <http://lobid.org/resources/TT002881480#!> <http://purl.org/lobid/lv#subjectAltLabel> "Öffentlicher Betrieb" .
 <http://lobid.org/resources/TT002881480#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT002881480#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002881480> .
 <http://lobid.org/resources/TT002881480#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT002881480#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/PublicationIssue> .
 <http://lobid.org/resources/TT002881480#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT002881480#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT002881480> .
 <http://lobid.org/resources/TT002881480#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT002881480> .
 <http://lobid.org/resources/TT002881480> <http://purl.org/dc/terms/created> "20090528" .
 <http://lobid.org/resources/TT002881480> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11790,10 +11790,10 @@
 <http://lobid.org/resources/TT003059252#!> <http://purl.org/lobid/lv#hbzID> "TT003059252" .
 <http://lobid.org/resources/TT003059252#!> <http://rdaregistry.info/Elements/u/P60493> "Magical Mystery Tour" .
 <http://lobid.org/resources/TT003059252#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT003059252#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003059252> .
 <http://lobid.org/resources/TT003059252#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT003059252#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT003059252#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT003059252#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003059252> .
 <http://lobid.org/resources/TT003059252#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003059252> .
 <http://lobid.org/resources/TT003059252> <http://purl.org/dc/terms/created> "20110411" .
 <http://lobid.org/resources/TT003059252> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11816,10 +11816,10 @@
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://purl.org/lobid/lv#hbzID> "TT003059252_contAndCrea" .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://rdaregistry.info/Elements/u/P60493> "Magical Mystery Tour" .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003059252_contAndCrea> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT003059252_contAndCrea#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003059252_contAndCrea> .
 <http://lobid.org/resources/TT003059252_contAndCrea#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003059252_contAndCrea> .
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://purl.org/dc/terms/created> "20110411" .
 <http://lobid.org/resources/TT003059252_contAndCrea> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11843,10 +11843,10 @@
 <http://lobid.org/resources/TT003060418#!> <http://purl.org/lobid/lv#hbzID> "TT003060418" .
 <http://lobid.org/resources/TT003060418#!> <http://rdaregistry.info/Elements/u/P60493> "Oper in fünf Akten" .
 <http://lobid.org/resources/TT003060418#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT003060418#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003060418> .
 <http://lobid.org/resources/TT003060418#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT003060418#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#Miscellaneous> .
 <http://lobid.org/resources/TT003060418#!> <http://www.w3.org/2000/01/rdf-schema#label> "lobid Ressource" .
-<http://lobid.org/resources/TT003060418#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003060418> .
 <http://lobid.org/resources/TT003060418#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003060418> .
 <http://lobid.org/resources/TT003060418> <http://purl.org/dc/terms/created> "20110411" .
 <http://lobid.org/resources/TT003060418> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11864,9 +11864,9 @@
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/lobid/lv#hbzID> "TT003280170" .
 <http://lobid.org/resources/TT003280170#!> <http://purl.org/lobid/lv#isPartOf> _:bnodeDummy .
 <http://lobid.org/resources/TT003280170#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT003280170#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003280170> .
 <http://lobid.org/resources/TT003280170#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT003280170#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/TT003280170#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT003280170> .
 <http://lobid.org/resources/TT003280170#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT003280170> .
 <http://lobid.org/resources/TT003280170> <http://purl.org/dc/terms/created> "20150417" .
 <http://lobid.org/resources/TT003280170> <http://purl.org/lobid/lv#inDataset> <http://lobid.org/resources/dataset#!> .
@@ -11891,11 +11891,11 @@
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/ontology/bibo/doi> "10.1007/978-3-642-20784-6" .
 <http://lobid.org/resources/TT050409948#!> <http://purl.org/ontology/bibo/isbn> "9783642207846" .
 <http://lobid.org/resources/TT050409948#!> <http://schema.org/publication> _:bnodeDummy .
+<http://lobid.org/resources/TT050409948#!> <http://schema.org/sameAs> <http://hub.culturegraph.org/resource/HBZ-TT050409948> .
 <http://lobid.org/resources/TT050409948#!> <http://umbel.org/umbel#isLike> <http://dx.doi.org/10.1007/978-3-642-20784-6> .
 <http://lobid.org/resources/TT050409948#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/terms/BibliographicResource> .
 <http://lobid.org/resources/TT050409948#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/lobid/lv#EditedVolume> .
 <http://lobid.org/resources/TT050409948#!> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> .
-<http://lobid.org/resources/TT050409948#!> <http://www.w3.org/2002/07/owl#sameAs> <http://hub.culturegraph.org/resource/HBZ-TT050409948> .
 <http://lobid.org/resources/TT050409948#!> <http://www.w3.org/2007/05/powder-s#describedby> <http://lobid.org/resources/TT050409948> .
 <http://lobid.org/resources/TT050409948> <http://purl.org/dc/terms/created> "20120103" .
 <http://lobid.org/resources/TT050409948> <http://purl.org/dc/terms/modified> "20120309" .

--- a/src/test/resources/jsonld/CT001004829.json
+++ b/src/test/resources/jsonld/CT001004829.json
@@ -120,13 +120,13 @@
     "publishedBy" : "Landesbibliothekszentrum Rheinland-Pfalz",
     "startDate" : "2013"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:0128-1-37874",
-    "label" : "URN-Link"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-CT001004829",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:0128-1-37874",
+    "label" : "URN-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/CT001004829",

--- a/src/test/resources/jsonld/CT003012479.json
+++ b/src/test/resources/jsonld/CT003012479.json
@@ -218,24 +218,24 @@
   "urn" : [ "urn:nbn:de:hbz:061:2-46125" ],
   "otherTitleInformation" : [ "... wird heute Mittwoch den 17ten April die hier anwesende deutsche Schauspieler-Gesellschaft (Zum Letztenmale) die Ehre haben aufzuführen ; Abonnement suspendu ; eine ganz neue große komische Oper in 2 Aufzügen" ],
   "publication" : [ {
-    "type" : [ "PublicationEvent" ],
-    "location" : "Düsseldorf",
-    "publishedBy" : "Bögemann",
-    "startDate" : "1805"
-  }, {
     "type" : [ "SecondaryPublicationEvent" ],
     "description" : [ "Digitalisierte Ausg." ],
     "location" : "Düsseldorf",
     "publishedBy" : "Universitäts- und Landesbibliothek",
     "startDate" : "2015"
-  } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125",
-    "label" : "URN-Link"
+  }, {
+    "type" : [ "PublicationEvent" ],
+    "location" : "Düsseldorf",
+    "publishedBy" : "Bögemann",
+    "startDate" : "1805"
   } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-CT003012479",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:2-46125",
+    "label" : "URN-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/CT003012479",

--- a/src/test/resources/jsonld/HT000009600.json
+++ b/src/test/resources/jsonld/HT000009600.json
@@ -473,14 +473,14 @@
     "startDate" : "1948"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/6211-x",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT000009600",
     "label" : "Culturegraph Ressource"
   }, {
     "id" : "http://worldcat.org/oclc/263589870",
     "label" : "263589870"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/6211-x",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT000009600",

--- a/src/test/resources/jsonld/HT002619538.json
+++ b/src/test/resources/jsonld/HT002619538.json
@@ -110,11 +110,11 @@
     "startDate" : "1955"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/1257-9",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT002619538",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/1257-9",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT002619538",

--- a/src/test/resources/jsonld/HT003160768.json
+++ b/src/test/resources/jsonld/HT003160768.json
@@ -22,18 +22,18 @@
     },
     "label" : "lobid Bestandsressource"
   }, {
-    "id" : "http://lobid.org/items/HT003160768:DE-6-007:ONG%2Fg52127#!",
-    "type" : [ "Item" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-6-007#!",
-      "label" : "lobid Organisation"
-    },
-    "label" : "lobid Bestandsressource"
-  }, {
     "id" : "http://lobid.org/items/HT003160768:DE-465:ONG%2Fg52127#!",
     "type" : [ "Item" ],
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "lobid Organisation"
+    },
+    "label" : "lobid Bestandsressource"
+  }, {
+    "id" : "http://lobid.org/items/HT003160768:DE-6-007:ONG%2Fg52127#!",
+    "type" : [ "Item" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-6-007#!",
       "label" : "lobid Organisation"
     },
     "label" : "lobid Bestandsressource"

--- a/src/test/resources/jsonld/HT003536695.json
+++ b/src/test/resources/jsonld/HT003536695.json
@@ -72,13 +72,13 @@
     "publishedBy" : "Elzevir",
     "startDate" : "1646"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:bvb:12-bsb10057885-8",
-    "label" : "urn:nbn:de:bvb:12-bsb10057885-8"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT003536695",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:bvb:12-bsb10057885-8",
+    "label" : "urn:nbn:de:bvb:12-bsb10057885-8"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT003536695",

--- a/src/test/resources/jsonld/HT003654516.json
+++ b/src/test/resources/jsonld/HT003654516.json
@@ -93,14 +93,14 @@
     "publishedBy" : "Bergbau-Berufsgenossenschaft"
   } ],
   "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/224546401",
-    "label" : "224546401"
+    "id" : "http://worldcat.org/oclc/84927101",
+    "label" : "84927101"
   }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT003654516",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://worldcat.org/oclc/84927101",
-    "label" : "84927101"
+    "id" : "http://worldcat.org/oclc/224546401",
+    "label" : "224546401"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT003654516",

--- a/src/test/resources/jsonld/HT007015768.json
+++ b/src/test/resources/jsonld/HT007015768.json
@@ -62,11 +62,11 @@
     "startDate" : "1980"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/796481-x",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT007015768",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/796481-x",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT007015768",

--- a/src/test/resources/jsonld/HT008733617.json
+++ b/src/test/resources/jsonld/HT008733617.json
@@ -142,16 +142,16 @@
   "hbzId" : "HT008733617",
   "edition" : [ "[Mikrofiche-Ausg.]" ],
   "publication" : [ {
-    "type" : [ "PublicationEvent" ],
-    "location" : "Strassburg",
-    "startDate" : "1624"
-  }, {
     "type" : [ "SecondaryPublicationEvent" ],
     "description" : [ "Mikrofiche-Ausg.:" ],
     "endDate" : "1994",
     "location" : "München [u.a.]",
     "publishedBy" : "Saur",
     "startDate" : "1990"
+  }, {
+    "type" : [ "PublicationEvent" ],
+    "location" : "Strassburg",
+    "startDate" : "1624"
   } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT008733617",

--- a/src/test/resources/jsonld/HT009719670.json
+++ b/src/test/resources/jsonld/HT009719670.json
@@ -68,12 +68,12 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "Les films du losange"
+      "label" : "Collection libre échange"
     } ]
   }, {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "Collection libre échange"
+      "label" : "Les films du losange"
     } ]
   } ],
   "otherTitleInformation" : [ "extraits de films de Eric Rohmer" ],

--- a/src/test/resources/jsonld/HT010726584.json
+++ b/src/test/resources/jsonld/HT010726584.json
@@ -374,11 +374,11 @@
     "startDate" : "1994"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/1472746-8",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT010726584",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/1472746-8",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT010726584",

--- a/src/test/resources/jsonld/HT012237361.json
+++ b/src/test/resources/jsonld/HT012237361.json
@@ -52,11 +52,11 @@
     "startDate" : "1975"
   } ],
   "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT012237361",
-    "label" : "Culturegraph Ressource"
-  }, {
     "id" : "http://ld.zdb-services.de/resource/590016-5",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT012237361",
+    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT012237361",

--- a/src/test/resources/jsonld/HT012734833.json
+++ b/src/test/resources/jsonld/HT012734833.json
@@ -109,14 +109,14 @@
     "startDate" : "1989"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/1500025-4",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT012734833",
     "label" : "Culturegraph Ressource"
   }, {
     "id" : "http://worldcat.org/oclc/863021596",
     "label" : "863021596"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/1500025-4",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT012734833",

--- a/src/test/resources/jsonld/HT012989088.json
+++ b/src/test/resources/jsonld/HT012989088.json
@@ -113,11 +113,11 @@
     "startDate" : "1992"
   } ],
   "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT012989088",
-    "label" : "Culturegraph Ressource"
-  }, {
     "id" : "http://ld.zdb-services.de/resource/2013112-4",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT012989088",
+    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT012989088",

--- a/src/test/resources/jsonld/HT013056453.json
+++ b/src/test/resources/jsonld/HT013056453.json
@@ -238,14 +238,14 @@
     "startDate" : "1991"
   } ],
   "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/183350230",
-    "label" : "183350230"
-  }, {
     "id" : "http://ld.zdb-services.de/resource/1125458-0",
     "label" : "ZDB-Ressource"
   }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT013056453",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/183350230",
+    "label" : "183350230"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT013056453",

--- a/src/test/resources/jsonld/HT013304490.json
+++ b/src/test/resources/jsonld/HT013304490.json
@@ -110,11 +110,11 @@
     "startDate" : "2002"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/2073588-1",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT013304490",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2073588-1",
+    "label" : "ZDB-Ressource"
   }, {
     "id" : "http://worldcat.org/oclc/635743319",
     "label" : "635743319"

--- a/src/test/resources/jsonld/HT013532539.json
+++ b/src/test/resources/jsonld/HT013532539.json
@@ -182,28 +182,28 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "id" : "http://lobid.org/resources/HT002878738#!",
-      "label" : "lobid Ressource"
-    } ],
-    "numbering" : "2001"
-  }, {
-    "type" : [ "IsPartOfRelation" ],
-    "hasSuperordinate" : [ {
       "id" : "http://lobid.org/resources/HT004031599#!",
       "label" : "Bundesanzeiger ; Jg. 54, Nr. 92a"
     } ],
     "numbering" : "53,92a"
+  }, {
+    "type" : [ "IsPartOfRelation" ],
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT002878738#!",
+      "label" : "lobid Ressource"
+    } ],
+    "numbering" : "2001"
   } ],
   "subjectAltLabel" : [ "Cour Constitutionnelle Fédérale (Deutschland)", "BVerfG", "Deutschland. Cour Constitutionnelle Fédérale", "Spruchpraxis", "Constitutional Court (Deutschland)", "Deutschland. Pressestelle", "De guo lian bang xian fa fa yuan", "Pressestelle (Deutschland, Bundesverfassungsgericht)", "Deutschland. Savezni Ustavni Sud", "Savezni Ustavni Sud (Deutschland)", "Judikatur", "BVerfGK", "Bundesverfassungsgericht (Deutschland)", "Bundesverfassungsgericht (Deutschland, Bundesrepublik)", "Savezni Ustavni Sud Nemačke", "Pressestelle (Deutschland, Bundesrepublik, Bundesverfassungsgericht)", "Federal Constitutional Court (Deutschland)", "Deutschland. Constitutional Court", "Deutschland. Dezernat Kirchhof" ],
   "edition" : [ "[Mikrofiche-Ausg.]" ],
   "publication" : [ {
-    "type" : [ "PublicationEvent" ],
+    "type" : [ "SecondaryPublicationEvent" ],
+    "description" : [ "Mikrofiche-Ausg." ],
     "location" : "Köln",
     "publishedBy" : "Bundesanzeiger",
     "startDate" : "2002"
   }, {
-    "type" : [ "SecondaryPublicationEvent" ],
-    "description" : [ "Mikrofiche-Ausg." ],
+    "type" : [ "PublicationEvent" ],
     "location" : "Köln",
     "publishedBy" : "Bundesanzeiger",
     "startDate" : "2002"

--- a/src/test/resources/jsonld/HT014078228.json
+++ b/src/test/resources/jsonld/HT014078228.json
@@ -124,14 +124,14 @@
     "startDate" : "2003"
   } ],
   "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/1071459233",
-    "label" : "1071459233"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT014078228",
     "label" : "Culturegraph Ressource"
   }, {
     "id" : "http://ld.zdb-services.de/resource/2151120-2",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1071459233",
+    "label" : "1071459233"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT014078228",

--- a/src/test/resources/jsonld/HT014176012.json
+++ b/src/test/resources/jsonld/HT014176012.json
@@ -144,11 +144,11 @@
     "startDate" : "1983"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/2163340-X",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT014176012",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2163340-X",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT014176012",

--- a/src/test/resources/jsonld/HT014997977.json
+++ b/src/test/resources/jsonld/HT014997977.json
@@ -106,13 +106,13 @@
     "location" : "Mainz",
     "startDate" : "2003"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:17507513",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:17507513"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT014997977",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:17507513",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:17507513"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT014997977",

--- a/src/test/resources/jsonld/HT015090208.json
+++ b/src/test/resources/jsonld/HT015090208.json
@@ -230,12 +230,12 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "ZDF-Theaterkanal-Edition"
+      "label" : "<<Die>> Theater-Edition"
     } ]
   }, {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "<<Die>> Theater-Edition"
+      "label" : "ZDF-Theaterkanal-Edition"
     } ]
   } ],
   "subjectAltLabel" : [ "Goethe, Johann Wolfgang von (Faust et le second Faust)" ],

--- a/src/test/resources/jsonld/HT015891797.json
+++ b/src/test/resources/jsonld/HT015891797.json
@@ -55,16 +55,6 @@
     "callNumber" : "LRKA1168-1,10,2",
     "label" : "LRKA1168-1,10,2"
   }, {
-    "id" : "http://lobid.org/items/HT015891797:DE-Sie5:82%20=%204385#!",
-    "type" : [ "Item" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-Sie5#!",
-      "label" : "lobid Organisation"
-    },
-    "note" : [ "00002001" ],
-    "callNumber" : "82 = 4385",
-    "label" : "82 = 4385"
-  }, {
     "id" : "http://lobid.org/items/HT015891797:DE-107:9.1191%2F10,2#!",
     "type" : [ "Item" ],
     "heldBy" : {
@@ -84,6 +74,16 @@
     "note" : [ "00000000" ],
     "callNumber" : "LRKA 101-S,4,2",
     "label" : "LRKA 101-S,4,2"
+  }, {
+    "id" : "http://lobid.org/items/HT015891797:DE-Sie5:82%20=%204385#!",
+    "type" : [ "Item" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Sie5#!",
+      "label" : "lobid Organisation"
+    },
+    "note" : [ "00002001" ],
+    "callNumber" : "82 = 4385",
+    "label" : "82 = 4385"
   }, {
     "id" : "http://lobid.org/items/HT015891797:DE-121:09%20A%20756#!",
     "type" : [ "Item" ],

--- a/src/test/resources/jsonld/HT015894164.json
+++ b/src/test/resources/jsonld/HT015894164.json
@@ -256,13 +256,13 @@
     "publishedBy" : "OECD Publishing",
     "startDate" : "1999"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.1787/9789264273085-fr",
-    "label" : "DOI-Link"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT015894164",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.1787/9789264273085-fr",
+    "label" : "DOI-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT015894164",

--- a/src/test/resources/jsonld/HT016138627.json
+++ b/src/test/resources/jsonld/HT016138627.json
@@ -163,16 +163,16 @@
     "publishedBy" : "Statistisches Landesamt Rheinland-Pfalz",
     "startDate" : "2002"
   } ],
+  "sameAs" : [ {
+    "id" : "http://ld.zdb-services.de/resource/2524920-4",
+    "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016138627",
+    "label" : "Culturegraph Ressource"
+  } ],
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:52061113",
     "label" : "URN-Link"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016138627",
-    "label" : "Culturegraph Ressource"
-  }, {
-    "id" : "http://ld.zdb-services.de/resource/2524920-4",
-    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT016138627",

--- a/src/test/resources/jsonld/HT016382441.json
+++ b/src/test/resources/jsonld/HT016382441.json
@@ -287,13 +287,13 @@
     "publishedBy" : "Wiley-VCH",
     "startDate" : "2011"
   } ],
-  "seeAlso" : [ {
-    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer",
-    "label" : "Digitool"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT016382441",
     "label" : "Culturegraph Ressource"
+  } ],
+  "seeAlso" : [ {
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=4027723&custom_att_2=simple_viewer",
+    "label" : "Digitool"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT016382441",

--- a/src/test/resources/jsonld/HT016618741.json
+++ b/src/test/resources/jsonld/HT016618741.json
@@ -54,13 +54,13 @@
     "type" : [ "PublicationEvent" ],
     "startDate" : "2010"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061-20101201-135613-9",
-    "label" : "urn:nbn:de:hbz:061-20101201-135613-9"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT016618741",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061-20101201-135613-9",
+    "label" : "urn:nbn:de:hbz:061-20101201-135613-9"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT016618741",

--- a/src/test/resources/jsonld/HT016925914.json
+++ b/src/test/resources/jsonld/HT016925914.json
@@ -52,11 +52,11 @@
     "startDate" : "1835"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/2621309-6",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT016925914",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2621309-6",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT016925914",

--- a/src/test/resources/jsonld/HT016987148.json
+++ b/src/test/resources/jsonld/HT016987148.json
@@ -155,16 +155,16 @@
     "type" : [ "PublicationEvent" ],
     "startDate" : "2011"
   } ],
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016987148",
+    "label" : "Culturegraph Ressource"
+  } ],
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000004639",
     "label" : "URN-Link"
   }, {
     "id" : "http://dx.doi.org/10.4126/38m-000000463",
     "label" : "38m-000000463"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT016987148",
-    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT016987148",

--- a/src/test/resources/jsonld/HT017028573.json
+++ b/src/test/resources/jsonld/HT017028573.json
@@ -43,11 +43,11 @@
     "startDate" : "1924"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/2635665-X",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT017028573",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2635665-X",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT017028573",

--- a/src/test/resources/jsonld/HT017411546.json
+++ b/src/test/resources/jsonld/HT017411546.json
@@ -203,10 +203,6 @@
   "urn" : [ "urn:nbn:de:hbz:6-85659520092" ],
   "zdbId" : "2685248-2",
   "publication" : [ {
-    "type" : [ "SecondaryPublicationEvent" ],
-    "description" : [ "Münster : Universitäts- und Landesbibliothek, 2012. (Digitale Sammlungen der Universitäts- und Landesbibliothek Münster)", "Digitalisierte Ausg." ],
-    "startDate" : "2012"
-  }, {
     "type" : [ "PublicationEvent" ],
     "note" : [ "Ersch. in Lfg; springende Ersch.-Jahre" ],
     "publicationHistory" : "1.1951/55; 2.1961/90; 3.1977; 4.2004=Register; damit Ersch. eingest.",
@@ -214,17 +210,21 @@
     "location" : "Münster",
     "publishedBy" : [ "Historische Kommission, Landschaftsverband Westfalen-Lippe", "Regensberg" ],
     "startDate" : "1951"
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "description" : [ "Münster : Universitäts- und Landesbibliothek, 2012. (Digitale Sammlungen der Universitäts- und Landesbibliothek Münster)", "Digitalisierte Ausg." ],
+    "startDate" : "2012"
+  } ],
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017411546",
+    "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2685248-2",
+    "label" : "ZDB-Ressource"
   } ],
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
     "label" : "URN-Link"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/2685248-2",
-    "label" : "ZDB-Ressource"
-  }, {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017411546",
-    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT017411546",

--- a/src/test/resources/jsonld/HT017480009.json
+++ b/src/test/resources/jsonld/HT017480009.json
@@ -71,16 +71,16 @@
     "type" : [ "PublicationEvent" ],
     "startDate" : "2012"
   } ],
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017480009",
+    "label" : "Culturegraph Ressource"
+  } ],
   "similar" : [ {
     "id" : "http://dx.doi.org/10.4126/38m-004826540",
     "label" : "DOI-Link"
   }, {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:38m-0000006293",
     "label" : "URN-Link"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017480009",
-    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT017480009",

--- a/src/test/resources/jsonld/HT017642656.json
+++ b/src/test/resources/jsonld/HT017642656.json
@@ -92,11 +92,11 @@
     "startDate" : "1932"
   } ],
   "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017642656",
-    "label" : "Culturegraph Ressource"
-  }, {
     "id" : "http://ld.zdb-services.de/resource/2716332-5",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017642656",
+    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT017642656",

--- a/src/test/resources/jsonld/HT018138676.json
+++ b/src/test/resources/jsonld/HT018138676.json
@@ -101,12 +101,6 @@
   } ],
   "otherTitleInformation" : [ "für Politik, Handel und Literatur" ],
   "publication" : [ {
-    "type" : [ "SecondaryPublicationEvent" ],
-    "description" : [ "München : Münchener Digitalisierungszentrum, 2008-2013. - Digital. Ausg.: Bremen : Staats- und Universitätsbibliothek Bremen, 2015", "Digital. Ausg." ],
-    "location" : "München",
-    "publishedBy" : "Münchener Digitalisierungszentrum",
-    "startDate" : "2008"
-  }, {
     "type" : [ "PublicationEvent" ],
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#d",
@@ -118,17 +112,23 @@
     "location" : "Bremen",
     "publishedBy" : "Meier",
     "startDate" : "1741"
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "description" : [ "München : Münchener Digitalisierungszentrum, 2008-2013. - Digital. Ausg.: Bremen : Staats- und Universitätsbibliothek Bremen, 2015", "Digital. Ausg." ],
+    "location" : "München",
+    "publishedBy" : "Münchener Digitalisierungszentrum",
+    "startDate" : "2008"
+  } ],
+  "sameAs" : [ {
+    "id" : "http://ld.zdb-services.de/resource/2751526-6",
+    "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018138676",
+    "label" : "Culturegraph Ressource"
   } ],
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:gbv:46:1-6622",
     "label" : "URN-Link"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018138676",
-    "label" : "Culturegraph Ressource"
-  }, {
-    "id" : "http://ld.zdb-services.de/resource/2751526-6",
-    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018138676",

--- a/src/test/resources/jsonld/HT018239864.json
+++ b/src/test/resources/jsonld/HT018239864.json
@@ -182,13 +182,13 @@
     "publishedBy" : "de Gruyter",
     "startDate" : "2014"
   } ],
-  "seeAlso" : [ {
-    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764418&custom_att_2=simple_viewer",
-    "label" : "Digitool"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018239864",
     "label" : "Culturegraph Ressource"
+  } ],
+  "seeAlso" : [ {
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5764418&custom_att_2=simple_viewer",
+    "label" : "Digitool"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018239864",

--- a/src/test/resources/jsonld/HT018260267.json
+++ b/src/test/resources/jsonld/HT018260267.json
@@ -236,11 +236,11 @@
     "id" : "http://worldcat.org/oclc/1075956736",
     "label" : "1075956736"
   }, {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018260267",
-    "label" : "Culturegraph Ressource"
-  }, {
     "id" : "http://worldcat.org/oclc/1067791026",
     "label" : "1067791026"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018260267",
+    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018260267",

--- a/src/test/resources/jsonld/HT018295975.json
+++ b/src/test/resources/jsonld/HT018295975.json
@@ -158,13 +158,13 @@
     "publishedBy" : "Salier",
     "startDate" : "2014"
   } ],
-  "seeAlso" : [ {
-    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852708&custom_att_2=simple_viewer",
-    "label" : "Digitool"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018295975",
     "label" : "Culturegraph Ressource"
+  } ],
+  "seeAlso" : [ {
+    "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=5852708&custom_att_2=simple_viewer",
+    "label" : "Digitool"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018295975",

--- a/src/test/resources/jsonld/HT018305016.json
+++ b/src/test/resources/jsonld/HT018305016.json
@@ -377,14 +377,14 @@
       "id" : "http://lobid.org/resources/HT016533311#!",
       "label" : "Schauspielhaus Düsseldorf"
     } ],
-    "numbering" : "1925,01,31"
+    "numbering" : "1925,02,01"
   }, {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
       "id" : "http://lobid.org/resources/HT016533311#!",
       "label" : "Schauspielhaus Düsseldorf"
     } ],
-    "numbering" : "1925,02,01"
+    "numbering" : "1925,01,31"
   } ],
   "otherTitleInformation" : [ "Sonnabend, den 31. Januar ; Sonntag, den 1. Februar ; abends 7 Uhr ; Dramatische Chronik in 6 Scenen und einem Epilog" ],
   "publication" : [ {

--- a/src/test/resources/jsonld/HT018468645.json
+++ b/src/test/resources/jsonld/HT018468645.json
@@ -140,13 +140,13 @@
     "publishedBy" : "Böhlau",
     "startDate" : "2014"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689",
-    "label" : "DOI-Link"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018468645",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689",
+    "label" : "DOI-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018468645",

--- a/src/test/resources/jsonld/HT018585406.json
+++ b/src/test/resources/jsonld/HT018585406.json
@@ -140,13 +140,13 @@
     "location" : "Kaiserslautern",
     "startDate" : "2006"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70000475",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:70000475"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018585406",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70000475",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:70000475"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018585406",

--- a/src/test/resources/jsonld/HT018617137.json
+++ b/src/test/resources/jsonld/HT018617137.json
@@ -132,13 +132,13 @@
     "publishedBy" : "Projekt \"Nachhaltige Forschung an Fachhochschulen in NRW\"",
     "startDate" : "2015"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128",
-    "label" : "URN-Link"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018617137",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-66128",
+    "label" : "URN-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018617137",

--- a/src/test/resources/jsonld/HT018700720.json
+++ b/src/test/resources/jsonld/HT018700720.json
@@ -124,16 +124,16 @@
     "publishedBy" : "BZgA",
     "startDate" : "2015"
   } ],
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018700720",
+    "label" : "Culturegraph Ressource"
+  } ],
   "similar" : [ {
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-135798",
     "label" : "URN-Link"
   }, {
     "id" : "http://dx.doi.org/10.4126/38m-006326817",
     "label" : "38m-006326817"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018700720",
-    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018700720",

--- a/src/test/resources/jsonld/HT018703339.json
+++ b/src/test/resources/jsonld/HT018703339.json
@@ -103,13 +103,13 @@
     "location" : "Waltrop",
     "startDate" : "2015"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.17629/www.diagnosticpathology.eu-2015-1:14",
-    "label" : "DOI-Link"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018703339",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.17629/www.diagnosticpathology.eu-2015-1:14",
+    "label" : "DOI-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018703339",

--- a/src/test/resources/jsonld/HT018801101.json
+++ b/src/test/resources/jsonld/HT018801101.json
@@ -109,13 +109,13 @@
     "publishedBy" : "ZB MED - Leibniz-Informationszentrum Lebenswissenschaften",
     "startDate" : "2015"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006399387",
-    "label" : "FRL01-006399387"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018801101",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.4126/FRL01-006399387",
+    "label" : "FRL01-006399387"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018801101",

--- a/src/test/resources/jsonld/HT018895767.json
+++ b/src/test/resources/jsonld/HT018895767.json
@@ -159,13 +159,13 @@
     "publishedBy" : "Landeszentrale für Politische Bildung",
     "startDate" : "2015"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:70030352"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018895767",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:70030352"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018895767",

--- a/src/test/resources/jsonld/HT018939763.json
+++ b/src/test/resources/jsonld/HT018939763.json
@@ -117,6 +117,10 @@
     "publishedBy" : "Peter Lang Edition",
     "startDate" : "2015"
   } ],
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018939763",
+    "label" : "Culturegraph Ressource"
+  } ],
   "similar" : [ {
     "id" : "http://dx.doi.org/10.3726/978-3-653-05265-7",
     "label" : "978-3-653-05265-7"
@@ -124,10 +128,6 @@
   "seeAlso" : [ {
     "id" : "http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6721516&custom_att_2=simple_viewer",
     "label" : "Digitool"
-  } ],
-  "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT018939763",
-    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT018939763",

--- a/src/test/resources/jsonld/HT019011249.json
+++ b/src/test/resources/jsonld/HT019011249.json
@@ -54,13 +54,13 @@
     "publishedBy" : "Language science press",
     "startDate" : "2016"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.17169/langsci.b91.109",
-    "label" : "langsci.b91.109"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019011249",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.17169/langsci.b91.109",
+    "label" : "langsci.b91.109"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019011249",

--- a/src/test/resources/jsonld/HT019054687.json
+++ b/src/test/resources/jsonld/HT019054687.json
@@ -128,13 +128,13 @@
     "publishedBy" : "Bundesanstalt für Wasserbau (BAW)",
     "startDate" : "2015"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:101:1-201602092139",
-    "label" : "urn:nbn:de:101:1-201602092139"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019054687",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:101:1-201602092139",
+    "label" : "urn:nbn:de:101:1-201602092139"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019054687",

--- a/src/test/resources/jsonld/HT019149667.json
+++ b/src/test/resources/jsonld/HT019149667.json
@@ -184,13 +184,13 @@
     "publishedBy" : "Rheinland-Pfalz, Landesamt für Soziales, Jugend und Versorgung - Landesjugendamt",
     "startDate" : "2004"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70052615",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:70052615"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019149667",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70052615",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:70052615"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019149667",

--- a/src/test/resources/jsonld/HT019248596.json
+++ b/src/test/resources/jsonld/HT019248596.json
@@ -144,13 +144,13 @@
     "publishedBy" : "[Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht Rheinland-Pfalz]",
     "startDate" : "2016"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019248596",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019248596",

--- a/src/test/resources/jsonld/HT019357035.json
+++ b/src/test/resources/jsonld/HT019357035.json
@@ -54,17 +54,17 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "id" : "http://lobid.org/resources/HT001252634#!",
-      "label" : "Progress in brain research"
-    } ],
-    "numbering" : "231"
-  }, {
-    "type" : [ "IsPartOfRelation" ],
-    "hasSuperordinate" : [ {
       "id" : "http://lobid.org/resources/HT006472521#!",
       "label" : "lobid Ressource"
     } ],
     "numbering" : "4, part B"
+  }, {
+    "type" : [ "IsPartOfRelation" ],
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT001252634#!",
+      "label" : "Progress in brain research"
+    } ],
+    "numbering" : "231"
   } ],
   "edition" : [ "First edition" ],
   "isbn" : [ "9780128138793" ],

--- a/src/test/resources/jsonld/HT019440025.json
+++ b/src/test/resources/jsonld/HT019440025.json
@@ -191,13 +191,13 @@
     "publishedBy" : "Landtag Rheinland-Pfalz",
     "startDate" : "2017"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70119907",
-    "label" : "urn:nbn:de:hbz:929:02-edoweb:70119907"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019440025",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70119907",
+    "label" : "urn:nbn:de:hbz:929:02-edoweb:70119907"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019440025",

--- a/src/test/resources/jsonld/HT019474284.json
+++ b/src/test/resources/jsonld/HT019474284.json
@@ -91,13 +91,13 @@
     "publishedBy" : "Springer",
     "startDate" : "2016"
   } ],
-  "similar" : [ {
-    "note" : [ "Erscheint auch als" ],
-    "isbn" : [ "9783319324159" ]
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019474284",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "note" : [ "Erscheint auch als" ],
+    "isbn" : [ "9783319324159" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019474284",

--- a/src/test/resources/jsonld/HT019488427.json
+++ b/src/test/resources/jsonld/HT019488427.json
@@ -80,13 +80,13 @@
     "publishedBy" : "ZB MED - Informationszentrum Lebenswissenschaften",
     "startDate" : "2017"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006405231",
-    "label" : "FRL01-006405231"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019488427",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.4126/FRL01-006405231",
+    "label" : "FRL01-006405231"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019488427",

--- a/src/test/resources/jsonld/HT019552585.json
+++ b/src/test/resources/jsonld/HT019552585.json
@@ -137,11 +137,11 @@
     "startDate" : "2017"
   } ],
   "sameAs" : [ {
-    "id" : "http://ld.zdb-services.de/resource/2915820-5",
-    "label" : "ZDB-Ressource"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019552585",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2915820-5",
+    "label" : "ZDB-Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019552585",

--- a/src/test/resources/jsonld/HT019582722.json
+++ b/src/test/resources/jsonld/HT019582722.json
@@ -106,11 +106,11 @@
     "startDate" : "2015"
   } ],
   "sameAs" : [ {
-    "id" : "http://worldcat.org/oclc/956518475",
-    "label" : "956518475"
-  }, {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019582722",
     "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/956518475",
+    "label" : "956518475"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019582722",

--- a/src/test/resources/jsonld/HT019838800.json
+++ b/src/test/resources/jsonld/HT019838800.json
@@ -106,13 +106,13 @@
     "publishedBy" : "Herausgeber: Umweltbundesamt",
     "startDate" : "2018"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006410624",
-    "label" : "FRL01-006410624"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019838800",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.4126/FRL01-006410624",
+    "label" : "FRL01-006410624"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT019838800",

--- a/src/test/resources/jsonld/HT020015895.json
+++ b/src/test/resources/jsonld/HT020015895.json
@@ -90,12 +90,12 @@
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "Lieblingsplätze zum Entdecken"
+      "label" : "Gmeiner Kultur"
     } ]
   }, {
     "type" : [ "IsPartOfRelation" ],
     "hasSuperordinate" : [ {
-      "label" : "Gmeiner Kultur"
+      "label" : "Lieblingsplätze zum Entdecken"
     } ]
   } ],
   "edition" : [ "1. Auflage" ],

--- a/src/test/resources/jsonld/HT021282447.json
+++ b/src/test/resources/jsonld/HT021282447.json
@@ -84,11 +84,11 @@
     "startDate" : "2022"
   } ],
   "sameAs" : [ {
-    "id" : "http://hub.culturegraph.org/resource/HBZ-HT021282447",
-    "label" : "Culturegraph Ressource"
-  }, {
     "id" : "http://ld.zdb-services.de/resource/3112826-9",
     "label" : "ZDB-Ressource"
+  }, {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT021282447",
+    "label" : "Culturegraph Ressource"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/HT021282447",

--- a/src/test/resources/jsonld/TT002234042.json
+++ b/src/test/resources/jsonld/TT002234042.json
@@ -77,13 +77,13 @@
     "type" : [ "PublicationEvent" ],
     "startDate" : "2001"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-1513",
-    "label" : "urn:nbn:de:hbz:929:02-1513"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-TT002234042",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-1513",
+    "label" : "urn:nbn:de:hbz:929:02-1513"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/TT002234042",

--- a/src/test/resources/jsonld/TT002234459.json
+++ b/src/test/resources/jsonld/TT002234459.json
@@ -113,13 +113,13 @@
     "id" : "http://www.rhein-lahn-info.de/jakobsweg/",
     "label" : "jakobsweg"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079",
-    "label" : "urn:nbn:de:hbz:929:01-2079"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-TT002234459",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-2079",
+    "label" : "urn:nbn:de:hbz:929:01-2079"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/TT002234459",

--- a/src/test/resources/jsonld/TT002234858.json
+++ b/src/test/resources/jsonld/TT002234858.json
@@ -75,13 +75,13 @@
     "id" : "http://cmswebserver10.icteam.net/stk/",
     "label" : "stk"
   } ],
-  "similar" : [ {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-8578",
-    "label" : "urn:nbn:de:hbz:929:01-8578"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-TT002234858",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:01-8578",
+    "label" : "urn:nbn:de:hbz:929:01-8578"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/TT002234858",

--- a/src/test/resources/jsonld/TT050409948.json
+++ b/src/test/resources/jsonld/TT050409948.json
@@ -83,13 +83,13 @@
     "publishedBy" : "Springer Berlin Heidelberg",
     "startDate" : "2012"
   } ],
-  "similar" : [ {
-    "id" : "http://dx.doi.org/10.1007/978-3-642-20784-6",
-    "label" : "DOI-Link"
-  } ],
   "sameAs" : [ {
     "id" : "http://hub.culturegraph.org/resource/HBZ-TT050409948",
     "label" : "Culturegraph Ressource"
+  } ],
+  "similar" : [ {
+    "id" : "http://dx.doi.org/10.1007/978-3-642-20784-6",
+    "label" : "DOI-Link"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/TT050409948",

--- a/web/conf/context.jsonld
+++ b/web/conf/context.jsonld
@@ -9,18 +9,18 @@
     "focus" : {
       "@id" : "http://xmlns.com/foaf/0.1/focus"
     },
-    "SecondaryPublicationEvent" : {
-      "@id" : "http://purl.org/lobid/lv#SecondaryPublicationEvent"
-    },
     "altLabel" : {
       "@id" : "http://www.w3.org/2004/02/skos/core#altLabel"
     },
-    "Image" : {
-      "@id" : "http://purl.org/ontology/bibo/Image"
+    "SecondaryPublicationEvent" : {
+      "@id" : "http://purl.org/lobid/lv#SecondaryPublicationEvent"
     },
     "type" : {
       "@id" : "@type",
       "@container" : "@set"
+    },
+    "Image" : {
+      "@id" : "http://purl.org/ontology/bibo/Image"
     },
     "ReferenceSource" : {
       "@id" : "http://purl.org/ontology/bibo/ReferenceSource"
@@ -35,14 +35,14 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/contribution",
       "@container" : "@list"
     },
+    "notation" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#notation"
+    },
     "Book" : {
       "@id" : "http://purl.org/ontology/bibo/Book"
     },
     "Combination" : {
       "@id" : "http://iflastandards.info/ns/isbd/terms/mediatype/T1008"
-    },
-    "notation" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#notation"
     },
     "Work" : {
       "@id" : "https://d-nb.info/standards/elementset/gnd#Work"
@@ -100,14 +100,14 @@
     "bibliographicCitation" : {
       "@id" : "http://purl.org/dc/terms/bibliographicCitation"
     },
+    "dateOfBirthAndDeath" : {
+      "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfBirthAndDeath"
+    },
     "Map" : {
       "@id" : "http://purl.org/ontology/bibo/Map"
     },
     "Person" : {
       "@id" : "https://d-nb.info/standards/elementset/gnd#Person"
-    },
-    "dateOfBirthAndDeath" : {
-      "@id" : "https://d-nb.info/standards/elementset/gnd#dateOfBirthAndDeath"
     },
     "startDate" : {
       "@id" : "http://schema.org/startDate"
@@ -143,12 +143,12 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/hasItem",
       "@container" : "@set"
     },
-    "Festschrift" : {
-      "@id" : "http://purl.org/lobid/lv#Festschrift"
-    },
     "alternativeTitle" : {
       "@id" : "http://purl.org/dc/terms/alternative",
       "@container" : "@set"
+    },
+    "Festschrift" : {
+      "@id" : "http://purl.org/lobid/lv#Festschrift"
     },
     "lon" : {
       "@id" : "http://schema.org/longitude"
@@ -179,18 +179,18 @@
     "modifiedBy" : {
       "@id" : "http://open-services.net/ns/core#modifiedBy"
     },
-    "PublishedScore" : {
-      "@id" : "http://purl.org/ontology/mo/PublishedScore"
-    },
     "gndIdentifier" : {
       "@id" : "https://d-nb.info/standards/elementset/gnd#gndIdentifier"
     },
-    "PublicationIssue" : {
-      "@id" : "http://schema.org/PublicationIssue"
+    "PublishedScore" : {
+      "@id" : "http://purl.org/ontology/mo/PublishedScore"
     },
     "oclcNumber" : {
       "@id" : "http://purl.org/ontology/bibo/oclcnum",
       "@container" : "@set"
+    },
+    "PublicationIssue" : {
+      "@id" : "http://schema.org/PublicationIssue"
     },
     "corporateBodyForTitle" : {
       "@id" : "http://rdaregistry.info/Elements/u/P60327",
@@ -246,14 +246,14 @@
     "publishedBy" : {
       "@id" : "http://schema.org/publishedBy"
     },
-    "Miscellaneous" : {
-      "@id" : "http://purl.org/lobid/lv#Miscellaneous"
-    },
     "agent" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/agent"
     },
     "inDataset" : {
       "@id" : "http://purl.org/lobid/lv#inDataset"
+    },
+    "Miscellaneous" : {
+      "@id" : "http://purl.org/lobid/lv#Miscellaneous"
     },
     "ComplexSubject" : {
       "@id" : "http://www.loc.gov/mads/rdf/v1#ComplexSubject"
@@ -329,21 +329,21 @@
     "workNumbering" : {
       "@id" : "http://rdaregistry.info/Elements/w/P10079"
     },
-    "Thesis" : {
-      "@id" : "http://purl.org/ontology/bibo/Thesis"
-    },
     "exampleOfWork" : {
       "@id" : "http://purl.org/lobid/lv#exampleOfWork"
+    },
+    "Thesis" : {
+      "@id" : "http://purl.org/ontology/bibo/Thesis"
     },
     "ArchivedWebPage" : {
       "@id" : "http://purl.org/lobid/lv#ArchivedWebPage"
     },
-    "BibliographicResource" : {
-      "@id" : "http://purl.org/dc/terms/BibliographicResource"
-    },
     "license" : {
       "@id" : "http://schema.org/license",
       "@container" : "@set"
+    },
+    "BibliographicResource" : {
+      "@id" : "http://purl.org/dc/terms/BibliographicResource"
     },
     "musicalKey" : {
       "@id" : "http://rdaregistry.info/Elements/w/P10221"
@@ -380,9 +380,6 @@
       "@id" : "http://www.w3.org/2001/XMLSchema#",
       "@container" : "@set"
     },
-    "DataFeedItem" : {
-      "@id" : "http://schema.org/DataFeedItem"
-    },
     "description" : {
       "@id" : "http://purl.org/dc/terms/description",
       "@container" : "@set"
@@ -391,11 +388,14 @@
       "@id" : "http://purl.org/ontology/bibo/edition",
       "@container" : "@set"
     },
-    "Standard" : {
-      "@id" : "http://purl.org/ontology/bibo/Standard"
+    "DataFeedItem" : {
+      "@id" : "http://schema.org/DataFeedItem"
     },
     "instrument" : {
       "@id" : "http://schema.org/instrument"
+    },
+    "Standard" : {
+      "@id" : "http://purl.org/ontology/bibo/Standard"
     },
     "medium" : {
       "@id" : "http://purl.org/dc/terms/medium",
@@ -460,12 +460,12 @@
     "currentLocation" : {
       "@id" : "http://purl.org/lobid/lv#currentLocation"
     },
-    "Series" : {
-      "@id" : "http://purl.org/ontology/bibo/Series"
-    },
     "hasSuperordinate" : {
       "@id" : "http://purl.org/lobid/lv#hasSuperordinate",
       "@container" : "@set"
+    },
+    "Series" : {
+      "@id" : "http://purl.org/ontology/bibo/Series"
     },
     "subjectAltLabel" : {
       "@id" : "http://purl.org/lobid/lv#subjectAltLabel",
@@ -474,11 +474,11 @@
     "itemOf" : {
       "@id" : "http://id.loc.gov/ontologies/bibframe/itemOf"
     },
-    "PublicationEvent" : {
-      "@id" : "http://schema.org/PublicationEvent"
-    },
     "sourceOrganization" : {
       "@id" : "http://schema.org/sourceOrganization"
+    },
+    "PublicationEvent" : {
+      "@id" : "http://schema.org/PublicationEvent"
     },
     "location" : {
       "@id" : "http://schema.org/location"
@@ -487,7 +487,7 @@
       "@id" : "http://id.loc.gov/ontologies/bibframe/Contribution"
     },
     "sameAs" : {
-      "@id" : "http://www.w3.org/2002/07/owl#sameAs",
+      "@id" : "http://schema.org/sameAs",
       "@container" : "@set"
     }
   }


### PR DESCRIPTION
As discussed here: https://github.com/hbz/lobid-resources/issues/1400#issuecomment-1293361050

@dr0i could you change the context of owl:sameAs to sdo:sameAs.

Also @acka47 `"similar"` also had links to other reproductions and physical forms without URI/URLs now in MARC listed as:
~~775 - Other Edition Entry (R)~~
776 - Additional Physical Form Entry (R) 
Which duplicates info from "primaryForm" and other related elements, should we drop mappings from 775/776 to `"sameAs"`?