### PR TITLE
Move date into `describedBy.resultOf.Object` #1470

### DIFF
--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -40,13 +40,17 @@ replace_all("describedBy.resultOf.object.dateCreated"," .*","")
 replace_all("describedBy.resultOf.object.dateCreated","c|©|\\s?|,|.|:|;|/|=","")
 replace_all("describedBy.resultOf.object.dateModified","-","")
 replace_all("describedBy.resultOf.object.dateModified"," .*","")
-replace_all("describedBy.resultOf.object.+dateModified","c|©|\\s?|,|.|:|;|/|=","")
+replace_all("describedBy.resultOf.object.dateModified","c|©|\\s?|,|.|:|;|/|=","")
 unless any_match("describedBy.resultOf.object.dateCreated","\\d{8}|\\d{4}")
 	remove_field("describedBy.resultOf.object.dateCreated")
 end
 unless any_match("describedBy.resultOf.object.dateModified","\\d{8}|\\d{4}")
 	remove_field("describedBy.resultOf.object.dateModified")
 end
+replace_all("describedBy.resultOf.object.dateCreated","^(\\d{4})(\\d{2})(\\d{2})$","$1-$2-$3")
+replace_all("describedBy.resultOf.object.dateModified","^(\\d{4})(\\d{2})(\\d{2})$","$1-$2-$3")
+replace_all("describedBy.resultOf.object.dateCreated","^(\\d{4})$","$1-01-01")
+replace_all("describedBy.resultOf.object.dateModified","^(\\d{4})$","$1-01-01")
 
 set_array("describedBy.resultOf.object.type[]", "DataFeedItem")
 

--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -7,22 +7,6 @@ prepend("describedBy.label", "Webseite der hbz-Ressource ")
 
 set_array("describedBy.type[]", "BibliographicDescription")
 
-# MNG is a ALMA-specific element
-
-copy_field("MNG  .b","describedBy.dateCreated")
-copy_field("MNG  .d","describedBy.dateModified")
-replace_all("describedBy.dateCreated","-","")
-replace_all("describedBy.dateCreated"," .*","")
-replace_all("describedBy.dateCreated","c|©|\\s?|,|.|:|;|/|=","")
-replace_all("describedBy.dateModified","-","")
-replace_all("describedBy.dateModified"," .*","")
-replace_all("describedBy.dateModified","c|©|\\s?|,|.|:|;|/|=","")
-unless any_match("describedBy.dateCreated","\\d{8}|\\d{4}")
-	remove_field("describedBy.dateCreated")
-end
-unless any_match("describedBy.dateModified","\\d{8}|\\d{4}")
-	remove_field("describedBy.dateModified")
-end
 
 add_field("describedBy.inDataset.id","http://lobid.org/resources/dataset#!")
 
@@ -47,6 +31,22 @@ add_field("describedBy.resultOf.instrument.label","Software lobid-resources")
 copy_field("almaMmsId","describedBy.resultOf.object.id")
 prepend("describedBy.resultOf.object.id","https://lobid.org/hbz01/")
 
+# MNG is a ALMA-specific element
+
+copy_field("MNG  .b","describedBy.resultOf.object.dateCreated")
+copy_field("MNG  .d","describedBy.resultOf.object.dateModified")
+replace_all("describedBy.resultOf.object.dateCreated","-","")
+replace_all("describedBy.resultOf.object.dateCreated"," .*","")
+replace_all("describedBy.resultOf.object.dateCreated","c|©|\\s?|,|.|:|;|/|=","")
+replace_all("describedBy.resultOf.object.dateModified","-","")
+replace_all("describedBy.resultOf.object.dateModified"," .*","")
+replace_all("describedBy.resultOf.object.+dateModified","c|©|\\s?|,|.|:|;|/|=","")
+unless any_match("describedBy.resultOf.object.dateCreated","\\d{8}|\\d{4}")
+	remove_field("describedBy.resultOf.object.dateCreated")
+end
+unless any_match("describedBy.resultOf.object.dateModified","\\d{8}|\\d{4}")
+	remove_field("describedBy.resultOf.object.dateModified")
+end
 
 set_array("describedBy.resultOf.object.type[]", "DataFeedItem")
 

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990001412590206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220911",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-09-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990001412590206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990001412590206441",
     "label" : "Webseite der hbz-Ressource 990001412590206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220911",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990001412590206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220911",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990001412590206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990011470300206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990011470300206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990011470300206441",
     "label" : "Webseite der hbz-Ressource 990011470300206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990011470300206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990011470300206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990014830510206441",
     "label" : "Webseite der hbz-Ressource 990014830510206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990014830510206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990014830510206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990014830510206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990014830510206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990015048200206447.json
