### PR TITLE
Exclude DigiBib subject facet from document source (public API).

### DIFF
--- a/src/main/resources/index-config.json
+++ b/src/main/resources/index-config.json
@@ -127,6 +127,11 @@
       },
       "resource" : {
          "dynamic": false,
+         "_source": {
+           "excludes": [
+             "digiBibSubjectFacet"
+           ]
+         },
          "properties" : {
             "inCollection": {
                 "properties": {


### PR DESCRIPTION
In case the bespoke field `digiBibSubjectFacet` (see #1684) should be excluded from the public API, this might be an option at index level ([documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/mapping-source-field.html#include-exclude)).