### PR TITLE
ChangeIds_WIP

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -1,7 +1,5 @@
 copy_field("001","almaMmsId")
 
-paste("id", "~http://lobid.org/resources/", "001", "~#!", join_char: "")
-
 
 # 024 - Other Standard Identifier (R) Subfield: $a (NR) $2 (NR)
 # urn
@@ -113,3 +111,13 @@ replace_all("zdbId", "\\(DE-600\\)","")
 
 copy_field("almaMmsId","rpbId")
 lookup("rpbId","almaMmsId2rpbId",delete:"true")
+
+if exists("hbzId")
+  copy_field("hbzId","@id")
+elsif exists("zdbId")
+  copy_field("zdbId","@id")
+else
+  copy_field("almaMmsId","@id")
+end
+
+paste("id", "~http://lobid.org/resources/", "@id", "~#!", join_char: "")

--- a/src/main/resources/alma/fix/item.fix
+++ b/src/main/resources/alma/fix/item.fix
@@ -25,7 +25,7 @@ do list(path:"ITM  ", "var": "$i")
   prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
   append("hasItem[].$last.heldBy.id","#!")
   # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-  paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
+  paste("hasItem[].$last.id", "~http://lobid.org/items/","@id", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
 end
 
 do list(path: "HOL  ", "var": "$i")
@@ -55,7 +55,7 @@ do list(path: "HOL  ", "var": "$i")
       prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
       append("hasItem[].$last.heldBy.id","#!")
       # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-      paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:","$i.8","~#!", join_char: "")
+      paste("hasItem[].$last.id", "~http://lobid.org/items/","@id", "~:", "hasItem[].$last.heldBy.isil","~:","$i.8","~#!", join_char: "")
     end
   end
 end
@@ -76,7 +76,7 @@ do list(path: "MBD  ", "var": "$i")
             prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
             append("hasItem[].$last.heldBy.id","#!")
             # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-            paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.i", "~#!", join_char: "")
+            paste("hasItem[].$last.id", "~http://lobid.org/items/","@id", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.i", "~#!", join_char: "")
           end
         end
       end
@@ -103,7 +103,7 @@ do list(path:"POR  ", "var": "$i")
     prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
     append("hasItem[].$last.heldBy.id","#!")
     # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-    paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
+    paste("hasItem[].$last.id", "~http://lobid.org/items/","@id", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
   end
   # entity for every POR  .A
   if exists ("$i.A")
@@ -123,7 +123,7 @@ do list(path:"POR  ", "var": "$i")
       prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
       append("hasItem[].$last.heldBy.id","#!")
       # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-      paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
+      paste("hasItem[].$last.id", "~http://lobid.org/items/","@id", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
     end
   end
 end

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -235,5 +235,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990001412590206441#!"
+  "id" : "http://lobid.org/resources/HT000161712#!"
 }

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -118,7 +118,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-468:23138155830006447#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-468:23138155830006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -130,7 +130,7 @@
       "isil" : "DE-708",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-708:2397648970006464#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-708:2397648970006464#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -142,7 +142,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-290:23197423230006445#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-290:23197423230006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -154,7 +154,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-361:23278036660006442#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-361:23278036660006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -166,7 +166,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-61:23299197890006443#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-61:23299197890006443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -178,7 +178,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-6:23507162560006449#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-6:23507162560006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -190,7 +190,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-467:2394316400006462#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-467:2394316400006462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -202,7 +202,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-466:23135518530006463#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-466:23135518530006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -212,7 +212,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990001412590206441:DE-466:22135518500006463#!"
+    "id" : "http://lobid.org/items/HT000161712:DE-466:22135518500006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -99,7 +99,7 @@
       "isil" : "DE-6-015",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990011470300206441:DE-6-015:23600509680006449#!"
+    "id" : "http://lobid.org/items/HT003109553:DE-6-015:23600509680006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -134,5 +134,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990011470300206441#!"
+  "id" : "http://lobid.org/resources/HT003109553#!"
 }

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -121,5 +121,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990014830510206441#!"
+  "id" : "http://lobid.org/resources/HT003864492#!"
 }

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -102,7 +102,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990014830510206441:DE-465:23382608040006446#!"
+    "id" : "http://lobid.org/items/HT003864492:DE-465:23382608040006446#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -116,5 +116,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990016782920206441#!"
+  "id" : "http://lobid.org/resources/HT004285445#!"
 }

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -81,7 +81,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990016782920206441:DE-1156:2311409300006459#!"
+    "id" : "http://lobid.org/items/HT004285445:DE-1156:2311409300006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -93,7 +93,7 @@
       "isil" : "DE-6-286",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990016782920206441:DE-6-286:23506545980006449#!"
+    "id" : "http://lobid.org/items/HT004285445:DE-6-286:23506545980006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -173,5 +173,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990021367710206441#!"
+  "id" : "http://lobid.org/resources/HT005207972#!"
 }

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -98,7 +98,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021367710206441:DE-290:23198604440006445#!"
+    "id" : "http://lobid.org/items/HT005207972:DE-290:23198604440006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -110,7 +110,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021367710206441:DE-290:23198604460006445#!"
+    "id" : "http://lobid.org/items/HT005207972:DE-290:23198604460006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -122,7 +122,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021367710206441:DE-361:23251929370006442#!"
+    "id" : "http://lobid.org/items/HT005207972:DE-361:23251929370006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -131,7 +131,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021367710206441:DE-466:990014134660106463#!"
+    "id" : "http://lobid.org/items/HT005207972:DE-466:990014134660106463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -110,7 +110,7 @@
       "isil" : "DE-82-604",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021974470206441:DE-82-604:23253806030006448#!"
+    "id" : "http://lobid.org/items/HT005271161:DE-82-604:23253806030006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -122,7 +122,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021974470206441:DE-361:23252165950006442#!"
+    "id" : "http://lobid.org/items/HT005271161:DE-361:23252165950006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -134,7 +134,7 @@
       "isil" : "DE-6-016",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990021974470206441:DE-6-016:23561372540006449#!"
+    "id" : "http://lobid.org/items/HT005271161:DE-6-016:23561372540006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -179,5 +179,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990021974470206441#!"
+  "id" : "http://lobid.org/resources/HT005271161#!"
 }

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -116,5 +116,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990030574430206441#!"
+  "id" : "http://lobid.org/resources/HT007847893#!"
 }

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -81,7 +81,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990033263300206441:DE-361:23234824210006442#!"
+    "id" : "http://lobid.org/items/HT008389117:DE-361:23234824210006442#!"
   } ],
   "medium" : [ {
     "label" : "Manuskript",

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -88,5 +88,5 @@
     "id" : "http://purl.org/ontology/bibo/Manuscript"
   } ],
   "type" : [ "BibliographicResource", "ReferenceSource", "Book" ],