+++ b/src/test/resources/alma-fix/990015048200206447.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990015048200206447",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220612",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-06-12",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990015048200206447 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990015048200206447.json
+++ b/src/test/resources/alma-fix/990015048200206447.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990015048200206447",
     "label" : "Webseite der hbz-Ressource 990015048200206447",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220612",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990015048200206447",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220612",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990015048200206447 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990016782920206441",
     "label" : "Webseite der hbz-Ressource 990016782920206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990016782920206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990016782920206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990016782920206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990016782920206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990021367710206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990021367710206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990021367710206441",
     "label" : "Webseite der hbz-Ressource 990021367710206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990021367710206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990021367710206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990021974470206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220531",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-05-31",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990021974470206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990021974470206441",
     "label" : "Webseite der hbz-Ressource 990021974470206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220531",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990021974470206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220531",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990021974470206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990030574430206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220606",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-06-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990030574430206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990030574430206441",
     "label" : "Webseite der hbz-Ressource 990030574430206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220606",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990030574430206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220606",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990030574430206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990033263300206441",
     "label" : "Webseite der hbz-Ressource 990033263300206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990033263300206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990033263300206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990033263300206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990033263300206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990035016180206441",
     "label" : "Webseite der hbz-Ressource 990035016180206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220311",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990035016180206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220311",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990035016180206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990035016180206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220311",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-03-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990035016180206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990041403870206441",
     "label" : "Webseite der hbz-Ressource 990041403870206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990041403870206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990041403870206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990041403870206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990041403870206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990050000600206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990050000600206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990050000600206441",
     "label" : "Webseite der hbz-Ressource 990050000600206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990050000600206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990050000600206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990051552280206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220215",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-02-15",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990051552280206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/990051552280206441",
     "label" : "Webseite der hbz-Ressource 990051552280206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220215",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990051552280206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220215",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990051552280206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990051708340206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990051708340206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/990051708340206441",
     "label" : "Webseite der hbz-Ressource 990051708340206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990051708340206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990051708340206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -13,8 +13,6 @@
     "id" : "http://lobid.org/resources/990052965140206441",
     "label" : "Webseite der hbz-Ressource 990052965140206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20221108",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -29,6 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990052965140206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20221108",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990052965140206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -27,8 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990052965140206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20221108",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-11-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990052965140206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -32,8 +32,6 @@
     "id" : "http://lobid.org/resources/990053976760206441",
     "label" : "Webseite der hbz-Ressource 990053976760206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -48,6 +46,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990053976760206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990053976760206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -46,8 +46,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990053976760206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990053976760206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -34,8 +34,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990054215550206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054215550206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -20,8 +20,6 @@
     "id" : "http://lobid.org/resources/990054215550206441",
     "label" : "Webseite der hbz-Ressource 990054215550206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -36,6 +34,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990054215550206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054215550206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -35,8 +35,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990054301770206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210407",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054301770206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -21,8 +21,6 @@
     "id" : "http://lobid.org/resources/990054301770206441",
     "label" : "Webseite der hbz-Ressource 990054301770206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210407",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -37,6 +35,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990054301770206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210407",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054301770206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990059571560206441",
     "label" : "Webseite der hbz-Ressource 990059571560206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220308",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990059571560206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220308",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990059571560206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990059571560206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220308",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-03-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990059571560206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990063549080206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990063549080206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990063549080206441",
     "label" : "Webseite der hbz-Ressource 990063549080206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990063549080206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990063549080206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990065341720206441",
     "label" : "Webseite der hbz-Ressource 990065341720206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990065341720206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990065341720206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990065341720206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990065341720206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -34,8 +34,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990103770440206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210424",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990103770440206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -20,8 +20,6 @@
     "id" : "http://lobid.org/resources/990103770440206441",
     "label" : "Webseite der hbz-Ressource 990103770440206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210424",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -36,6 +34,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990103770440206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210424",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990103770440206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -19,8 +19,6 @@
     "id" : "http://lobid.org/resources/990103899140206441",
     "label" : "Webseite der hbz-Ressource 990103899140206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210911",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -35,6 +33,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990103899140206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210911",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990103899140206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -33,8 +33,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990103899140206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210911",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-09-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990103899140206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990104908070206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220624",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-06-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990104908070206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990104908070206441",
     "label" : "Webseite der hbz-Ressource 990104908070206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220624",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990104908070206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220624",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990104908070206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -32,8 +32,6 @@
     "id" : "http://lobid.org/resources/990108740950206441",
     "label" : "Webseite der hbz-Ressource 990108740950206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -48,6 +46,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990108740950206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108740950206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -46,8 +46,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990108740950206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108740950206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990108873860206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108873860206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990108873860206441",
     "label" : "Webseite der hbz-Ressource 990108873860206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990108873860206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108873860206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990108874370206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108874370206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990108874370206441",
     "label" : "Webseite der hbz-Ressource 990108874370206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990108874370206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108874370206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990110509950206441",
     "label" : "Webseite der hbz-Ressource 990110509950206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990110509950206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110509950206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990110509950206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110509950206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -26,8 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990110714900206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20221008",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-10-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110714900206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -12,8 +12,6 @@
     "id" : "http://lobid.org/resources/990110714900206441",
     "label" : "Webseite der hbz-Ressource 990110714900206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20221008",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -28,6 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990110714900206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20221008",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110714900206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -12,8 +12,6 @@
     "id" : "http://lobid.org/resources/990110881770206441",
     "label" : "Webseite der hbz-Ressource 990110881770206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -28,6 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990110881770206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110881770206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -26,8 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990110881770206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110881770206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990114098170206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990114098170206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990114098170206441",
     "label" : "Webseite der hbz-Ressource 990114098170206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990114098170206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990114098170206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990118562160206441",
     "label" : "Webseite der hbz-Ressource 990118562160206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220513",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990118562160206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220513",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990118562160206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990118562160206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220513",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-05-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990118562160206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/990122511970206441",
     "label" : "Webseite der hbz-Ressource 990122511970206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210610",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990122511970206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210610",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990122511970206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990122511970206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210610",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-06-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990122511970206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990123613330206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990123613330206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990123613330206441",
     "label" : "Webseite der hbz-Ressource 990123613330206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990123613330206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990123613330206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990124590390206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210926",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-09-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990124590390206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990124590390206441",
     "label" : "Webseite der hbz-Ressource 990124590390206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210926",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990124590390206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210926",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990124590390206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990126276700206441",
     "label" : "Webseite der hbz-Ressource 990126276700206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220228",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990126276700206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220228",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990126276700206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990126276700206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220228",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-02-28",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990126276700206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990133067580206441",
     "label" : "Webseite der hbz-Ressource 990133067580206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990133067580206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990133067580206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990133067580206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990133067580206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990139686910206441",
     "label" : "Webseite der hbz-Ressource 990139686910206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220603",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990139686910206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220603",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990139686910206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990139686910206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220603",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-06-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990139686910206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990141342350206441",
     "label" : "Webseite der hbz-Ressource 990141342350206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220504",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990141342350206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220504",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990141342350206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990141342350206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220504",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-05-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990141342350206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990150856900206441",
     "label" : "Webseite der hbz-Ressource 990150856900206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220723",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990150856900206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220723",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990150856900206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990150856900206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220723",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-07-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990150856900206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -12,8 +12,6 @@
     "id" : "http://lobid.org/resources/990156027740206441",
     "label" : "Webseite der hbz-Ressource 990156027740206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210408",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -28,6 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990156027740206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210408",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990156027740206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -26,8 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990156027740206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210408",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990156027740206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990167595410206441",
     "label" : "Webseite der hbz-Ressource 990167595410206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210914",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990167595410206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210914",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990167595410206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990167595410206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210914",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-09-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990167595410206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990171142550206441",
     "label" : "Webseite der hbz-Ressource 990171142550206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990171142550206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990171142550206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990171142550206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990171142550206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990173811970206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990173811970206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990173811970206441",
     "label" : "Webseite der hbz-Ressource 990173811970206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990173811970206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990173811970206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -33,8 +33,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990181275760206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990181275760206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -19,8 +19,6 @@
     "id" : "http://lobid.org/resources/990181275760206441",
     "label" : "Webseite der hbz-Ressource 990181275760206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -35,6 +33,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990181275760206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990181275760206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -37,8 +37,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990183054020206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220709",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-07-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183054020206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -23,8 +23,6 @@
     "id" : "http://lobid.org/resources/990183054020206441",
     "label" : "Webseite der hbz-Ressource 990183054020206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220709",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -39,6 +37,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990183054020206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220709",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183054020206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -27,8 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990183092590206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220610",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-06-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183092590206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -13,8 +13,6 @@
     "id" : "http://lobid.org/resources/990183092590206441",
     "label" : "Webseite der hbz-Ressource 990183092590206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220610",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -29,6 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990183092590206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220610",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183092590206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990184127410206441",
     "label" : "Webseite der hbz-Ressource 990184127410206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210416",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990184127410206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210416",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990184127410206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990184127410206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210416",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-16",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990184127410206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990185607520206441",
     "label" : "Webseite der hbz-Ressource 990185607520206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210826",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990185607520206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210826",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990185607520206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990185607520206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210826",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-08-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990185607520206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990185619180206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220223",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-02-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990185619180206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990185619180206441",
     "label" : "Webseite der hbz-Ressource 990185619180206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220223",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990185619180206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220223",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990185619180206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990189160110206441",
     "label" : "Webseite der hbz-Ressource 990189160110206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990189160110206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990189160110206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990189160110206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990189160110206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -12,8 +12,6 @@
     "id" : "http://lobid.org/resources/990190567380206441",
     "label" : "Webseite der hbz-Ressource 990190567380206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -28,6 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990190567380206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990190567380206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -26,8 +26,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990190567380206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990190567380206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990193094010206441",
     "label" : "Webseite der hbz-Ressource 990193094010206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990193094010206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193094010206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990193094010206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193094010206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -25,8 +25,6 @@
     "id" : "http://lobid.org/resources/990193229450206441",
     "label" : "Webseite der hbz-Ressource 990193229450206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -41,6 +39,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990193229450206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193229450206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -39,8 +39,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990193229450206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193229450206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990193806600206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193806600206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990193806600206441",
     "label" : "Webseite der hbz-Ressource 990193806600206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990193806600206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193806600206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990194668760206441",
     "label" : "Webseite der hbz-Ressource 990194668760206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990194668760206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990194668760206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990194668760206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990194668760206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990194744870206441",
     "label" : "Webseite der hbz-Ressource 990194744870206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990194744870206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990194744870206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990194744870206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990194744870206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -22,8 +22,6 @@
     "id" : "http://lobid.org/resources/990196925330206441",
     "label" : "Webseite der hbz-Ressource 990196925330206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210802",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -38,6 +36,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990196925330206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210802",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990196925330206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -36,8 +36,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990196925330206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210802",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-08-02",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990196925330206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990197023370206441",
     "label" : "Webseite der hbz-Ressource 990197023370206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990197023370206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197023370206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990197023370206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197023370206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990197067610206441",
     "label" : "Webseite der hbz-Ressource 990197067610206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990197067610206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197067610206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990197067610206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197067610206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -19,8 +19,6 @@
     "id" : "http://lobid.org/resources/990197293880206441",
     "label" : "Webseite der hbz-Ressource 990197293880206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -35,6 +33,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990197293880206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197293880206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -33,8 +33,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990197293880206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197293880206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990199611280206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220204",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-02-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990199611280206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990199611280206441",
     "label" : "Webseite der hbz-Ressource 990199611280206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220204",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990199611280206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220204",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990199611280206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990204246530206441",
     "label" : "Webseite der hbz-Ressource 990204246530206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220524",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990204246530206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220524",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990204246530206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990204246530206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220524",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-05-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990204246530206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990206060640206441",
     "label" : "Webseite der hbz-Ressource 990206060640206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220414",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990206060640206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220414",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990206060640206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990206060640206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220414",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-04-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990206060640206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990207668220206441",
     "label" : "Webseite der hbz-Ressource 990207668220206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990207668220206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990207668220206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990207668220206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990207668220206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990207856340206441",
     "label" : "Webseite der hbz-Ressource 990207856340206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220923",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990207856340206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220923",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990207856340206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990207856340206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220923",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-09-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990207856340206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990209515320206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220514",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-05-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990209515320206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990209515320206441",
     "label" : "Webseite der hbz-Ressource 990209515320206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220514",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990209515320206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220514",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990209515320206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990210093550206441",
     "label" : "Webseite der hbz-Ressource 990210093550206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20211118",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210093550206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20211118",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210093550206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210093550206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20211118",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-11-18",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210093550206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210237770206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20221022",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-10-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210237770206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990210237770206441",
     "label" : "Webseite der hbz-Ressource 990210237770206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20221022",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210237770206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20221022",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210237770206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/990210285400206441",
     "label" : "Webseite der hbz-Ressource 990210285400206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20220821",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210285400206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20220821",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210285400206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210285400206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20220821",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2022-08-21",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210285400206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -13,8 +13,6 @@
     "id" : "http://lobid.org/resources/990210312460206441",
     "label" : "Webseite der hbz-Ressource 990210312460206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220606",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -29,6 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210312460206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220606",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210312460206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -27,8 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210312460206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220606",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-06-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210312460206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210667610206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210667610206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990210667610206441",
     "label" : "Webseite der hbz-Ressource 990210667610206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210667610206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210667610206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -15,8 +15,6 @@
     "id" : "http://lobid.org/resources/990210781980206441",
     "label" : "Webseite der hbz-Ressource 990210781980206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220204",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -31,6 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210781980206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220204",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210781980206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -29,8 +29,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210781980206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220204",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-02-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210781980206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210950050206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210950050206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990210950050206441",
     "label" : "Webseite der hbz-Ressource 990210950050206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990210950050206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210950050206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990213367870206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210605",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-06-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990213367870206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990213367870206441",
     "label" : "Webseite der hbz-Ressource 990213367870206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210605",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990213367870206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210605",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990213367870206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -35,8 +35,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990213906490206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20211201",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-12-01",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990213906490206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -21,8 +21,6 @@
     "id" : "http://lobid.org/resources/990213906490206441",
     "label" : "Webseite der hbz-Ressource 990213906490206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20211201",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -37,6 +35,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990213906490206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20211201",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990213906490206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990217478660206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217478660206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990217478660206441",
     "label" : "Webseite der hbz-Ressource 990217478660206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990217478660206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217478660206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990217495840206441",
     "label" : "Webseite der hbz-Ressource 990217495840206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210813",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990217495840206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210813",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217495840206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990217495840206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210813",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-08-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217495840206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -13,8 +13,6 @@
     "id" : "http://lobid.org/resources/990219911120206441",
     "label" : "Webseite der hbz-Ressource 990219911120206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20221111",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -29,6 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990219911120206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20221111",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990219911120206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -27,8 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990219911120206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20221111",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-11-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990219911120206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990223521400206441",
