### PR TITLE
EtlError300repeatable

### DIFF
--- a/src/main/resources/alma/fix/mediumAndType.fix
+++ b/src/main/resources/alma/fix/mediumAndType.fix
@@ -36,8 +36,14 @@ paste("@leaderTyp+008","@leaderTyp","008", join_char:"")
 
 # TODO: Check introx concerning possible mappings of 340 https://github.com/hbz/limetrans/blob/d2dff10e1b5cdf5699239a8f3474f8b652d582a3/src/main/resources/transformation/alma.fix#L629
 
-copy_field("300  .a","@300  .a_mainExtend") # All extent infos listed after : or ; are only refering to parts not the resource itself.
-replace_all("@300  .a_mainExtend", "[:;].*","")
+set_array("@300a_mainExtend")
+do list(path:"300  ", "var":"$i")
+  do list(path:"$i.a", "var":"$j")
+    copy_field("$j","@300a_mainExtend.$append") # All extent infos listed after : or ; are only refering to parts not the resource itself.
+  end
+end
+
+replace_all("@300a_mainExtend.*", "[:;].*","")
 
 # medium: "Audio-Dokument":	"http://purl.org/ontology/bibo/AudioDocument"
 
@@ -61,7 +67,7 @@ elsif any_match("245[10]0.h", "^[Tt][oO].*|Audio-CD")
   add_field("medium[].$append.label","Audio-Dokument")
 elsif any_match("natureOfContent[].*.label", ".*(Hörbuch|Hörspiel|Tonträger).*")
   add_field("medium[].$append.label","Audio-Dokument")
-elsif any_match("@300  .a_mainExtend", ".*(Tonkassette|Schallplatte|Schallpl.|Magnetbandkassette|Kompaktkassette|Compact-Disk|Compact-Disc|CD |CD$).*")
+elsif any_match("@300a_mainExtend", ".*(Tonkassette|Schallplatte|Schallpl.|Magnetbandkassette|Kompaktkassette|Compact-Disk|Compact-Disc|CD |CD$).*")
   add_field("medium[].$append.label","Audio-Dokument")
 end
 
@@ -70,7 +76,7 @@ if any_match("007", "^ss.*")
   add_field("medium[].$append.label","Audio-Kassette")
 elsif any_match("245[10]0.h", "Kompaktkassette|MC|Tonkassette")
   add_field("medium[].$append.label","Audio-Kassette")
-elsif any_match("@300  .a_mainExtend", ".*Kompaktkassette.*")
+elsif any_match("@300a_mainExtend", ".*Kompaktkassette.*")
   add_field("medium[].$append.label","Audio-Kassette")
 end
 
@@ -89,7 +95,7 @@ elsif any_match("006", "^[gkor](.{15})[fmstv].*") # Pos00+16 Check if s (Slide/D
 elsif any_match("245[10]0.h", "Bildtonträger")
   add_field("medium[].$append.label","Video")
   add_field("medium[].$append.label", "Audio-Visuell")
-elsif any_match("@300  .a_mainExtend", ".*(DVD-Video|Video).*")
+elsif any_match("@300a_mainExtend", ".*(DVD-Video|Video).*")
   add_field("medium[].$append.label","Video")
   add_field("medium[].$append.label", "Audio-Visuell")
 elsif any_match("337  .a", "video")
@@ -258,7 +264,7 @@ elsif any_match("006", "^[acdijpst](.{5})[o].*") # Pos00+06
   add_field("medium[].$append.label","Online-Ressource")
 elsif any_match("007", "^cr.*") # Old Aleph Transformation maps Computerdatei(en) im Fernzugriff as online resource. We continue to map this in ALMA.
   add_field("medium[].$append.label","Online-Ressource")
-elsif any_match("@300  .a_mainExtend", ".*([Oo]nline|ressource en ligne).*") # Pos00+06
+elsif any_match("@300a_mainExtend", ".*([Oo]nline|ressource en ligne).*") # Pos00+06
   add_field("medium[].$append.label","Online-Ressource")
 elsif any_match("338  .a", "^.*([Oo]nline.*|online bron|online resource|online-ressource|Online-Ressource|ressource en ligne).*$")
   add_field("medium[].$append.label","Online-Ressource")
@@ -279,7 +285,7 @@ end
 # TODO: What about Shellac?
 # TODO: In all the MARC specifics for SChallplatten seem poor.
 
-if any_match("@300  .a_mainExtend", ".*Schallpl.*")
+if any_match("@300a_mainExtend", ".*Schallpl.*")
   add_field("medium[].$append.label","Schallplatte")
   add_field("medium[].$append.label","Audio-Dokument")
 elsif any_match("340  .a", "[Vv]inyl")