-  "id" : "http://lobid.org/resources/990033263300206441#!"
+  "id" : "http://lobid.org/resources/HT008389117#!"
 }

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -87,7 +87,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-468:23121154640006447#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-468:23121154640006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -99,7 +99,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-290:23200446830006445#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-290:23200446830006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -111,7 +111,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-361:23262944040006442#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-361:23262944040006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -123,7 +123,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-465:23372647300006446#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-465:23372647300006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -135,7 +135,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-465:23372647280006446#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-465:23372647280006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -147,7 +147,7 @@
       "isil" : "DE-6-Z",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-6-Z:23504836650006449#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-6-Z:23504836650006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -159,7 +159,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-467:2377634040006462#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-467:2377634040006462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -171,7 +171,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-466:23125280390006463#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-466:23125280390006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -181,7 +181,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990035016180206441:DE-466:22125280380006463#!"
+    "id" : "http://lobid.org/items/HT008733617:DE-466:22125280380006463#!"
   } ],
   "medium" : [ {
     "label" : "Mikroformat",

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -204,5 +204,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990035016180206441#!"
+  "id" : "http://lobid.org/resources/HT008733617#!"
 }

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -80,5 +80,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990041403870206441#!"
+  "id" : "http://lobid.org/resources/HT009965981#!"
 }

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -174,7 +174,7 @@
       "isil" : "DE-Hag4-4",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-Hag4-4:2365401280006461#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-Hag4-4:2365401280006461#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -186,7 +186,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-386:2365786110007476#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-386:2365786110007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -197,7 +197,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-386:2365786130007476#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-386:2365786130007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -209,7 +209,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-386:2365786080007476#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-386:2365786080007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -221,7 +221,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-466:23137495220006463#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-466:23137495220006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -232,7 +232,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-465:22369588590006446#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-465:22369588590006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -243,7 +243,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-465:22369588600006446#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-465:22369588600006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -252,7 +252,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-468:990007452950206447#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-468:990007452950206447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -261,7 +261,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-Dm13:991001984839706451#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-Dm13:991001984839706451#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -270,7 +270,7 @@
       "isil" : "DE-708",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-708:990005940980106464#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-708:990005940980106464#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -279,7 +279,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-A96:991002141299706444#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-A96:991002141299706444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -288,7 +288,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-Bi10:991001234009706450#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-Bi10:991001234009706450#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -297,7 +297,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-Bm40:991000247429706454#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-Bm40:991000247429706454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -306,7 +306,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-1044:991000161599706452#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-1044:991000161599706452#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -315,7 +315,7 @@
       "isil" : "DE-Due62",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-Due62:991001481009706455#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-Due62:991001481009706455#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -324,7 +324,7 @@
       "isil" : "DE-1393",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-1393:991000857029706453#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-1393:991000857029706453#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -333,7 +333,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-82:991002777419706448#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-82:991002777419706448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -342,7 +342,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-290:991001802079706445#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-290:991001802079706445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -351,7 +351,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-361:991013990859706442#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-361:991013990859706442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -360,7 +360,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-61:990010318920206443#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-61:990010318920206443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -369,7 +369,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-6:991037504519706449#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-6:991037504519706449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -378,7 +378,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-467:990007901380106462#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-467:990007901380106462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -387,7 +387,7 @@
       "isil" : "DE-1010",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990050000600206441:DE-1010:991001095739706456#!"
+    "id" : "http://lobid.org/items/HT006855611:DE-1010:991001095739706456#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -410,5 +410,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990050000600206441#!"
+  "id" : "http://lobid.org/resources/HT006855611#!"
 }

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -128,5 +128,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990051552280206441#!"
+  "id" : "http://lobid.org/resources/HT009719670#!"
 }

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -71,7 +71,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990051708340206441:DE-466:23139237860006463#!"
+    "id" : "http://lobid.org/items/HT009976241:DE-466:23139237860006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -80,7 +80,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990051708340206441:DE-361:991019320629706442#!"
+    "id" : "http://lobid.org/items/HT009976241:DE-361:991019320629706442#!"
   } ],
   "medium" : [ {
     "label" : "Kombination",

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -99,5 +99,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990051708340206441#!"
+  "id" : "http://lobid.org/resources/HT009976241#!"
 }

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -129,7 +129,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990052965140206441:DE-468:990004566360206447#!"
+    "id" : "http://lobid.org/items/HT002529477:DE-468:990004566360206447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -138,7 +138,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990052965140206441:DE-1044:991003168089706452#!"
+    "id" : "http://lobid.org/items/HT002529477:DE-1044:991003168089706452#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -147,7 +147,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990052965140206441:DE-82:991023049269706448#!"
+    "id" : "http://lobid.org/items/HT002529477:DE-82:991023049269706448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -156,7 +156,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990052965140206441:DE-465:990004010910206446#!"
+    "id" : "http://lobid.org/items/HT002529477:DE-465:990004010910206446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -165,7 +165,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990052965140206441:DE-61:990003684970206443#!"
+    "id" : "http://lobid.org/items/HT002529477:DE-61:990003684970206443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -174,7 +174,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990052965140206441:DE-6:991040627879706449#!"
+    "id" : "http://lobid.org/items/HT002529477:DE-6:991040627879706449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -194,5 +194,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990052965140206441#!"
+  "id" : "http://lobid.org/resources/HT002529477#!"
 }

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -208,7 +208,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-465:23409593810006446#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-465:23409593810006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -220,7 +220,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-467:2379886190006462#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-467:2379886190006462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -231,7 +231,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-468:22142187260006447#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-468:22142187260006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -242,7 +242,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-82:22222365420006448#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-82:22222365420006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -253,7 +253,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-386:2266381760007476#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-386:2266381760007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -264,7 +264,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-386:2266381820007476#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-386:2266381820007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -275,7 +275,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-386:2266381790007476#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-386:2266381790007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -286,7 +286,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-290:22189310720006445#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-290:22189310720006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -297,7 +297,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-361:22274254620006442#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-361:22274254620006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -308,7 +308,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-61:22302058760006443#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-61:22302058760006443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -319,7 +319,7 @@
       "isil" : "DE-6-023",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-6-023:22526741320006449#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-6-023:22526741320006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -330,7 +330,7 @@
       "isil" : "DE-6-123",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-6-123:22526741310006449#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-6-123:22526741310006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -341,7 +341,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-6:22526741340006449#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-6:22526741340006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -352,7 +352,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990053976760206441:DE-466:22131234930006463#!"
+    "id" : "http://lobid.org/items/HT000312236:DE-466:22131234930006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -359,5 +359,5 @@
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "type" : [ "BibliographicResource", "Periodical" ],
-  "id" : "http://lobid.org/resources/990053976760206441#!"
+  "id" : "http://lobid.org/resources/HT000312236#!"
 }

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -144,5 +144,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990054215550206441#!"
+  "id" : "http://lobid.org/resources/HT002619538#!"
 }

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -256,5 +256,5 @@
   } ],
   "type" : [ "BibliographicResource", "Periodical", "PublicationIssue" ],
   "responsibilityStatement" : [ "hrsg. im Auftrag des Deutschen Fremdenverkehrsverbandes e.V. Frankfurt/Main und in Zusammenarbeit mit dem Deutschen Bäderverband e.V" ],
-  "id" : "http://lobid.org/resources/990054301770206441#!"
+  "id" : "http://lobid.org/resources/HT003176544#!"
 }

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -239,7 +239,7 @@
       "isil" : "DE-6-139a",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990054301770206441:DE-6-139a:22577982090006449#!"
