### PR TITLE
Add inCollection for ALMA NZ DE-655 #1677

### DIFF
--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -300,6 +300,15 @@ end
 
 set_array("inCollection[]")
 
+# hbz NZ
+
+do list(path:"MBD  ","var":"$i")
+  if any_equal("$i.M", "49HBZ_NETWORK")
+    add_field("inCollection[].$append.id", "http://lobid.org/organisations/DE-655#!")
+    add_field("inCollection[].$last.label", "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone")
+  end
+end
+
 # zdb
 
 if exists("zdbId")

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -68,6 +68,10 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2019/04/06/file_4/8295425.pdf"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT013494180#!",
     "label" : "Rheinland-Pfälzische Bibliographie",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -63,6 +63,11 @@
       "label" : "SUNY series in political theory"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "XV, 607 S.",
   "natureOfContent" : [ {
     "label" : "Aufsatzsammlung",

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -57,6 +57,11 @@
     "id" : "http://worldcat.org/oclc/1067416031",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -64,6 +64,11 @@
   "supplement" : [ {
     "label" : "Tägliche Einspiel-Übungen"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "80 S. + lose Beil.",
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -62,6 +62,11 @@
     "id" : "http://worldcat.org/oclc/265495256",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -64,6 +64,11 @@
     "id" : "http://worldcat.org/oclc/1067969357",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Sovetskoe administrativnoe pravo dt.",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -55,6 +55,11 @@
     "id" : "http://worldcat.org/oclc/1071256649",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Carmina",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -57,6 +57,11 @@
     "id" : "http://worldcat.org/oclc/1068461604",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/chi",
     "label" : "Chinesisch"

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -63,6 +63,11 @@
     "id" : "http://worldcat.org/oclc/1072809401",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "subject" : [ {
     "notation" : "200",
     "type" : [ "Concept" ],

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -57,6 +57,11 @@
     "id" : "http://worldcat.org/oclc/1070982209",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "104 Spielkt. : Ill. ; Begleith",
   "medium" : [ {
     "label" : "Sonstige",

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -65,6 +65,11 @@
     "id" : "http://worldcat.org/oclc/961364901",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -71,6 +71,11 @@
       "label" : "Collection libre échange"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/fre",
     "label" : "Französisch"

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -55,6 +55,11 @@
     "id" : "http://worldcat.org/oclc/1072570332",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -64,6 +64,10 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -89,6 +89,10 @@
     "id" : "http://lobid.org/resources/HT008498541#!"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -73,6 +73,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -73,6 +73,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -77,6 +77,11 @@
     "label" : "Inhaltsverzeichnis",
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2021/05/31/file_1/9034428.pdf"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Hú̀rdú̀s ham-meleḵ dt.",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -73,6 +73,11 @@
     } ],
     "numbering" : "29"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -69,6 +69,11 @@
     } ],
     "numbering" : "509"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -68,6 +68,11 @@
     } ],
     "numbering" : "42,2,3"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -67,6 +67,11 @@
     } ],
     "numbering" : "1934,4"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -64,6 +64,11 @@
     } ],
     "numbering" : "1,2"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "XI, 131 S. : zahlr. Ill., graph. Darst.",
   "subject" : [ {
     "type" : [ "Concept" ],

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -73,6 +73,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -71,6 +71,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -71,6 +71,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -82,6 +82,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -77,6 +77,10 @@
     "issn" : "0955-8810"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -76,6 +76,10 @@
     "label" : "Yearbook of anthropology"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -71,6 +71,10 @@
     "numbering" : "2"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -58,6 +58,10 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -58,6 +58,10 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -63,6 +63,10 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -67,6 +67,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -67,6 +67,11 @@
       "label" : "Oxford India paperbacks"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -77,6 +77,11 @@
     "note" : [ "Reproduktion" ],
     "label" : "lobid Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -70,6 +70,11 @@
     "id" : "(DE-605)HT013365271",
     "label" : "Reproduktion von HT013365271"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -59,6 +59,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-TT000075751",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Folk song arrangements",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -64,6 +64,11 @@
     } ],
     "numbering" : "Tonkassette"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "1 Kompaktkassette",
   "medium" : [ {
     "label" : "Audio-Dokument",

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -64,6 +64,11 @@
     } ],
     "numbering" : "5"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -65,6 +65,11 @@
     "id" : "http://worldcat.org/oclc/238307096",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -76,6 +76,10 @@
     "issn" : "0177-3283"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -81,6 +81,10 @@
     "id" : "http://lobid.org/resources/HT014878025#!"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -52,6 +52,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT014525099",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Kantaten / Ausw.",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -74,6 +74,11 @@
     } ],
     "numbering" : "F,2001,1"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "De arte venandi cum avibus",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -71,6 +71,11 @@
       "label" : "Royal Asiatic Society books"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -68,6 +68,11 @@
     } ],
     "numbering" : "1"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -61,6 +61,11 @@
     "note" : [ "Druckausg. u.d.T." ],
     "label" : "Strukturelle und biochemische Einblicke in Mechanismen des Nukleotidaustauschs von Rab-Proteinen"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -59,6 +59,11 @@
     "id" : "http://worldcat.org/oclc/1075948907",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "53 BL. MIT ZAHLR. ABB. U. TAF., TEILS FARB.",
   "note" : [ "NE: SOHLE 1 <GALERIE, BERGKAMEN>. - AUSSTELLUNGSKAT." ],
   "hasItem" : [ {

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -69,6 +69,11 @@
     "label" : "Inhaltsverzeichnis",
     "id" : "http://digitale-objekte.hbz-nrw.de/storage/2011/07/09/file_16/4219074.pdf"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990172512030206441.json
+++ b/src/test/resources/alma-fix/990172512030206441.json
@@ -57,6 +57,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-TT002815323",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -70,6 +70,11 @@
     } ],
     "numbering" : "Vontei"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -66,6 +66,11 @@
     } ],
     "numbering" : "1"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -81,6 +81,10 @@
     "label" : "Bericht der Beschwerdekommission  / PsychiatrieVerbund Westfalen, Beschwerdekommission"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -62,6 +62,11 @@
     "id" : "http://lobid.org/resources/HT016607985#!",
     "label" : "Mélodies / Claude Debussy"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Pierrot",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -79,6 +79,10 @@
     "id" : "http://www.duesseldorf.de/wohnen/veroeffentlichung/index.shtml"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -60,6 +60,11 @@
     "id" : "http://worldcat.org/oclc/1074092439",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -60,6 +60,11 @@
     "id" : "http://worldcat.org/oclc/1075349291",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Faust",
     "type" : [ "Work" ]

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -77,6 +77,11 @@
     "note" : [ "Online-Ausgabe" ],
     "isbn" : [ "9783840334900", "384033490X" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -58,6 +58,10 @@
     "label" : "Westfalen"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -65,6 +65,11 @@
     "label" : "Inhaltsverzeichnis",
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2019/08/04/file_26/8646388.pdf"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -98,6 +98,10 @@
     "issn" : "0508-590x"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -64,6 +64,11 @@
     "note" : [ "Reproduktion" ],
     "label" : "Territorium Seculare Episcopatus Monasterii Munster Germanis dicti. Ubi una cum Episcopatu Osnabr. simul integri Comitatus Bentheim, Steinfurt, Teklenburg, Lingen, Diepholz, Gemen conspiciuntur"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/lat",
     "label" : "Latein"

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -73,6 +73,11 @@
     "note" : [ "Reproduktion" ],
     "label" : "Cöln, Gasthaus \"Zum St. Peter\", Unter Hutmacher 31"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -61,6 +61,11 @@
       "label" : "Die Grundschulzeitschrift"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -77,6 +77,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -85,6 +85,10 @@
     "label" : "Aegyptische Nachrichten"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -74,6 +74,10 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "https://lobid.org/collections#ldd",
     "type" : [ "Collection" ],
     "label" : "collections#ldd"

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -85,6 +85,10 @@
     "isbn" : [ "9783642320781", "3642320783" ]
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-2-STI#!",
     "type" : [ "Collection" ],
     "label" : "lobid Organisation"

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -61,6 +61,11 @@
     "label" : "Inhaltstext",
     "id" : "http://deposit.dnb.de/cgi-bin/dokserv?id=2649059&prov=M&dok_var=1&dok_ext=htm"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -71,6 +71,11 @@
     "note" : [ "Druckausg." ],
     "label" : "Advances in special education"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -70,6 +70,11 @@
     "label" : "Inhaltstext",
     "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4685554&prov=M&dok_var=1&dok_ext=htm"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -80,6 +80,10 @@
     "isbn" : [ "9783412221607", "3412221600" ]
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-117-VRE#!",
     "type" : [ "Collection" ],
     "label" : "V&R eLibrary / EBooks"

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -67,6 +67,11 @@
     } ],
     "numbering" : "3"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -73,6 +73,11 @@
       "label" : "Journal of gastrointestinal surgery"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -59,6 +59,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018781534",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Momento capriccioso",
     "id" : "https://d-nb.info/gnd/107360974X",

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -69,6 +69,10 @@
     "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4521553&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -75,6 +75,10 @@
     "label" : "Classics in linguistics"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -57,6 +57,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018853619",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "exampleOfWork" : {
     "label" : "Lieder aus letzter Zeit",
     "id" : "https://d-nb.info/gnd/4777353-4",

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -55,6 +55,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018857620",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "containsExampleOfWork" : [ {
     "label" : "La forza del destino. Ouvertüre",
     "creatorOfWork" : "Verdi, Giuseppe 1813-1901",

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -62,6 +62,10 @@
     "label" : "Zeitschrift des Geschichtsvereins Mülheim a. d. Ruhr"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -65,6 +65,10 @@
     "numbering" : "65"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -74,6 +74,10 @@
     "numbering" : "1"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://repository.publisso.de",
     "label" : "Fachrepositorium Lebenswissenschaften",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -67,6 +67,10 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -65,6 +65,10 @@
     "isbn" : [ "9783736992580", "3736992580" ]
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "https://lobid.org/collections#cuvillier",
     "type" : [ "Collection" ],
     "label" : "Cuvillier-E-Books"

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -74,6 +74,10 @@
     "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -82,6 +82,11 @@
     "label" : "Architektur wahrnehmen",
     "isbn" : [ "9783839436547", "3839436540" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -65,6 +65,10 @@
     "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -62,6 +62,11 @@
     "label" : "Zusammenfassung",
     "id" : "http://hss-opus.ub.ruhr-uni-bochum.de/scans/NowackNikola/Zusammenfassung.pdf"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990220027540206441.json
+++ b/src/test/resources/alma-fix/990220027540206441.json
@@ -62,6 +62,11 @@
     } ],
     "numbering" : "1"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/hin",
     "label" : "Hindi"

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -80,6 +80,11 @@
     "label" : "Inhaltstext",
     "id" : "http://deposit.dnb.de/cgi-bin/dokserv?id=c575d80bb6cd4fbbbe8bf63f61eceae9&prov=M&dok_var=1&dok_ext=htm"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -69,6 +69,11 @@
     } ],
     "numbering" : "3"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -69,6 +69,10 @@
     "numbering" : "2018,55"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://repository.publisso.de",
     "label" : "Fachrepositorium Lebenswissenschaften",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -55,6 +55,10 @@
     "label" : "Der Rhein / herausgegeben von/édité par Hélène Miard-Delacroix, Guido Thiemeyer"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -79,6 +79,10 @@
     "isbn" : [ "9783161546105", "3161546105" ]
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-197-MSE#!",
     "type" : [ "Collection" ],
     "label" : "Mohr Siebeck eBooks"

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -68,6 +68,10 @@
     "label" : "Why does the Sustainable Development Goal on Education (SDG 4) matter for OECD countries?"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-13-SOC#!",
     "type" : [ "Collection" ],
     "label" : "lobid Organisation"

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -50,6 +50,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT020446683",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/nds",
     "label" : "Niederdeutsch"

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -64,6 +64,10 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-22-CAN#!",
     "type" : [ "Collection" ],
     "label" : "Ciando"

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -51,6 +51,11 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT020681018",
     "label" : "Culturegraph Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/fre",
     "label" : "Französisch"

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -70,6 +70,11 @@
     "id" : "http://nbn-resolving.de/urn:nbn:de:bsz:14-qucosa2-386112",
     "label" : "urn:nbn:de:bsz:14-qucosa2-386112"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -67,6 +67,11 @@
   "related" : [ {
     "issn" : "2190-0574"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99370738710506441.json
+++ b/src/test/resources/alma-fix/99370738710506441.json
@@ -66,6 +66,11 @@
   "related" : [ {
     "isbn" : [ "9789004297982", "9004297987" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "1 online resource (398 pages)",
   "abstract" : [ "In A Comparative Appraisal of Normative Power Ville Sinkkonen constructs a three-pronged analytical framework for the analysis of normative power, a theoretical concept recently associated with studying the international role of the European Union. This toolkit allows him to compare the foreign policy conduct of the EU and the United States in the context of the January 25th, 2011 Revolution in Egypt along three dimensions: ‘norms and identity’, ‘means’ and ‘paradoxes’. These components permit an in-depth analysis of Western norm promotion in the midst of the upheaval, building on a large pool of source documents. The monograph broadens the remit of normative power through its empirical bent, comparative research set-up and focus on a swiftly unfolding revolution/transition complex. In the process, the prevalent discourse of the EU as a benign international actor is subjected to rigorous analytical scrutiny." ],
   "natureOfContent" : [ {

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -69,6 +69,11 @@
   "related" : [ {
     "isbn" : [ "9780444533999", "0444533990" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -69,6 +69,11 @@
   "related" : [ {
     "isbn" : [ "9780271084749", "027108474X" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "1 online resource",
   "abstract" : [ "\"Explores how superhero comics, with their creative fusions of fantasy and realism, provide a flexible visual form for engaging issues of disability and intersectional identity (race, class, gender, sexuality) as well as for imagining and valuing different physical and cognitive ways of being in the world\"--Provided by publisher." ],
   "subject" : [ {

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -65,6 +65,11 @@
   }, {
     "isbn" : [ "9789027237019", "9027237018" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99370771475306441.json
+++ b/src/test/resources/alma-fix/99370771475306441.json
@@ -72,6 +72,11 @@
     "note" : [ "Online-Ausgabe (epub)" ],
     "isbn" : [ "9789783405264", "9783405268" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -72,6 +72,11 @@
     } ],
     "numbering" : "2"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -62,6 +62,11 @@
   "related" : [ {
     "issn" : "2471-5506"
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "1 online resource",
   "note" : [ "The research and policy journal of the World Congress of Families." ],
   "natureOfContent" : [ {

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -71,6 +71,11 @@
     "note" : [ "Print version (hardback):" ],
     "isbn" : [ "9783631660126", "363166012X" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -70,6 +70,11 @@
   "related" : [ {
     "isbn" : [ "9780702075599", "0702075590" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "1 online resource (ix, 357 pages) : illustrations (chiefly color)",
   "note" : [ "Revised edition of: Wheater's basic pathology : a text, atlas, and review of histopathology / [edited by] Barbara Young, William Stewart, and Geraldine O'Dowd. 5th ed. ©2011." ],
   "abstract" : [ "This concise introduction to pathology covers basic pathological mechanisms and offers a detailed review of systems pathology, making it a complete, effective review for today's readers. Hundreds of high-quality images-many new to this edition-illustrate common entities, and associated captions provide key pathological points. Reader-friendly text clarifies basic and complex information, helping you understand challenging concepts more easily. Wheater's Pathology is an excellent companion resource for users of Wheater's Functional Histology, 6th Edition, offering a comparison of normal histology with the pathological changes in disease. Contains a new chapter, Introduction to Pathology and Techniques, that provides more background information on histology techniques, immunohistochemistry, molecular tests and digital pathology. Contains new, full-color illustrations that depict additional pathological entities and update classifications. Includes quick-reference features such as keys to the lettering in images at the bottom of each page and fully revised clinical boxes with clinical-pathological correlations that explain the relevance of the pathological processes underlying common diseases and their complications. Summarizes key points with chapter reviews at the end of each section. -- Publisher" ],

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -57,6 +57,11 @@
   "related" : [ {
     "isbn" : [ "9781784714864", "1784714860" ]
   } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
   "extent" : "1 online resource (528 pages)",
   "note" : [ "Includes index." ],
   "abstract" : [ "This Handbook covers the accounts, by practitioners and observers, of the ways in which policy is formed around problems, how these problems are recognized and understood, and how diverse participants come to be involved in addressing them. H.K. Colebatch and Robert Hoppe draw together a range of original contributions from experts in the field to illuminate the ways in which policies are formed and how they shape the process of governing. The Handbook on Policy, Process and Governing covers not only the activities of government, but also the contributions of other stakeholders, and the ways in which a wide range of participants contribute to the formation of public policy. It explores the tensions involved in the policy process between: innovative choice and stable practice, authoritative decision and negotiated order, and agreed activity and announced goals. The scholar's focus on the analysis of activity and the practitioner's interest in the achievement of outcomes are brought together in this timely book, making it a valuable read for public policy scholars and practitioners alike." ],


### PR DESCRIPTION
I redid the solution for #1677.
`
003=DE-655` is not provided in our test data.
Therefore I used the `MBD` reference to `49HBZ_NETWORK`


We can change the condition if needed later.