@@ -439,8 +445,8 @@ elsif any_match("natureOfContent[].*.label", ".*(Altkarte|Karte|Stadtplan|Weltka
 end
 
 unless any_equal("type[]","Game")
-  unless any_match("@300  .a_mainExtend", ".*Spiel.*")
-    if any_match("@300  .a_mainExtend", ".*(Kt.|[kK]arte).*")
+  unless any_match("@300a_mainExtend", ".*Spiel.*")
+    if any_match("@300a_mainExtend", ".*(Kt.|[kK]arte).*")
       add_field("type[].$append","Map")
     end
   end

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -1,0 +1,107 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "almaMmsId" : "990198383780206441",
+  "hbzId" : "HT017775049",
+  "deprecatedUri" : "http://lobid.org/resources/HT017775049#!",
+  "isbn" : [ "393724039X", "9783937240398" ],
+  "oclcNumber" : [ "1106740171" ],
+  "title" : "Jana und das Weihnachtsgeheimnis",
+  "otherTitleInformation" : [ "Adventskalender-Geschichten für Kinder ; Hörbuch" ],
+  "publication" : [ {
+    "startDate" : "2005",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Wesel" ],
+    "publishedBy" : [ "Felsenfest-Verl.", "Kawohl-Verl. [Vertrieb]" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990198383780206441",
+    "label" : "Webseite der hbz-Ressource 990198383780206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/hbz01/990198383780206441",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2021-04-09",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990198383780206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ],
+    "sourceOrganization" : {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "lobid Organisation"
+    }
+  },
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT017775049",
+    "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1106740171",
+    "label" : "OCLC Ressource"
+  } ],
+  "description" : [ {
+    "label" : "Inhaltstext",
+    "id" : "http://deposit.dnb.de/cgi-bin/dokserv?id=2649059&prov=M&dok_var=1&dok_ext=htm"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "1 CD : digital ; 12 cm, 100 gr ; 1 Booklet [(2)] S (1 CD (75 04 Min. ; 12 cm",
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "cds/a2392",
+    "serialNumber" : "130028201",
+    "currentLocation" : "X0001 / 00",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "isil" : "DE-61",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/990198383780206441:DE-61:23317843550006443#!"
+  } ],
+  "medium" : [ {
+    "label" : "Audio-Dokument",
+    "id" : "http://purl.org/ontology/bibo/AudioDocument"
+  }, {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  } ],
+  "type" : [ "BibliographicResource", "Miscellaneous" ],
+  "responsibilityStatement" : [ "von Werner Hoffmann" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "134887263",
+      "id" : "https://d-nb.info/gnd/134887263",
+      "label" : "Hoffmann, Werner",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1953",
+      "altLabel" : [ "Hoffmann, Werner A.", "Hoffmann, Werner Arthur" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/cmp",
+      "label" : "Komposition"
+    },
+    "type" : [ "Contribution" ]
+  } ],
+  "id" : "http://lobid.org/resources/990198383780206441#!"
+}