+    "id" : "http://lobid.org/items/HT003176544:DE-6-139a:22577982090006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -248,7 +248,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990054301770206441:DE-290:991007182009706445#!"
+    "id" : "http://lobid.org/items/HT003176544:DE-290:991007182009706445#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -313,5 +313,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990058434730206441#!"
+  "id" : "http://lobid.org/resources/HT000893437#!"
 }

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -157,7 +157,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-468:23143362620006447#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-468:23143362620006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -169,7 +169,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-465:23378107640006446#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-465:23378107640006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -181,7 +181,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-61:23316394070006443#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-61:23316394070006443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -193,7 +193,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-61:23316394030006443#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-61:23316394030006443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -205,7 +205,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-61:23316394050006443#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-61:23316394050006443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -217,7 +217,7 @@
       "isil" : "DE-6-119",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-6-119:23602951480006449#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-6-119:23602951480006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -229,7 +229,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-6:23602951640006449#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-6:23602951640006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -241,7 +241,7 @@
       "isil" : "DE-6-006",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-6-006:23602951510006449#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-6-006:23602951510006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -253,7 +253,7 @@
       "isil" : "DE-6-011",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-6-011:23602951550006449#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-6-011:23602951550006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -265,7 +265,7 @@
       "isil" : "DE-6-248",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-6-248:23602951590006449#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-6-248:23602951590006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -277,7 +277,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-467:2394453370006462#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-467:2394453370006462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -289,7 +289,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990058434730206441:DE-466:23136243400006463#!"
+    "id" : "http://lobid.org/items/HT000893437:DE-466:23136243400006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -144,5 +144,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990059571560206441#!"
+  "id" : "http://lobid.org/resources/HT001039253#!"
 }

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -122,7 +122,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990059571560206441:DE-82:23246474340006448#!"
+    "id" : "http://lobid.org/items/HT001039253:DE-82:23246474340006448#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -171,5 +171,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990063549080206441#!"
+  "id" : "http://lobid.org/resources/HT003538502#!"
 }

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -121,7 +121,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990063549080206441:DE-468:23124074000006447#!"
+    "id" : "http://lobid.org/items/HT003538502:DE-468:23124074000006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -132,7 +132,7 @@
       "isil" : "DE-708",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990063549080206441:DE-708:23104630370006464#!"
+    "id" : "http://lobid.org/items/HT003538502:DE-708:23104630370006464#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -143,7 +143,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990063549080206441:DE-386:2380642040007476#!"
+    "id" : "http://lobid.org/items/HT003538502:DE-386:2380642040007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -152,7 +152,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990063549080206441:DE-6:991027259779706449#!"
+    "id" : "http://lobid.org/items/HT003538502:DE-6:991027259779706449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -89,7 +89,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990065341720206441:DE-6:23553702130006449#!"
+    "id" : "http://lobid.org/items/HT004764408:DE-6:23553702130006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -124,5 +124,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990065341720206441#!"
+  "id" : "http://lobid.org/resources/HT004764408#!"
 }

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -88,7 +88,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-361:23256260230006442#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-361:23256260230006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -100,7 +100,7 @@
       "isil" : "DE-6-020",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-6-020:23595716610006449#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-6-020:23595716610006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -112,7 +112,7 @@
       "isil" : "DE-6-246",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-6-246:23595716590006449#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-6-246:23595716590006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -124,7 +124,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-6:23595716630006449#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-6:23595716630006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -134,7 +134,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-466:22124728180006463#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-466:22124728180006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -143,7 +143,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-61:990023296720206443#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-61:990023296720206443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -152,7 +152,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075429930206441:DE-467:990002110800106462#!"
+    "id" : "http://lobid.org/items/HT000944190:DE-467:990002110800106462#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -175,5 +175,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990075429930206441#!"
+  "id" : "http://lobid.org/resources/HT000944190#!"
 }

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -175,5 +175,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990075538650206441#!"
+  "id" : "http://lobid.org/resources/HT003184116#!"
 }

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -136,7 +136,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075538650206441:DE-466:23134766780006463#!"
+    "id" : "http://lobid.org/items/HT003184116:DE-466:23134766780006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -146,7 +146,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990075538650206441:DE-466:22134766770006463#!"
+    "id" : "http://lobid.org/items/HT003184116:DE-466:22134766770006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -140,5 +140,5 @@
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "type" : [ "BibliographicResource", "Newspaper" ],
-  "id" : "http://lobid.org/resources/990103770440206441#!"
+  "id" : "http://lobid.org/resources/HT012224491#!"
 }

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -120,5 +120,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990103899140206441#!"
+  "id" : "http://lobid.org/resources/HT012237361#!"
 }

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -116,5 +116,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990104908070206441#!"
+  "id" : "http://lobid.org/resources/HT012338254#!"
 }

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -146,5 +146,5 @@
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "type" : [ "BibliographicResource", "Newspaper" ],
-  "id" : "http://lobid.org/resources/990108740950206441#!"
+  "id" : "http://lobid.org/resources/HT012721542#!"
 }

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -122,7 +122,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990108873860206441:DE-466:990009633110106463#!"
+    "id" : "http://lobid.org/items/HT012734833:DE-466:990009633110106463#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -132,5 +132,5 @@
     "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
   } ],
   "type" : [ "BibliographicResource", "Periodical" ],
-  "id" : "http://lobid.org/resources/990108873860206441#!"
+  "id" : "http://lobid.org/resources/HT012734833#!"
 }

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -167,5 +167,5 @@
   } ],
   "type" : [ "BibliographicResource", "Periodical" ],
   "responsibilityStatement" : [ "Wenner-Gren Foundation for Anthropological Research" ],
-  "id" : "http://lobid.org/resources/990108874370206441#!"
+  "id" : "http://lobid.org/resources/HT012734884#!"
 }

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -150,5 +150,5 @@
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "type" : [ "BibliographicResource", "Map" ],
-  "id" : "http://lobid.org/resources/990110509950206441#!"
+  "id" : "http://lobid.org/resources/BT000003404#!"
 }

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -139,5 +139,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990110714900206441#!"
+  "id" : "http://lobid.org/resources/BT000024700#!"
 }

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -112,5 +112,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990110881770206441#!"
+  "id" : "http://lobid.org/resources/BT000041593#!"
 }

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -168,5 +168,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990112067120206441#!"
+  "id" : "http://lobid.org/resources/BT000160670#!"
 }

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -97,5 +97,5 @@
   } ],
   "type" : [ "BibliographicResource", "Periodical" ],
   "responsibilityStatement" : [ "Touristik Centrale Mainz" ],
-  "id" : "http://lobid.org/resources/990113537330206441#!"
+  "id" : "http://lobid.org/resources/HT013026834#!"
 }

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -153,5 +153,5 @@
   } ],
   "type" : [ "BibliographicResource", "Book" ],
   "responsibilityStatement" : [ "Carmel Berkson" ],
-  "id" : "http://lobid.org/resources/990114098170206441#!"
+  "id" : "http://lobid.org/resources/HT013083243#!"
 }

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -145,7 +145,7 @@
       "isil" : "DE-6-069",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990114098170206441:DE-6-069:23507172540006449#!"