-        "dateCreated" : "20210406",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-06",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990223521400206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990223521400206441",
     "label" : "Webseite der hbz-Ressource 990223521400206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210406",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990223521400206441",
+        "dateCreated" : "20210406",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990223521400206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990225056670206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990225056670206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/990225056670206441",
     "label" : "Webseite der hbz-Ressource 990225056670206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990225056670206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990225056670206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/990226465800206441",
     "label" : "Webseite der hbz-Ressource 990226465800206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210914",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990226465800206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210914",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990226465800206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990226465800206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210914",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-09-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990226465800206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -13,8 +13,6 @@
     "id" : "http://lobid.org/resources/990226763120206441",
     "label" : "Webseite der hbz-Ressource 990226763120206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20220329",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -29,6 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990226763120206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20220329",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990226763120206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -27,8 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990226763120206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20220329",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-03-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990226763120206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990363946050206441",
     "label" : "Webseite der hbz-Ressource 990363946050206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990363946050206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990363946050206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990363946050206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990363946050206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990365842280206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990365842280206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/990365842280206441",
     "label" : "Webseite der hbz-Ressource 990365842280206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990365842280206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990365842280206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -27,8 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990366394400206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990366394400206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -13,8 +13,6 @@
     "id" : "http://lobid.org/resources/990366394400206441",
     "label" : "Webseite der hbz-Ressource 990366394400206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -29,6 +27,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990366394400206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990366394400206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/990367731740206441",
     "label" : "Webseite der hbz-Ressource 990367731740206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20221115",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990367731740206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20221115",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990367731740206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990367731740206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20221115",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2022-11-15",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990367731740206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/990368743120206441",
     "label" : "Webseite der hbz-Ressource 990368743120206441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210405",