--- a/src/test/resources/alma-fix/990198383780206441.xml
+++ b/src/test/resources/alma-fix/990198383780206441.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01304ncm#a2200361#c#4500</leader>
+  <controlfield tag="005">20210409071316.0</controlfield>
+  <controlfield tag="007">co#||a||||||||</controlfield>
+  <controlfield tag="007">qu</controlfield>
+  <controlfield tag="007">sd#|||||||||||</controlfield>
+  <controlfield tag="008">130919|2005####gw#uu|#|############ger#c</controlfield>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="001">990198383780206441</controlfield>
+  <datafield tag="015" ind1=" " ind2=" ">
+    <subfield code="a">06,A01,2360</subfield>
+    <subfield code="z">05,N27,2875</subfield>
+    <subfield code="2">dnb</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1106740171</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">393724039X</subfield>
+    <subfield code="c">: EUR 9.95 (DE, freier Pr.), EUR 10.70 (AT, freier Pr.), sfr 19.95 (freier Pr.)</subfield>
+    <subfield code="9">3-937240-39-X</subfield>
+    <subfield code="0">http://www.isbnsearch.org/isbn/393724039X</subfield>
+  </datafield>
+  <datafield tag="024" ind1="3" ind2=" ">
+    <subfield code="a">9783937240398</subfield>
+  </datafield>
+  <datafield tag="028" ind1="5" ind2="2">
+    <subfield code="a">944187</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT017775049</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">61</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DE-NW</subfield>
+  </datafield>
+  <datafield tag="090" ind1=" " ind2=" ">
+    <subfield code="b">a</subfield>
+    <subfield code="h">h</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Hoffmann, Werner</subfield>
+    <subfield code="d">1953-</subfield>
+    <subfield code="0">(DE-588)134887263</subfield>
+    <subfield code="4">cmp</subfield>
+    <subfield code="0">https://portal.dnb.de/opac.htm?method=simpleSearch&amp;cqlMode=true&amp;query=idn=134887263</subfield>
+    <subfield code="0">http://viaf.org/viaf/sourceID/DNB|134887263</subfield>
+    <subfield code="B">GND-134887263</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Jana und das Weihnachtsgeheimnis</subfield>
+    <subfield code="h">Tonträger</subfield>
+    <subfield code="b">Adventskalender-Geschichten für Kinder ; Hörbuch</subfield>
+    <subfield code="c">von Werner Hoffmann</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Wesel</subfield>
+    <subfield code="b">Felsenfest-Verl.</subfield>
+    <subfield code="a">Wesel</subfield>
+    <subfield code="b">Kawohl-Verl. [Vertrieb]</subfield>
+    <subfield code="c">2005</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 CD</subfield>
+    <subfield code="b">digital</subfield>
+    <subfield code="c">12 cm, 100 gr.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 CD (75 04 Min.)</subfield>
+    <subfield code="c">12 cm</subfield>
+    <subfield code="e">1 Booklet [(2)] S.</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="m">X:MVB</subfield>
+    <subfield code="q">text/html</subfield>
+    <subfield code="u">http://deposit.dnb.de/cgi-bin/dokserv?id=2649059&amp;prov=M&amp;dok_var=1&amp;dok_ext=htm</subfield>
+    <subfield code="3">Inhaltstext</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||17</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">|||||aa|||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">mm||z|||</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1106740171</subfield>
+    <subfield code="0">http://www.worldcat.org/oclc/1106740171</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT017775049</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990198383780206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_DUE</subfield>
+    <subfield code="i">990029302170206443</subfield>
+    <subfield code="n">Universität Düsseldorf</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">393724039X</subfield>
+    <subfield code="c">: EUR 9.95 (DE, freier Pr.), EUR 10.70 (AT, freier Pr.), sfr 19.95 (freier Pr.)</subfield>
+    <subfield code="9">3-937240-39-X</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="s">Geschichte</subfield>
+    <subfield code="0">(DE-588)4020517-4</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="s">Hörbuch</subfield>
+    <subfield code="0">(DE-588)4329497-2</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="s">Kind</subfield>
+    <subfield code="0">(DE-588)4030550-8</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="a">Advent</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="a">Adventskalender</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="a">Adventskalender-Geschichte</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="996" ind1=" " ind2=" ">
+    <subfield code="a">Kalender</subfield>
+    <subfield code="9">LOCAL</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2021-04-09 07:13:16 Europe/Berlin</subfield>
+    <subfield code="g">019838378-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 23:09:11 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">X0001</subfield>
+    <subfield code="c">00</subfield>
+    <subfield code="h">cds/a2392</subfield>
+    <subfield code="8">22317843560006443</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2021-04-01 13:09:42</subfield>
+    <subfield code="8">22317843560006443</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22317843560006443</subfield>
+    <subfield code="x">00</subfield>
+    <subfield code="f">CD</subfield>
+    <subfield code="v">00</subfield>
+    <subfield code="p">11</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2013-09-19 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2022-09-21 16:15:05 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">130028201</subfield>
+    <subfield code="a">23317843550006443</subfield>
+    <subfield code="R">Maintenance count: 001</subfield>
+    <subfield code="c">cds/a2392</subfield>
+    <subfield code="B">P2013/2731</subfield>
+    <subfield code="D">20130919</subfield>
+    <subfield code="W">2013-09-19 02:00:00 Europe/Berlin</subfield>
+    <subfield code="u">X0001</subfield>
+    <subfield code="w">X0001</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoffmann, Werner A.</subfield>
+    <subfield code="d">1953-</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-134887263</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoffmann, Werner Arthur</subfield>
+    <subfield code="d">1953-</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-134887263</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">134887263</subfield>
+    <subfield code="0">http://d-nb.info/gnd/134887263</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-134887263</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>


### PR DESCRIPTION
Instead of only copying a simple field we need to iterate twice over 300 (r) and $a (r).

Error was reported by the monitoring of ALMA ETL.

The error is the result from the first PR in #1567 