### PR TITLE
Add hasItem Object for HOL without ITM #1174

### DIFF
--- a/src/main/resources/alma/fix/item.fix
+++ b/src/main/resources/alma/fix/item.fix
@@ -62,7 +62,22 @@ do list(path:"ITM  ", "var": "$i")
   paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "hasItem[].$last.callNumber","~#!", join_char: "")
 end
 
-
+do list(path: "HOL  ", "var": "$i")
+  unless in("$i.8", "ITM  .H")
+    unless in("$i.8", "ITM  .*.H")
+      add_field( "hasItem[].$append.test","")
+      add_field("hasItem[].$last.label", "lobid Bestandsressource")
+      set_array("hasItem[].$last.type[]", "Item","NoItem")
+      copy_field("$i.8", "hasItem[].$last.heldBy.id")
+      replace_all("hasItem[].$last.heldBy.id",".*(\\d{4})$","$1")
+      lookup("hasItem[].$last.heldBy.id", "alma-institution-code-to-isil")
+      copy_field("hasItem[].$last.heldBy.id","hasItem[].$last.heldBy.isil")
+      prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
+      append("hasItem[].$last.heldBy.id","#!")
+      paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~#!", join_char: "")
+    end
+  end
+end
 
 do list(path:"POR  ", "var": "$i")
 # entity for every POR  .a without POR  .A

--- a/src/main/resources/alma/fix/item.fix
+++ b/src/main/resources/alma/fix/item.fix
@@ -75,6 +75,12 @@ do list(path: "HOL  ", "var": "$i")
       prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
       append("hasItem[].$last.heldBy.id","#!")
       paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~#!", join_char: "")
+      do list(path:"H52??", "var": "$H52")
+        if in("$i.8", "$H52.8")
+          paste("hasItem[].$last.currentLocation", "$H52.b", "~/", "$H52.c")
+          copy_field("$H52.h", "hasItem[].$last.callNumber")
+        end
+      end
     end
   end
 end

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -207,7 +207,8 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-466#!"
+    "id" : "http://lobid.org/items/990001412590206441:DE-466#!",
+    "currentLocation" : "P0001 / UNASSIGNED"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -199,6 +199,15 @@
       "label" : "lobid Organisation"
     },
     "id" : "http://lobid.org/items/990001412590206441:DE-467:20ICM1270#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "isil" : "DE-466",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990001412590206441:DE-466#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -152,6 +152,25 @@
       "gndIdentifier" : "4155620-3"
     } ]
   } ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "isil" : "DE-465",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990050000600206441:DE-465#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "isil" : "DE-465",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990050000600206441:DE-465#!"
+  } ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -160,7 +160,9 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-465#!"
+    "id" : "http://lobid.org/items/990050000600206441:DE-465#!",
+    "currentLocation" : "E0001 / EHS",
+    "callNumber" : "TBM1318 <<Grundsignatur>>"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NoItem" ],
@@ -169,7 +171,9 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-465#!"
+    "id" : "http://lobid.org/items/990050000600206441:DE-465#!",
+    "currentLocation" : "D0001 / DHS",
+    "callNumber" : "TBM1318_d <<Grundsignatur>>"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -251,7 +251,9 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-361#!"
+    "id" : "http://lobid.org/items/990053976760206441:DE-361#!",
+    "currentLocation" : "UB_BI / 17_Zs",
+    "callNumber" : "17 QD000 P600"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NoItem" ],
@@ -260,7 +262,9 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-290#!"
+    "id" : "http://lobid.org/items/990053976760206441:DE-290#!",
+    "currentLocation" : "ZB / ZS",
+    "callNumber" : "ZN 535"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NoItem" ],
@@ -269,7 +273,9 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-468#!"
+    "id" : "http://lobid.org/items/990053976760206441:DE-468#!",
+    "currentLocation" : "W0001 / 04",
+    "callNumber" : "67P9"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NoItem" ],
@@ -278,7 +284,9 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-61#!"
+    "id" : "http://lobid.org/items/990053976760206441:DE-61#!",
+    "currentLocation" : "X0001 / 03P",
+    "callNumber" : "phy z p 455"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -243,6 +243,42 @@
       "label" : "lobid Organisation"
     },
     "id" : "http://lobid.org/items/990053976760206441:DE-465:67 P 23#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "isil" : "DE-361",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990053976760206441:DE-361#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-290#!",
+      "isil" : "DE-290",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990053976760206441:DE-290#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "isil" : "DE-468",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990053976760206441:DE-468#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NoItem" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "isil" : "DE-61",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990053976760206441:DE-61#!"
   } ],
   "medium" : [ {
     "label" : "Print",


### PR DESCRIPTION
#1174 I have set a first try to catch all HOL without ITMs. I saw that 990050000600206441 has also H52 with matching HOL id and it has a duplicate HOL object. Perhaps we could enrich this HOL without ITM with infos from the special H elements?

Also includes the callNumber for entries with H52. See #1188.