-    "dateModified" : "20210409",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990368743120206441",
+        "dateCreated" : "20210405",
+        "dateModified" : "20210409",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990368743120206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/990368743120206441",
-        "dateCreated" : "20210405",
-        "dateModified" : "20210409",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990368743120206441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/991000688209706449.json
+++ b/src/test/resources/alma-fix/991000688209706449.json
@@ -29,7 +29,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/991000688209706449",
-        "dateCreated" : "20220711",
+        "dateCreated" : "2022-07-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991000688209706449 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/991000688209706449.json
+++ b/src/test/resources/alma-fix/991000688209706449.json
@@ -15,7 +15,6 @@
     "id" : "http://lobid.org/resources/991000688209706449",
     "label" : "Webseite der hbz-Ressource 991000688209706449",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20220711",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +29,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/991000688209706449",
+        "dateCreated" : "20220711",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991000688209706449 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -22,7 +22,6 @@
     "id" : "http://lobid.org/resources/991005935279706485",
     "label" : "Webseite der hbz-Ressource 991005935279706485",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20220706",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -37,6 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/991005935279706485",
+        "dateCreated" : "20220706",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991005935279706485 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/991005935279706485",
-        "dateCreated" : "20220706",
+        "dateCreated" : "2022-07-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991005935279706485 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -22,8 +22,6 @@
     "id" : "http://lobid.org/resources/99370682219806441",
     "label" : "Webseite der hbz-Ressource 99370682219806441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210419",