+    "id" : "http://lobid.org/items/HT013083243:DE-6-069:23507172540006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -121,5 +121,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990114617880206441#!"
+  "id" : "http://lobid.org/resources/HT013135581#!"
 }

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -97,7 +97,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990114617880206441:DE-61:23257820090006443#!"
+    "id" : "http://lobid.org/items/HT013135581:DE-61:23257820090006443#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -165,5 +165,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990118562160206441#!"
+  "id" : "http://lobid.org/resources/HT013532539#!"
 }

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -91,7 +91,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990118562160206441:DE-465:23420787060006446#!"
+    "id" : "http://lobid.org/items/HT013532539:DE-465:23420787060006446#!"
   } ],
   "medium" : [ {
     "label" : "Mikroformat",

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -170,5 +170,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990122511970206441#!"
+  "id" : "http://lobid.org/resources/TT000075751#!"
 }

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -90,5 +90,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990123613330206441#!"
+  "id" : "http://lobid.org/resources/TT000166861#!"
 }

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -100,7 +100,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990124590390206441:DE-361:23240897810006442#!"
+    "id" : "http://lobid.org/items/HT013911008:DE-361:23240897810006442#!"
   } ],
   "medium" : [ {
     "label" : "Audio-Dokument",

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -113,5 +113,5 @@
     "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
   } ],
   "type" : [ "BibliographicResource", "Miscellaneous" ],
-  "id" : "http://lobid.org/resources/990124590390206441#!"
+  "id" : "http://lobid.org/resources/HT013911008#!"
 }

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -263,5 +263,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990126276700206441#!"
+  "id" : "http://lobid.org/resources/HT014015351#!"
 }

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -123,7 +123,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-468:23148746030006447#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-468:23148746030006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -135,7 +135,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-Dm13:2346678150006451#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-Dm13:2346678150006451#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -147,7 +147,7 @@
       "isil" : "DE-708",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-708:2390329400006464#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-708:2390329400006464#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -159,7 +159,7 @@
       "isil" : "DE-82-609",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-82-609:23232408510006448#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-82-609:23232408510006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -171,7 +171,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-386:2380082230007476#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-386:2380082230007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -183,7 +183,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-386:2380082240007476#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-386:2380082240007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -195,7 +195,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-361:23264458310006442#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-361:23264458310006442#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -207,7 +207,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-61:23303488680006443#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-61:23303488680006443#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -219,7 +219,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-6:23535410630006449#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-6:23535410630006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -231,7 +231,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990126276700206441:DE-467:2393571990006462#!"
+    "id" : "http://lobid.org/items/HT014015351:DE-467:2393571990006462#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -258,5 +258,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990133067580206441#!"
+  "id" : "http://lobid.org/resources/HT014176012#!"
 }

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -200,7 +200,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990133067580206441:DE-61:53804555180006441#!"
+    "id" : "http://lobid.org/items/HT014176012:DE-61:53804555180006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -211,7 +211,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990133067580206441:DE-465:53804555180006441#!"
+    "id" : "http://lobid.org/items/HT014176012:DE-465:53804555180006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -222,7 +222,7 @@
       "isil" : "DE-836",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990133067580206441:DE-836:53804555180006441#!"
+    "id" : "http://lobid.org/items/HT014176012:DE-836:53804555180006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -233,7 +233,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990133067580206441:DE-6:53804555180006441#!"
+    "id" : "http://lobid.org/items/HT014176012:DE-6:53804555180006441#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -155,5 +155,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990136041660206441#!"
+  "id" : "http://lobid.org/resources/HT014388022#!"
 }

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -78,7 +78,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990139686910206441:DE-1156:2310267000006459#!"
+    "id" : "http://lobid.org/items/HT014525099:DE-1156:2310267000006459#!"
   } ],
   "medium" : [ {
     "label" : "Audio-Dokument",

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -277,5 +277,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990139686910206441#!"
+  "id" : "http://lobid.org/resources/HT014525099#!"
 }

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -160,5 +160,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990141342350206441#!"
+  "id" : "http://lobid.org/resources/TT001230001#!"
 }

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -186,5 +186,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990143325070206441#!"
+  "id" : "http://lobid.org/resources/HT014601018#!"
 }

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -167,7 +167,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990143325070206441:DE-6:23564603190006449#!"
+    "id" : "http://lobid.org/items/HT014601018:DE-6:23564603190006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -121,5 +121,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990150856900206441#!"
+  "id" : "http://lobid.org/resources/TT002001274#!"
 }

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -89,7 +89,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990156027740206441:DE-290:53209607190006445#!"
+    "id" : "http://lobid.org/items/HT015011399:DE-290:53209607190006445#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -114,5 +114,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990156027740206441#!"
+  "id" : "http://lobid.org/resources/HT015011399#!"
 }

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -77,7 +77,7 @@
       "isil" : "DE-6-015",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990167595410206441:DE-6-015:23616315430006449#!"
+    "id" : "http://lobid.org/items/TT002494857:DE-6-015:23616315430006449#!"
   } ],
   "medium" : [ {
     "label" : "Sonstige",

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -124,5 +124,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990167595410206441#!"
+  "id" : "http://lobid.org/resources/TT002494857#!"
 }

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -134,7 +134,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990171142550206441:DE-290:23199326600006445#!"
+    "id" : "http://lobid.org/items/HT015671602:DE-290:23199326600006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -146,7 +146,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990171142550206441:DE-361:23278788360006442#!"
+    "id" : "http://lobid.org/items/HT015671602:DE-361:23278788360006442#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -169,5 +169,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990171142550206441#!"
+  "id" : "http://lobid.org/resources/HT015671602#!"
 }

