### PR TITLE
Fix bibliographicCitation mapping

### DIFF
--- a/src/main/resources/alma/fix/otherFields.fix
+++ b/src/main/resources/alma/fix/otherFields.fix
@@ -120,19 +120,33 @@ set_array("bibliographicCitation")
 
 # 773 - Host Item Entry (R) - $t - Title (NR), $b - Edition (NR), $d - Place, publisher, and date of publication (NR), $g - Related parts (R), $n - Note (R)
 
-copy_field("77308.t","bibliographicCitation.$append")
-copy_field("77308.b","bibliographicCitation.$append")
-copy_field("77308.d","bibliographicCitation.$append")
-do list(path:"77308.g", "var":"$i")
-  copy_field("$i","bibliographicCitation.$append")
+
+do list(path: "500??", "var":"$i")
+  if any_contain("$i.a","In:")
+    copy_field("$i.a","bibliographicCitation.$append")
+  end
 end
-do list(path:"77308.n", "var":"$i")
-  copy_field("$i","bibliographicCitation.$append")
+
+unless exists("bibliographicCitation.1")
+  if exists("501??")
+    copy_field("501??.a","bibliographicCitation.$append")
+  else
+    copy_field("77308.t","bibliographicCitation.$append")
+    copy_field("77308.b","bibliographicCitation.$append")
+    copy_field("77308.d","bibliographicCitation.$append")
+    do list(path:"77308.g", "var":"$i")
+      copy_field("$i","bibliographicCitation.$append")
+    end
+    do list(path:"77308.n", "var":"$i")
+      copy_field("$i","bibliographicCitation.$append")
+    end
+  end
 end
-copy_field("501??.a","bibliographicCitation.$append")
+
 
 replace_all("bibliographicCitation.*","<<|>>","")
 replace_all("bibliographicCitation.*","^http","Siehe: http")
+replace_all("bibliographicCitation.*","^In: ","")
 
 join_field("bibliographicCitation", "; ")
 

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -64,7 +64,7 @@
     "type" : [ "Collection" ]
   } ],
   "note" : [ "In: Bürgerbuch Gronau und Epe. - 4. 1993/94 (1993) S. 68, 70-71 : Ill." ],
-  "bibliographicCitation" : "1993",
+  "bibliographicCitation" : "Bürgerbuch Gronau und Epe. - 4. 1993/94 (1993) S. 68, 70-71 : Ill.",
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N548040",
     "label" : "Messen. Ausstellungen",

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -64,7 +64,7 @@
     "type" : [ "Collection" ]
   } ],
   "note" : [ "In: Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb." ],
-  "bibliographicCitation" : "1983",
+  "bibliographicCitation" : "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb.",
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N543000",
     "label" : "Wirtschaftsstruktur",


### PR DESCRIPTION
Since bibliographicCitation info is not always in 501 but often in 500
I needed to adjust the mapping pattern.

This is different to the mapping here: https://service-wiki.hbz-nrw.de/pages/viewpage.action?pageId=483000321