-    "dateModified" : "20210419",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -38,6 +36,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370682219806441",
+        "dateCreated" : "20210419",
+        "dateModified" : "20210419",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370682219806441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -36,8 +36,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370682219806441",
-        "dateCreated" : "20210419",
-        "dateModified" : "20210419",
+        "dateCreated" : "2021-04-19",
+        "dateModified" : "2021-04-19",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370682219806441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/99370699582506441",
     "label" : "Webseite der hbz-Ressource 99370699582506441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210419",
-    "dateModified" : "20210419",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370699582506441",
+        "dateCreated" : "20210419",
+        "dateModified" : "20210419",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370699582506441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370699582506441",
-        "dateCreated" : "20210419",
-        "dateModified" : "20210419",
+        "dateCreated" : "2021-04-19",
+        "dateModified" : "2021-04-19",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370699582506441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370746459806441",
-        "dateCreated" : "20210429",
-        "dateModified" : "20210429",
+        "dateCreated" : "2021-04-29",
+        "dateModified" : "2021-04-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370746459806441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/99370746459806441",
     "label" : "Webseite der hbz-Ressource 99370746459806441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210429",
-    "dateModified" : "20210429",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370746459806441",
+        "dateCreated" : "20210429",
+        "dateModified" : "20210429",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370746459806441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/99370763433806441",
     "label" : "Webseite der hbz-Ressource 99370763433806441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210504",