--- a/src/test/resources/alma-fix/990172512030206441.json
+++ b/src/test/resources/alma-fix/990172512030206441.json
@@ -117,5 +117,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990172512030206441#!"
+  "id" : "http://lobid.org/resources/TT002815323#!"
 }

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -163,5 +163,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990173811970206441#!"
+  "id" : "http://lobid.org/resources/HT015865114#!"
 }

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -136,7 +136,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990173811970206441:DE-386:990006166350107476#!"
+    "id" : "http://lobid.org/items/HT015865114:DE-386:990006166350107476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -145,7 +145,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990173811970206441:DE-6:991037863219706449#!"
+    "id" : "http://lobid.org/items/HT015865114:DE-6:991037863219706449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -276,5 +276,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990181275760206441#!"
+  "id" : "http://lobid.org/resources/HT016433929#!"
 }

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -109,7 +109,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-Bm40:2313839880006454#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-Bm40:2313839880006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -121,7 +121,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-Bm40:2313839870006454#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-Bm40:2313839870006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -133,7 +133,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-Bm40:2313839860006454#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-Bm40:2313839860006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -145,7 +145,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-Bm40:2313839840006454#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-Bm40:2313839840006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -157,7 +157,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-Bm40:2313839830006454#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-Bm40:2313839830006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -169,7 +169,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914300006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914300006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -181,7 +181,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914190006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914190006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -193,7 +193,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914180006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914180006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -205,7 +205,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914220006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914220006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -217,7 +217,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914250006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914250006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -229,7 +229,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914260006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914260006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -241,7 +241,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914290006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914290006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -253,7 +253,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990181275760206441:DE-290:23176914230006445#!"
+    "id" : "http://lobid.org/items/HT016433929:DE-290:23176914230006445#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -183,7 +183,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990183054020206441:DE-6:22542862200006449#!"
+    "id" : "http://lobid.org/items/HT016604323:DE-6:22542862200006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -217,5 +217,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990183054020206441#!"
+  "id" : "http://lobid.org/resources/HT016604323#!"
 }

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -173,5 +173,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990183092590206441#!"
+  "id" : "http://lobid.org/resources/HT016608165#!"
 }

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -183,7 +183,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990184127410206441:DE-61:53738793900006441#!"
+    "id" : "http://lobid.org/items/HT016709661:DE-61:53738793900006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -194,7 +194,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990184127410206441:DE-61:53738793940006441#!"
+    "id" : "http://lobid.org/items/HT016709661:DE-61:53738793940006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -205,7 +205,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990184127410206441:DE-61:53804344220006441#!"
+    "id" : "http://lobid.org/items/HT016709661:DE-61:53804344220006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -216,7 +216,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990184127410206441:DE-465:53804344220006441#!"
+    "id" : "http://lobid.org/items/HT016709661:DE-465:53804344220006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -227,7 +227,7 @@
       "isil" : "DE-836",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990184127410206441:DE-836:53804344220006441#!"
+    "id" : "http://lobid.org/items/HT016709661:DE-836:53804344220006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -238,7 +238,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990184127410206441:DE-6:53804344220006441#!"
+    "id" : "http://lobid.org/items/HT016709661:DE-6:53804344220006441#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -263,5 +263,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990184127410206441#!"
+  "id" : "http://lobid.org/resources/HT016709661#!"
 }

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -94,5 +94,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990185607520206441#!"
+  "id" : "http://lobid.org/resources/TT003059252#!"
 }

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -197,5 +197,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990185619180206441#!"
+  "id" : "http://lobid.org/resources/TT003060418#!"
 }

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -305,5 +305,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990189160110206441#!"
+  "id" : "http://lobid.org/resources/HT017015300#!"
 }

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -153,7 +153,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-468:23146330000006447#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-468:23146330000006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -165,7 +165,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-468:23146310030006447#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-468:23146310030006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -177,7 +177,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-468:23146310010006447#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-468:23146310010006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -189,7 +189,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-386:2385580290007476#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-386:2385580290007476#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -201,7 +201,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-290:23197228550006445#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-290:23197228550006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -213,7 +213,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-465:23423021800006446#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-465:23423021800006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -225,7 +225,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-465:23423021780006446#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-465:23423021780006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -237,7 +237,7 @@
       "isil" : "DE-6-058",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-6-058:23527811750006449#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-6-058:23527811750006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -249,7 +249,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-6:23527811780006449#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-6:23527811780006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -261,7 +261,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-6:23527811770006449#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-6:23527811770006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -273,7 +273,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-466:23142134120006463#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-466:23142134120006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -283,7 +283,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990189160110206441:DE-466:22142134110006463#!"
+    "id" : "http://lobid.org/items/HT017015300:DE-466:22142134110006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -148,5 +148,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990190567380206441#!"
+  "id" : "http://lobid.org/resources/HT017150239#!"
 }

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -108,5 +108,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990193094010206441#!"
+  "id" : "http://lobid.org/resources/HT017398609#!"
 }

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -86,7 +86,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990193094010206441:DE-290:23195293910006445#!"
+    "id" : "http://lobid.org/items/HT017398609:DE-290:23195293910006445#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -259,7 +259,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990193229450206441:DE-61:53807024380006441#!"
+    "id" : "http://lobid.org/items/HT017411546:DE-61:53807024380006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -270,7 +270,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990193229450206441:DE-465:53807024380006441#!"
+    "id" : "http://lobid.org/items/HT017411546:DE-465:53807024380006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -281,7 +281,7 @@
       "isil" : "DE-836",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990193229450206441:DE-836:53807024380006441#!"
+    "id" : "http://lobid.org/items/HT017411546:DE-836:53807024380006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -292,7 +292,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990193229450206441:DE-6:53807024380006441#!"
+    "id" : "http://lobid.org/items/HT017411546:DE-6:53807024380006441#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -316,5 +316,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990193229450206441#!"
+  "id" : "http://lobid.org/resources/HT017411546#!"
 }

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -108,5 +108,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990193806600206441#!"
+  "id" : "http://lobid.org/resources/HT017468042#!"
 }

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -86,7 +86,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990193806600206441:DE-6:23526297370006449#!"
+    "id" : "http://lobid.org/items/HT017468042:DE-6:23526297370006449#!"
   } ],
   "medium" : [ {
     "label" : "Sonstige",

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -94,7 +94,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990194668760206441:DE-61:23289523250006443#!"
+    "id" : "http://lobid.org/items/HT017551955:DE-61:23289523250006443#!"
   } ],
   "medium" : [ {
     "label" : "Sonstige",

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -118,5 +118,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990194668760206441#!"
+  "id" : "http://lobid.org/resources/HT017551955#!"
 }

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -82,7 +82,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990194744870206441:DE-386:2363975880007476#!"
+    "id" : "http://lobid.org/items/HT017559543:DE-386:2363975880007476#!"
   } ],
   "medium" : [ {
     "label" : "Sonstige",

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -105,5 +105,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990194744870206441#!"
+  "id" : "http://lobid.org/resources/HT017559543#!"
 }

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -105,5 +105,5 @@
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "type" : [ "BibliographicResource", "Newspaper" ],
-  "id" : "http://lobid.org/resources/990196925330206441#!"
+  "id" : "http://lobid.org/resources/HT017655416#!"
 }

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -118,5 +118,5 @@
     "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
   } ],
   "type" : [ "BibliographicResource", "Newspaper" ],
-  "id" : "http://lobid.org/resources/990197023370206441#!"
+  "id" : "http://lobid.org/resources/HT017664407#!"
 }

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -102,7 +102,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197067610206441:DE-61:53723406060006441#!"
+    "id" : "http://lobid.org/items/CT003043468:DE-61:53723406060006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -113,7 +113,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197067610206441:DE-465:53723406060006441#!"
+    "id" : "http://lobid.org/items/CT003043468:DE-465:53723406060006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -124,7 +124,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197067610206441:DE-466:53723406060006441#!"
+    "id" : "http://lobid.org/items/CT003043468:DE-466:53723406060006441#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -151,5 +151,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990197067610206441#!"
+  "id" : "http://lobid.org/resources/CT003043468#!"
 }

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -409,5 +409,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990197293880206441#!"
+  "id" : "http://lobid.org/resources/TT050421649#!"
 }

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -178,7 +178,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-361:991009118459706442#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-361:991009118459706442#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -189,7 +189,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-Dm13:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-Dm13:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -200,7 +200,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-A96:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-A96:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -211,7 +211,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-465:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-465:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -222,7 +222,7 @@
       "isil" : "DE-1010",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-1010:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-1010:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -233,7 +233,7 @@
       "isil" : "DE-1393",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-1393:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-1393:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -244,7 +244,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-466:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-466:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -255,7 +255,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-467:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-467:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -266,7 +266,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-468:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-468:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -277,7 +277,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-361:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-361:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -288,7 +288,7 @@
       "isil" : "DE-Due62",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-Due62:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-Due62:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -299,7 +299,7 @@
       "isil" : "DE-Hag4",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-Hag4:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-Hag4:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -310,7 +310,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-290:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-290:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -321,7 +321,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-1044:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-1044:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -332,7 +332,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-61:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-61:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -343,7 +343,7 @@
       "isil" : "DE-836",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-836:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-836:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -354,7 +354,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-Bi10:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-Bi10:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -365,7 +365,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-386:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-386:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -376,7 +376,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-Bm40:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-Bm40:53717454420006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -387,7 +387,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990197293880206441:DE-82:53717454420006441#!"
