### PR TITLE
Fix jena dependency issue (#1622)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-arq</artifactId>
-			<version>2.10.1</version>
+			<version>3.17.0</version>
 			<exclusions>
 			<exclusion>
 				<groupId>log4j</groupId>
@@ -111,6 +111,12 @@
 			<groupId>com.github.jsonld-java</groupId>
 			<artifactId>jsonld-java</artifactId>
 			<version>0.12.5</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>xml-apis</groupId>

--- a/src/main/java/de/hbz/lobid/helper/CreateWikidataNwbibMaps.java
+++ b/src/main/java/de/hbz/lobid/helper/CreateWikidataNwbibMaps.java
@@ -9,18 +9,18 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.ResIterator;
-import com.hp.hpl.jena.rdf.model.Resource;
 
 /**
  * Creates nwbib maps used by morph.
- * 
+ *
  * @author Pascal Christoph (dr0i)
  *
  */
@@ -42,7 +42,7 @@ public final class CreateWikidataNwbibMaps {
 
 	/**
 	 * Creates a tsv using nwbib-spatial.ttl for a morph map.
-	 * 
+	 *
 	 * @param args nope
 	 */
 	public static void main(String... args) {

--- a/src/main/java/org/lobid/resources/PipeEncodeTriples.java
+++ b/src/main/java/org/lobid/resources/PipeEncodeTriples.java
@@ -8,8 +8,17 @@ import java.util.Stack;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.AnonId;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFList;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.util.ResourceUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.metafacture.framework.StreamReceiver;
@@ -17,20 +26,11 @@ import org.metafacture.framework.annotations.Description;
 import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 
-import com.hp.hpl.jena.graph.NodeFactory;
-import com.hp.hpl.jena.rdf.model.AnonId;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.RDFList;
-import com.hp.hpl.jena.rdf.model.RDFNode;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.util.ResourceUtils;
 
 /**
  * Treats Literals, URIs, Blank Nodes and Lists. The latter will be invoked by
  * using the <entity> element in the morph file. Output are N-Triples.
- * 
+ *
  * @author Fabian Steeg, Pascal Christoph (dr0i)
  */
 @Description("Encode a stream as N-Triples")
@@ -66,7 +66,7 @@ public class PipeEncodeTriples extends AbstractGraphPipeEncoder {
 
 	/**
 	 * Allows to define the subject from outside, e.g. from a flux file.
-	 * 
+	 *
 	 * @param subject set the subject for each triple
 	 */
 	public void setSubject(final String subject) {
@@ -76,7 +76,7 @@ public class PipeEncodeTriples extends AbstractGraphPipeEncoder {
 
 	/**
 	 * Allows to store URN's as URI's- Default is to store them as literals.
-	 * 
+	 *
 	 * @param storeUrnAsUri set if urn's should be stored as URIs
 	 */
 	public void setStoreUrnAsUri(final String storeUrnAsUri) {
@@ -176,7 +176,7 @@ public class PipeEncodeTriples extends AbstractGraphPipeEncoder {
 
 	/**
 	 * Treats bnodes and also rdf-lists .
-	 * 
+	 *
 	 */
 	@Override
 	public void startEntity(String name) {

--- a/src/main/java/org/lobid/resources/RdfModelFileWriter.java
+++ b/src/main/java/org/lobid/resources/RdfModelFileWriter.java
@@ -12,6 +12,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
@@ -24,12 +25,11 @@ import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectReceiver;
 import org.metafacture.xml.FilenameExtractor;
 
-import com.hp.hpl.jena.rdf.model.Model;
 
 /**
  * A sink, writing triples into files. The filenames are constructed from the
  * literal of an given property.
- * 
+ *
  * @author Pascal Christoph (dr0i)
  */
 @Description("Writes the object value of an RDF model into a file. Default serialization is 'NTRIPLES'. The filename is "
@@ -96,7 +96,7 @@ public final class RdfModelFileWriter extends DefaultObjectReceiver<Model>
 
 	/**
 	 * Sets the rdf serialization language.
-	 * 
+	 *
 	 * @param serialization the language to be serialized
 	 */
 	public void setSerialization(final String serialization) {

--- a/src/main/java/org/lobid/resources/Triples2RdfModel.java
+++ b/src/main/java/org/lobid/resources/Triples2RdfModel.java
@@ -6,7 +6,17 @@ import java.io.BufferedReader;
 import java.io.StringReader;
 import java.util.stream.Collectors;
 
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.reasoner.Reasoner;
+import org.apache.jena.reasoner.rulesys.RDFSRuleReasonerFactory;
 import org.apache.jena.riot.RiotException;
+import org.apache.jena.util.FileManager;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.vocabulary.ReasonerVocabulary;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.metafacture.framework.ObjectReceiver;
@@ -15,21 +25,11 @@ import org.metafacture.framework.annotations.In;
 import org.metafacture.framework.annotations.Out;
 import org.metafacture.framework.helpers.DefaultObjectPipe;
 
-import com.hp.hpl.jena.graph.Triple;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.reasoner.Reasoner;
-import com.hp.hpl.jena.reasoner.rulesys.RDFSRuleReasonerFactory;
-import com.hp.hpl.jena.util.FileManager;
-import com.hp.hpl.jena.util.iterator.ExtendedIterator;
-import com.hp.hpl.jena.vocabulary.ReasonerVocabulary;
 
 /**
  * Encodes triples into a jena RDF Model. Usage of inferencing by applying an
  * ontology is possible.
- * 
+ *
  * @author Pascal Christoph
  */
 @Description("Encodes triples into an RDF Model. Usage of inferencing by applying "
@@ -51,7 +51,7 @@ public class Triples2RdfModel
 
 	/**
 	 * Sets the serialization format of the incoming triples .
-	 * 
+	 *
 	 * @param serialization one of 'RDF/XML', 'N-TRIPLE', 'TURTLE' (or 'TTL') and
 	 *          'N3'. null represents the default language, 'RDF/XML'.
 	 *          'RDF/XML-ABBREV' is a synonym for 'RDF/XML'.")
@@ -64,7 +64,7 @@ public class Triples2RdfModel
 	 * Sets the filename of the ontology. This ontology will be loaded into an
 	 * inference model to gain statements about resources part of that ontology.
 	 * The reasoner being used is the most simple one and considers only RDFS.
-	 * 
+	 *
 	 * @param ontologyFilename the filename of the ontology
 	 */
 	public void setInferenceModel(String ontologyFilename) {
@@ -80,7 +80,7 @@ public class Triples2RdfModel
 	 * Sets the property to identify the node for inferencing. As we want only
 	 * statements about the "main" resource and discard all other resources which
 	 * may be added by inferencing, this resource needs to be set.
-	 * 
+	 *
 	 * @param property the property
 	 */
 	public void setPropertyIdentifyingTheNodeForInferencing(String property) {
@@ -92,31 +92,30 @@ public class Triples2RdfModel
 	public void process(final String str) {
 		if (str.startsWith("<" + PipeEncodeTriples.DUMMY_SUBJECT)) {
 			LOG.warn("Model without subject - skipping. Model size=" + str.length());
-		} else {
-			Model model = ModelFactory.createDefaultModel();
-			try {
-				model.read(new StringReader(str), "test:uri" + count++, serialization);
-				if (inferencing)
-					reasoning(model);
-				getReceiver().process(model);
-			} catch (RiotException rioe) {
-				LOG.warn("Resource with some broken triples:\n" + str);
-				String seb = new BufferedReader(new StringReader(str)).lines()
-						.filter((line) -> validTriple(line, model))
-						.collect(Collectors.joining("\n"));
-				model.read(new StringReader(seb), "test:uri" + count++, serialization);
-				getReceiver().process(model);
-			} catch (Exception e) {
-				LOG.error("Exception in " + str, e);
-			}
-		}
+        }
+        else {
+            Model model = ModelFactory.createDefaultModel();
+            try {
+                String seb = new BufferedReader(new StringReader(str)).lines()
+                    .filter((line) -> validTriple(line, model))
+                    .collect(Collectors.joining("\n"));
+                model.read(new StringReader(seb), "test:uri" + count++, serialization);
+                if (inferencing) {
+                    reasoning(model);
+                }
+                getReceiver().process(model);
+            }
+            catch (Exception e) {
+                LOG.error("Exception in " + str, e);
+            }
+        }
 	}
 
 	private boolean validTriple(String triple, Model model) {
 		try {
 			model.read(new StringReader(triple), "test:uri" + count++, serialization);
 		} catch (Exception e) {
-			LOG.info("... ignore broken triple: " + triple);
+			LOG.info("... ignore broken triple");
 			return false;
 		}
 		return true;
@@ -130,7 +129,7 @@ public class Triples2RdfModel
 						.next().asNode(), null, null);
 		Model model1 = ModelFactory.createDefaultModel();
 		while (it.hasNext()) {
-			Triple triple = it.next().asTriple();
+			Triple triple = it.next();
 			if (!triple.getObject().isBlank()) {
 				model1.add(model.asStatement(triple));
 			}

--- a/src/test/java/org/lobid/resources/Hbz01MabXmlDeletions2ElasticsearchTest.java
+++ b/src/test/java/org/lobid/resources/Hbz01MabXmlDeletions2ElasticsearchTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Model;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -48,7 +49,6 @@ import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JsonUtils;
-import com.hp.hpl.jena.rdf.model.Model;
 
 import de.hbz.lobid.helper.CompareJsonMaps;
 
@@ -57,7 +57,7 @@ import de.hbz.lobid.helper.CompareJsonMaps;
  * elasticsearch*JSON-LD.Query the index and test the data by transforming the
  * data into*several JSON-LD files(reflecting the records residing in
  * elasticsearch).**
- * 
+ *
  * @author Pascal Christoph(dr0i)
  **/
 @SuppressWarnings("javadoc")

--- a/web/app/controllers/resources/RdfConverter.java
+++ b/web/app/controllers/resources/RdfConverter.java
@@ -2,20 +2,18 @@
 
 package controllers.resources;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
-
-import com.github.jsonldjava.core.JsonLdError;
-import com.github.jsonldjava.core.JsonLdProcessor;
-import com.github.jsonldjava.jena.JenaTripleCallback;
-import com.github.jsonldjava.utils.JsonUtils;
-import com.hp.hpl.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 
 import play.Logger;
 
 /**
  * Helper class for converting JsonLd to RDF.
- * 
+ *
  * @author Fabian Steeg (fsteeg)
  *
  */
@@ -47,9 +45,11 @@ public class RdfConverter {
 	 */
 	public static String toRdf(final String jsonLd, final RdfFormat format) {
 		try {
-			final Object jsonObject = JsonUtils.fromString(jsonLd);
-			final JenaTripleCallback callback = new JenaTripleCallback();
-			final Model model = (Model) JsonLdProcessor.toRDF(jsonObject, callback);
+			//convert json-ld string into InputStream as is required by the read() function.
+			InputStream targetStream = new ByteArrayInputStream(jsonLd.getBytes());
+			Model model = ModelFactory.createDefaultModel() ;
+
+			model.read(targetStream, "", "JSON-LD");
 			model.setNsPrefix("bf", "http://id.loc.gov/ontologies/bibframe/");
 			model.setNsPrefix("bibo", "http://purl.org/ontology/bibo/");
 			model.setNsPrefix("dc", "http://purl.org/dc/elements/1.1/");
@@ -65,10 +65,11 @@ public class RdfConverter {
 			model.setNsPrefix("skos", "http://www.w3.org/2004/02/skos/core#");
 			model.setNsPrefix("wdrs", "http://www.w3.org/2007/05/powder-s#");
 			model.setNsPrefix("xsd", "http://www.w3.org/2001/XMLSchema#");
+
 			final StringWriter writer = new StringWriter();
 			model.write(writer, format.getName());
 			return writer.toString();
-		} catch (IOException | JsonLdError e) {
+		} catch ( Exception e) {
 			Logger.error(e.getMessage(), e);
 		}
 		return null;

--- a/web/app/controllers/resources/RdfConverter.java
+++ b/web/app/controllers/resources/RdfConverter.java
@@ -46,8 +46,8 @@ public class RdfConverter {
 	public static String toRdf(final String jsonLd, final RdfFormat format) {
 		try {
 			//convert json-ld string into InputStream as is required by the read() function.
-			InputStream targetStream = new ByteArrayInputStream(jsonLd.getBytes());
-			Model model = ModelFactory.createDefaultModel() ;
+			final InputStream targetStream = new ByteArrayInputStream(jsonLd.getBytes());
+			final Model model = ModelFactory.createDefaultModel() ;
 
 			model.read(targetStream, "", "JSON-LD");
 			model.setNsPrefix("bf", "http://id.loc.gov/ontologies/bibframe/");

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -17,9 +17,6 @@ libraryDependencies ++= Seq(
     // otherwise javaWs won't work
     exclude ("io.netty", "netty"),
   "org.mockito" % "mockito-core" % "1.9.5",
-  "com.github.jsonld-java" % "jsonld-java" % "0.4.1",
-  "com.github.jsonld-java" % "jsonld-java-jena" % "0.4.1",
-  "org.apache.jena" % "jena-arq" % "2.9.3",
   "com.google.gdata" % "core" % "1.47.1" exclude ("com.google.guava", "guava"),
   "org.easytesting" % "fest-assert" % "1.4" % "test"
 )


### PR DESCRIPTION
With https://github.com/metafacture/metafacture-fix/commit/b55bbbf508b2cd484abfa4221649589c06c9db7d#diff-67162ab57d816849d43c537ebdab31a8744ac824f4f512d0462a78d072937a4a a new jena dependency is transitively introduced via metafix.

- update "jena-arq" from "2.10.1" to "3.17.0"
- exclude "commons-codec" from "jsonld-java" dependency
- refactor classes
- remove unnecassary dependencies in buid.sbt (jsonld and jena)
- 
Resolves #1622