### PR TITLE
Exclude Zeitschrift if not Formschlagwort #1547

### DIFF
--- a/src/main/resources/alma/fix/mediumAndType.fix
+++ b/src/main/resources/alma/fix/mediumAndType.fix
@@ -624,10 +624,14 @@ if any_match("@leaderTyp+008", "(Continuing Resources)(.{21})p.*")  # Pos21
   add_field("type[].$append","Periodical")
 elsif any_match("006", "^[s](.{3})p.*") # Pos00+04
   add_field("type[].$append","Periodical")
-elsif any_match("689??.a", ".*Zeitschrift.*")
-  add_field("type[].$append", "Periodical")
-elsif any_match("689??.*.a", ".*Zeitschrift.*")
-  add_field("type[].$append", "Periodical")
+end
+
+do list(path:"689??", "var":"$i")
+  if all_match("$i.A", "f|F")
+    if any_match("$i.a", "Zeitschrift")
+      add_field("type[].$append", "Periodical")
+    end
+  end
 end
 
 # TODO: If mapping with 689?? keywords we should also integrate a control that A should be "f".

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -134,6 +134,6 @@
     "label" : "Online-Ressource",
     "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
   } ],
-  "type" : [ "BibliographicResource", "Periodical", "Report" ],
+  "type" : [ "BibliographicResource", "Report" ],
   "id" : "http://lobid.org/resources/990199611280206441#!"
 }


### PR DESCRIPTION
Until 2016 RWSK had the marker f for Formschlagwort. If Zeitschrift does not have this, the resource should not be identified as Zeitschrift.