+    "id" : "http://lobid.org/items/TT050421649:DE-82:53717454420006441#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -82,7 +82,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990198383780206441:DE-61:23317843550006443#!"
+    "id" : "http://lobid.org/items/HT017775049:DE-61:23317843550006443#!"
   } ],
   "medium" : [ {
     "label" : "Audio-Dokument",

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -108,5 +108,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990198383780206441#!"
+  "id" : "http://lobid.org/resources/HT017775049#!"
 }

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -165,5 +165,5 @@
     "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
   } ],
   "type" : [ "BibliographicResource", "EditedVolume", "Report" ],
-  "id" : "http://lobid.org/resources/990199611280206441#!"
+  "id" : "http://lobid.org/resources/HT017894012#!"
 }

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -135,7 +135,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990199611280206441:DE-290:991009656879706445#!"
+    "id" : "http://lobid.org/items/HT017894012:DE-290:991009656879706445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
@@ -144,7 +144,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990199611280206441:DE-467:990195668690106462#!"
+    "id" : "http://lobid.org/items/HT017894012:DE-467:990195668690106462#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -155,7 +155,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990199611280206441:DE-468:53155629910006447#!"
+    "id" : "http://lobid.org/items/HT017894012:DE-468:53155629910006447#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -192,5 +192,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990204246530206441#!"
+  "id" : "http://lobid.org/resources/HT018295975#!"
 }

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -157,7 +157,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990204246530206441:DE-6:23593081430006449#!"
+    "id" : "http://lobid.org/items/HT018295975:DE-6:23593081430006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -176,7 +176,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990206060640206441:DE-361:53307086040006442#!"
+    "id" : "http://lobid.org/items/HT018468645:DE-361:53307086040006442#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -187,7 +187,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990206060640206441:DE-361:53307086020006442#!"
+    "id" : "http://lobid.org/items/HT018468645:DE-361:53307086020006442#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -198,7 +198,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990206060640206441:DE-466:53165716350006463#!"
+    "id" : "http://lobid.org/items/HT018468645:DE-466:53165716350006463#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -237,5 +237,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990206060640206441#!"
+  "id" : "http://lobid.org/resources/HT018468645#!"
 }

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -97,7 +97,7 @@
       "isil" : "DE-82-223",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990207668220206441:DE-82-223:23233358930006448#!"
+    "id" : "http://lobid.org/items/TT003280170:DE-82-223:23233358930006448#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -104,5 +104,5 @@
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "type" : [ "BibliographicResource", "Festschrift", "Book" ],
-  "id" : "http://lobid.org/resources/990207668220206441#!"
+  "id" : "http://lobid.org/resources/TT003280170#!"
 }

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -102,5 +102,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990207856340206441#!"
+  "id" : "http://lobid.org/resources/HT018627673#!"
 }

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -108,5 +108,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990209515320206441#!"
+  "id" : "http://lobid.org/resources/HT018781534#!"
 }

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -189,5 +189,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990209817770206441#!"
+  "id" : "http://lobid.org/resources/HT018811791#!"
 }

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -157,7 +157,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990209817770206441:DE-6:23490552480006449#!"
+    "id" : "http://lobid.org/items/HT018811791:DE-6:23490552480006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -179,5 +179,5 @@
     "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
   } ],
   "type" : [ "BibliographicResource", "Series" ],
-  "id" : "http://lobid.org/resources/990210093550206441#!"
+  "id" : "http://lobid.org/resources/HT018839495#!"
 }

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -103,7 +103,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-Bi10:5322365740006450#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-Bi10:5322365740006450#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -114,7 +114,7 @@
       "isil" : "DE-Due62",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-Due62:5336568560006455#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-Due62:5336568560006455#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -125,7 +125,7 @@
       "isil" : "DE-386",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-386:53108868480007476#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-386:53108868480007476#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -136,7 +136,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-465:53428417070006446#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-465:53428417070006446#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -147,7 +147,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-6:53625317550006449#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-6:53625317550006449#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -158,7 +158,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-466:53164238820006463#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-466:53164238820006463#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -169,7 +169,7 @@
       "isil" : "DE-1010",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210093550206441:DE-1010:5316850710006456#!"
+    "id" : "http://lobid.org/items/HT018839495:DE-1010:5316850710006456#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -87,7 +87,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251010006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251010006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -99,7 +99,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251390006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251390006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -111,7 +111,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251020006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251020006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -123,7 +123,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251030006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251030006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -135,7 +135,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251000006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251000006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -147,7 +147,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251210006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251210006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -159,7 +159,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251040006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251040006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -171,7 +171,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251050006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251050006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -183,7 +183,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251220006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251220006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -195,7 +195,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251200006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251200006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -207,7 +207,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251190006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251190006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -219,7 +219,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251170006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251170006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -231,7 +231,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251180006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251180006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -243,7 +243,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251080006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251080006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -255,7 +255,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251250006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251250006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -267,7 +267,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251500006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251500006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -279,7 +279,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251340006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251340006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -291,7 +291,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251060006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251060006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -303,7 +303,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251230006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251230006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -315,7 +315,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251520006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251520006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -327,7 +327,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251270006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251270006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -339,7 +339,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251540006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251540006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -351,7 +351,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251300006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251300006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -363,7 +363,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251360006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251360006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -375,7 +375,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251380006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251380006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -387,7 +387,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251410006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251410006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -399,7 +399,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251430006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251430006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -411,7 +411,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251450006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251450006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -423,7 +423,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251470006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251470006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -435,7 +435,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251490006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251490006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -447,7 +447,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250960006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250960006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -459,7 +459,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250970006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250970006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -471,7 +471,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251130006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251130006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -483,7 +483,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250920006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250920006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -495,7 +495,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251290006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251290006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -507,7 +507,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250990006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250990006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -519,7 +519,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250940006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250940006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -531,7 +531,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250980006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250980006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -543,7 +543,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251110006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251110006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -554,7 +554,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311250900006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311250900006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -566,7 +566,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251100006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251100006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -578,7 +578,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251120006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251120006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -590,7 +590,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251140006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251140006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -602,7 +602,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251150006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251150006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -614,7 +614,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251160006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251160006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -626,7 +626,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251070006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251070006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -638,7 +638,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251090006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251090006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -650,7 +650,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251240006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251240006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -662,7 +662,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251260006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251260006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -674,7 +674,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251510006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251510006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -686,7 +686,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251350006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251350006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -698,7 +698,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251310006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251310006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -710,7 +710,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251370006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251370006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -722,7 +722,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251400006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251400006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -734,7 +734,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251480006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251480006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -746,7 +746,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251420006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251420006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -758,7 +758,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251440006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251440006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -770,7 +770,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251460006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251460006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -782,7 +782,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251550006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251550006459#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -794,7 +794,7 @@
       "isil" : "DE-1156",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210237770206441:DE-1156:2311251590006459#!"