-    "dateModified" : "20220329",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370763433806441",
+        "dateCreated" : "20210504",
+        "dateModified" : "20220329",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370763433806441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370763433806441",
-        "dateCreated" : "20210504",
-        "dateModified" : "20220329",
+        "dateCreated" : "2021-05-04",
+        "dateModified" : "2022-03-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370763433806441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -18,8 +18,6 @@
     "id" : "http://lobid.org/resources/99370763882706441",
     "label" : "Webseite der hbz-Ressource 99370763882706441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210504",
-    "dateModified" : "20220514",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -34,6 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370763882706441",
+        "dateCreated" : "20210504",
+        "dateModified" : "20220514",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370763882706441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -32,8 +32,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370763882706441",
-        "dateCreated" : "20210504",
-        "dateModified" : "20220514",
+        "dateCreated" : "2021-05-04",
+        "dateModified" : "2022-05-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370763882706441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/99370782520706441",
     "label" : "Webseite der hbz-Ressource 99370782520706441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20210528",
-    "dateModified" : "20211123",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370782520706441",
+        "dateCreated" : "20210528",
+        "dateModified" : "20211123",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370782520706441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99370782520706441",
-        "dateCreated" : "20210528",
-        "dateModified" : "20211123",
+        "dateCreated" : "2021-05-28",
+        "dateModified" : "2021-11-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370782520706441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -30,8 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99371107766906441",
-        "dateCreated" : "20211220",
-        "dateModified" : "20220128",
+        "dateCreated" : "2021-12-20",
+        "dateModified" : "2022-01-28",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371107766906441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -16,8 +16,6 @@
     "id" : "http://lobid.org/resources/99371107766906441",
     "label" : "Webseite der hbz-Ressource 99371107766906441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20211220",