+    "id" : "http://lobid.org/items/HT018853619:DE-1156:2311251590006459#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -847,5 +847,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990210237770206441#!"
+  "id" : "http://lobid.org/resources/HT018853619#!"
 }

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -213,5 +213,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990210285400206441#!"
+  "id" : "http://lobid.org/resources/HT018857620#!"
 }

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -155,5 +155,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990210312460206441#!"
+  "id" : "http://lobid.org/resources/HT018860300#!"
 }

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -167,5 +167,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990210667610206441#!"
+  "id" : "http://lobid.org/resources/HT018895767#!"
 }

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -186,5 +186,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990210781980206441#!"
+  "id" : "http://lobid.org/resources/HT018907266#!"
 }

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -219,5 +219,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990210950050206441#!"
+  "id" : "http://lobid.org/resources/HT018924091#!"
 }

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -185,7 +185,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990210950050206441:DE-61:23260972720006443#!"
+    "id" : "http://lobid.org/items/HT018924091:DE-61:23260972720006443#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -117,7 +117,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990213367870206441:DE-290:53209196500006445#!"
+    "id" : "http://lobid.org/items/HT019075404:DE-290:53209196500006445#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -141,5 +141,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990213367870206441#!"
+  "id" : "http://lobid.org/resources/HT019075404#!"
 }

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -147,5 +147,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990213906490206441#!"
+  "id" : "http://lobid.org/resources/HT019128882#!"
 }

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -237,7 +237,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719440006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719440006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -249,7 +249,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719430006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719430006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -261,7 +261,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719450006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719450006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -273,7 +273,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719550006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719550006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -285,7 +285,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719530006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719530006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -297,7 +297,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719500006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719500006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -309,7 +309,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719390006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719390006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -321,7 +321,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719400006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719400006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -333,7 +333,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719410006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719410006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -345,7 +345,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719470006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719470006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -357,7 +357,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719420006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719420006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -369,7 +369,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719370006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719370006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -381,7 +381,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-468:23121719380006447#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-468:23121719380006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -393,7 +393,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-Dm13:2346308310006451#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-Dm13:2346308310006451#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -405,7 +405,7 @@
       "isil" : "DE-708",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-708:23101974750006464#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-708:23101974750006464#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -417,7 +417,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-Bi10:2321369680006450#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-Bi10:2321369680006450#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -429,7 +429,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-Bm40:2314295720006454#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-Bm40:2314295720006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -441,7 +441,7 @@
       "isil" : "DE-82-211",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-82-211:23243058570006448#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-82-211:23243058570006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -453,7 +453,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-290:23194214350006445#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-290:23194214350006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -465,7 +465,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-6:23512237280006449#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-6:23512237280006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -477,7 +477,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-467:2393751950006462#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-467:2393751950006462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -489,7 +489,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-467:2393751960006462#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-467:2393751960006462#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -501,7 +501,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-466:23122059280006463#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-466:23122059280006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -511,7 +511,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990217478660206441:DE-466:22122059270006463#!"
+    "id" : "http://lobid.org/items/HT019246898:DE-466:22122059270006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -583,5 +583,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990217478660206441#!"
+  "id" : "http://lobid.org/resources/HT019246898#!"
 }

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -161,5 +161,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990217495840206441#!"
+  "id" : "http://lobid.org/resources/HT019248596#!"
 }

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -108,5 +108,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990219911120206441#!"
+  "id" : "http://lobid.org/resources/HT019485225#!"
 }

--- a/src/test/resources/alma-fix/990220027540206441.json
+++ b/src/test/resources/alma-fix/990220027540206441.json
@@ -113,5 +113,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990220027540206441#!"
+  "id" : "http://lobid.org/resources/HT019496555#!"
 }

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -533,5 +533,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990223521400206441#!"
+  "id" : "http://lobid.org/resources/HT019631849#!"
 }

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -223,7 +223,7 @@
       "isil" : "DE-468",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-468:23143395260006447#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-468:23143395260006447#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -235,7 +235,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-Dm13:2345522380006451#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-Dm13:2345522380006451#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -247,7 +247,7 @@
       "isil" : "DE-Hag4-2",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-Hag4-2:2360781850006461#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-Hag4-2:2360781850006461#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -259,7 +259,7 @@
       "isil" : "DE-Hag4-2",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-Hag4-2:2360781840006461#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-Hag4-2:2360781840006461#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -271,7 +271,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-A96:2384742870006444#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-A96:2384742870006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -283,7 +283,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-A96:2384742860006444#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-A96:2384742860006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -295,7 +295,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-1044:2347701840006452#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-1044:2347701840006452#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -307,7 +307,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-1044:2347701860006452#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-1044:2347701860006452#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -319,7 +319,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-1044:2347701900006452#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-1044:2347701900006452#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -331,7 +331,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-1044:2347701880006452#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-1044:2347701880006452#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -343,7 +343,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-290:23189128750006445#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-290:23189128750006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -355,7 +355,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947900006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947900006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -367,7 +367,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947910006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947910006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -379,7 +379,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947920006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947920006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -391,7 +391,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947870006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947870006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -403,7 +403,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947880006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947880006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -415,7 +415,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947940006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947940006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -427,7 +427,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947850006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947850006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -439,7 +439,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-465:23416947860006446#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-465:23416947860006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -451,7 +451,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-6:23506634650006449#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-6:23506634650006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -463,7 +463,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-6:23506634640006449#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-6:23506634640006449#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -475,7 +475,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-466:23127647720006463#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-466:23127647720006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -487,7 +487,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-466:23127647710006463#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-466:23127647710006463#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysikalischerTitel" ],
@@ -497,7 +497,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990223521400206441:DE-466:22127647700006463#!"
+    "id" : "http://lobid.org/items/HT019631849:DE-466:22127647700006463#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -113,5 +113,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990225056670206441#!"
+  "id" : "http://lobid.org/resources/TT003907920#!"
 }

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -90,7 +90,7 @@
       "isil" : "DE-82-501",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990225056670206441:DE-82-501:23217998250006448#!"