-    "dateModified" : "20220128",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -32,6 +30,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99371107766906441",
+        "dateCreated" : "20211220",
+        "dateModified" : "20220128",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371107766906441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -31,8 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99371447897606441",
-        "dateCreated" : "20220718",
-        "dateModified" : "20220718",
+        "dateCreated" : "2022-07-18",
+        "dateModified" : "2022-07-18",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371447897606441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -17,8 +17,6 @@
     "id" : "http://lobid.org/resources/99371447897606441",
     "label" : "Webseite der hbz-Ressource 99371447897606441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20220718",
-    "dateModified" : "20220718",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -33,6 +31,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99371447897606441",
+        "dateCreated" : "20220718",
+        "dateModified" : "20220718",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371447897606441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -14,8 +14,6 @@
     "id" : "http://lobid.org/resources/99371449208306441",
     "label" : "Webseite der hbz-Ressource 99371449208306441",
     "type" : [ "BibliographicDescription" ],
-    "dateCreated" : "20220718",
-    "dateModified" : "20220718",
     "inDataset" : {
       "id" : "http://lobid.org/resources/dataset#!",
       "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
@@ -30,6 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99371449208306441",
+        "dateCreated" : "20220718",
+        "dateModified" : "20220718",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371449208306441 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -28,8 +28,8 @@
       },
       "object" : {
         "id" : "https://lobid.org/hbz01/99371449208306441",
-        "dateCreated" : "20220718",
-        "dateModified" : "20220718",
+        "dateCreated" : "2022-07-18",
+        "dateModified" : "2022-07-18",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371449208306441 im Exportformat MARC21 XML",
         "inDataset" : {


### PR DESCRIPTION
I moved the dates as wished by @acka47 in #1470 one question though why do we format dates differently in `describedBy.resultOf.endTime`

`"endTime" : "0000-00-00T00:00:00"` is dateTime while `dateCreated` and `dateModified`: `YYYYMMDD` without `-`.