+    "id" : "http://lobid.org/items/TT003907920:DE-82-501:23217998250006448#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -151,5 +151,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990226465800206441#!"
+  "id" : "http://lobid.org/resources/HT019838800#!"
 }

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -133,5 +133,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990226763120206441#!"
+  "id" : "http://lobid.org/resources/HT019868557#!"
 }

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -160,5 +160,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990363946050206441#!"
+  "id" : "http://lobid.org/resources/HT020202475#!"
 }

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -134,7 +134,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990363946050206441:DE-290:53209365020006445#!"
+    "id" : "http://lobid.org/items/HT020202475:DE-290:53209365020006445#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -216,5 +216,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990365842280206441#!"
+  "id" : "http://lobid.org/resources/HT020391499#!"
 }

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -95,7 +95,7 @@
       "isil" : "DE-1044",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-1044:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-1044:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -106,7 +106,7 @@
       "isil" : "DE-61",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-61:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-61:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -117,7 +117,7 @@
       "isil" : "DE-361",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-361:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-361:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -128,7 +128,7 @@
       "isil" : "DE-Due62",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-Due62:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-Due62:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -139,7 +139,7 @@
       "isil" : "DE-1010",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-1010:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-1010:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -150,7 +150,7 @@
       "isil" : "DE-708",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-708:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-708:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -161,7 +161,7 @@
       "isil" : "DE-836",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-836:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-836:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -172,7 +172,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-Dm13:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-Dm13:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -183,7 +183,7 @@
       "isil" : "DE-466",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-466:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-466:53706734800006441#!"
   }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
@@ -194,7 +194,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990365842280206441:DE-6:53706734800006441#!"
+    "id" : "http://lobid.org/items/HT020391499:DE-6:53706734800006441#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -72,7 +72,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990366394400206441:DE-6:23534915260006449#!"
+    "id" : "http://lobid.org/items/HT020446683:DE-6:23534915260006449#!"
   } ],
   "medium" : [ {
     "label" : "Manuskript",

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -79,5 +79,5 @@
     "id" : "http://purl.org/ontology/bibo/Manuscript"
   } ],
   "type" : [ "BibliographicResource", "Book" ],
-  "id" : "http://lobid.org/resources/990366394400206441#!"
+  "id" : "http://lobid.org/resources/HT020446683#!"
 }

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -296,5 +296,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/990367731740206441#!"
+  "id" : "http://lobid.org/resources/HT020579803#!"
 }

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -73,7 +73,7 @@
       "isil" : "DE-6",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/990368743120206441:DE-6:23544500850006449#!"
+    "id" : "http://lobid.org/items/HT020681018:DE-6:23544500850006449#!"
   } ],
   "medium" : [ {
     "label" : "Manuskript",

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -80,5 +80,5 @@
     "id" : "http://purl.org/ontology/bibo/Manuscript"
   } ],
   "type" : [ "BibliographicResource", "Book" ],
-  "id" : "http://lobid.org/resources/990368743120206441#!"
+  "id" : "http://lobid.org/resources/HT020681018#!"
 }

--- a/src/test/resources/alma-fix/99370771475306441.json
+++ b/src/test/resources/alma-fix/99370771475306441.json
@@ -518,5 +518,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/99370771475306441#!"
+  "id" : "http://lobid.org/resources/HT020919504#!"
 }

--- a/src/test/resources/alma-fix/99370771475306441.json
+++ b/src/test/resources/alma-fix/99370771475306441.json
@@ -434,7 +434,7 @@
       "isil" : "DE-Dm13",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370771475306441:DE-Dm13:2346845850006451#!"
+    "id" : "http://lobid.org/items/HT020919504:DE-Dm13:2346845850006451#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -446,7 +446,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370771475306441:DE-Bi10:2317935550006450#!"
+    "id" : "http://lobid.org/items/HT020919504:DE-Bi10:2317935550006450#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -458,7 +458,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370771475306441:DE-Bi10:2317935560006450#!"
+    "id" : "http://lobid.org/items/HT020919504:DE-Bi10:2317935560006450#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -470,7 +470,7 @@
       "isil" : "DE-Bi10",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370771475306441:DE-Bi10:2317935570006450#!"
+    "id" : "http://lobid.org/items/HT020919504:DE-Bi10:2317935570006450#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -482,7 +482,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370771475306441:DE-465:23448803450006446#!"
+    "id" : "http://lobid.org/items/HT020919504:DE-465:23448803450006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -494,7 +494,7 @@
       "isil" : "DE-6-164",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370771475306441:DE-6-164:23545591700006449#!"
+    "id" : "http://lobid.org/items/HT020919504:DE-6-164:23545591700006449#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -96,7 +96,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389819160006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389819160006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -108,7 +108,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389819170006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389819170006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -120,7 +120,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389819180006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389819180006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -132,7 +132,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389819140006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389819140006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -144,7 +144,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389819150006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389819150006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -156,7 +156,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949700006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949700006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -168,7 +168,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949710006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949710006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -180,7 +180,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949690006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949690006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -192,7 +192,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949680006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949680006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -204,7 +204,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949720006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949720006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -216,7 +216,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949730006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949730006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -228,7 +228,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949740006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949740006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -240,7 +240,7 @@
       "isil" : "DE-A96",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-A96:2389949750006444#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-A96:2389949750006444#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -252,7 +252,7 @@
       "isil" : "DE-Bm40",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-Bm40:2313413830006454#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-Bm40:2313413830006454#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -264,7 +264,7 @@
       "isil" : "DE-Due62",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-Due62:2332725590006455#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-Due62:2332725590006455#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -276,7 +276,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82:23218957880006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82:23218957880006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -288,7 +288,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82:23218957810006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82:23218957810006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -300,7 +300,7 @@
       "isil" : "DE-82-202",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82-202:23218957790006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82-202:23218957790006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -312,7 +312,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82:23218957850006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82:23218957850006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -324,7 +324,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82:23218957840006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82:23218957840006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -336,7 +336,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82:23218957830006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82:23218957830006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -348,7 +348,7 @@
       "isil" : "DE-82",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-82:23218957870006448#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-82:23218957870006448#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -360,7 +360,7 @@
       "isil" : "DE-290",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-290:23212938760006445#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-290:23212938760006445#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -372,7 +372,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-465:23448939910006446#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-465:23448939910006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -384,7 +384,7 @@
       "isil" : "DE-465",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-465:23448939860006446#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-465:23448939860006446#!"
   }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
@@ -396,7 +396,7 @@
       "isil" : "DE-467",
       "label" : "lobid Organisation"
     },
-    "id" : "http://lobid.org/items/99370782520706441:DE-467:2358786050006462#!"
+    "id" : "http://lobid.org/items/HT020936481:DE-467:2358786050006462#!"
   } ],
   "medium" : [ {
     "label" : "Print",

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -418,5 +418,5 @@
     },
     "type" : [ "Contribution" ]
   } ],
-  "id" : "http://lobid.org/resources/99370782520706441#!"
+  "id" : "http://lobid.org/resources/HT020936481#!"
 }


### PR DESCRIPTION
I drafted a PR for another id handling. We would follow the approach from DigiBib (@blackwinter thats your approach right?):

> BTW: In DigiBib, we're using the hbz ID as record ID where available, otherwise the ZDB ID, falling back to the MMS ID as a last resort.

https://github.com/hbz/lobid-resources/issues/1693#issuecomment-1491781235

I also changed the item ids alike.

@acka47 @fsteeg @dr0i what do you think? can we change this. It would be a our last chance before ALMA-lobid replaces Aleph-lobid. what about RPBs reconcile activities?

@hagbeck  @UBmakla would this change be okay with you?

