### PR TITLE
Feature/hasitem nested

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -429,7 +429,7 @@
             },
             "contribution" : {
                "type" : "nested",
-               "include_in_parent" : "true",
+               "include_in_parent" : true,
                "properties" : {
                   "agent" : {
                      "properties" : {
@@ -511,7 +511,7 @@
             },
             "subject": {
                "type" : "nested",
-               "include_in_parent" : "true",
+               "include_in_parent" : true,
                "properties": {
                   "altLabel": {
                      "type": "text",
@@ -519,7 +519,7 @@
                   },
                   "componentList": {
                      "type" : "nested",
-                     "include_in_parent" : "true",
+                     "include_in_parent" : true,
                      "properties": {
                         "altLabel": {
                            "type": "text",

--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -383,6 +383,9 @@
                   },
                   "callNumber" : {
                      "type" : "keyword"
+                  },
+                  "currentLocation" : {
+                     "type" : "keyword"
                   }
                }
             },

--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -343,6 +343,8 @@
                 }
             },
             "hasItem" : {
+               "type" : "nested",
+               "include_in_parent" : true,
                "properties" : {
                   "type" : {
                      "type" : "keyword"

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -1,0 +1,410 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "almaMmsId" : "99371314897806441",
+  "hbzId" : "HT021352855",
+  "deprecatedUri" : "http://lobid.org/resources/HT021352855#!",
+  "isbn" : [ "9781444327540", "1444327542" ],
+  "doi" : [ "10.1002/9781444327540", "https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540" ],
+  "title" : "Political Atlas of the Modern World",
+  "edition" : [ "1" ],
+  "publication" : [ {
+    "startDate" : "2010",
+    "type" : [ "PublicationEvent" ],
+    "publishedBy" : [ "John Wiley & Sons, Inc" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99371314897806441",
+    "label" : "Webseite der hbz-Ressource 99371314897806441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/hbz01/99371314897806441",
+        "dateCreated" : "2022-04-29",
+        "dateModified" : "2022-08-02",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99371314897806441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-EBA-Wiley#!",
+          "label" : "lobid Organisation"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-EBA-Wiley#!",
+          "label" : "lobid Organisation"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "lobid Organisation"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "http://hub.culturegraph.org/resource/HBZ-HT021352855",
+    "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://dx.doi.org/10.1002/9781444327540",
+    "label" : "9781444327540"
+  }, {
+    "id" : "http://dx.doi.org/https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540",
+    "label" : "9781444327540"
+  } ],
+  "related" : [ {
+    "isbn" : [ "9781444335804", "1444335804" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/ZDB-35-Wiley-EBA#!",
+    "type" : [ "Collection" ],
+    "label" : "lobid Organisation"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
+    "label" : "Englisch"
+  } ],
+  "extent" : "1 Online-Ressource",
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Freie Verschlagwortung",
+      "id" : "https://www.wikidata.org/wiki/Q47524318"
+    },
+    "label" : "Political Science"
+  } ],
+  "subjectslabels" : [ "Political Science" ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLocation" : "N5001 / UNASSIGNED",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-829#!",
+      "isil" : "DE-829",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-829:2221466720007916#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLocation" : "Z9039 / UNASSIGNED",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-1032#!",
+      "isil" : "DE-1032",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-1032:2216648660007920#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLocation" : "B0001 / UNASSIGNED",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "isil" : "DE-294",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-294:22132983340007503#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLocation" : "Q0001 / UNASSIGNED",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "isil" : "DE-5",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-5:22165237240007502#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLocation" : "K0001 / UNASSIGNED",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "isil" : "DE-38",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-38:22185267420007147#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLocation" : "KP001 / UNASSIGNED",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Kn41#!",
+      "isil" : "DE-Kn41",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-Kn41:2225159930007146#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-832#!",
+      "isil" : "DE-832",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-832:9975224207504#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HBI/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HBI/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Bi10#!",
+      "isil" : "DE-Bi10",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-Bi10:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "isil" : "DE-61",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-61:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FHA/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FHA/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-A96#!",
+      "isil" : "DE-A96",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-A96:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UDE/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UDE/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "isil" : "DE-465",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-465:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WHS/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WHS/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-1010#!",
+      "isil" : "DE-1010",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-1010:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_RUW/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_RUW/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-1393#!",
+      "isil" : "DE-1393",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-1393:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FHM/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FHM/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-836#!",
+      "isil" : "DE-836",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-836:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "isil" : "DE-466",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-466:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "isil" : "DE-467",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-467:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "isil" : "DE-468",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-468:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "isil" : "DE-6",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-6:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBD/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBD/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-290#!",
+      "isil" : "DE-290",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-290:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BRS/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BRS/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-1044#!",
+      "isil" : "DE-1044",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-1044:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FDO/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FDO/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Dm13#!",
+      "isil" : "DE-Dm13",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-Dm13:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HBO/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Bm40#!",
+      "isil" : "DE-Bm40",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-Bm40:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "isil" : "DE-361",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-361:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "isil" : "DE-Due62",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-Due62:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FSW/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FSW/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-Hag4#!",
+      "isil" : "DE-Hag4",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-Hag4:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBA/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBA/openurl?u.ignore_date_coverage=true&rft.mms_id=99371314897806441",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-82#!",
+      "isil" : "DE-82",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-82:53769526120006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53133004370006464&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=990016111720106464",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "isil" : "DE-708",
+      "label" : "lobid Organisation"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-708:53133004370006464#!"
+  } ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "type" : [ "BibliographicResource", "Book" ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Melville",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ],
+  "id" : "http://lobid.org/resources/99371314897806441#!"
+}

--- a/src/test/resources/alma-fix/99371314897806441.xml
+++ b/src/test/resources/alma-fix/99371314897806441.xml
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01057cam#a2200373#c#4500</leader>
+  <controlfield tag="005">20220715184200.0</controlfield>
+  <controlfield tag="007">cr#|||||||||||</controlfield>
+  <controlfield tag="008">220429|2010####xx######o#####|||#|#eng#c</controlfield>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="001">99371314897806441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">10.1002/9781444327540</subfield>
+    <subfield code="2">XX-XxUND</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781444327540</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT021352855</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">EBA-Wiley</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">EBA-Wiley</subfield>
+    <subfield code="d">DE-605</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">eng</subfield>
+  </datafield>
+  <datafield tag="100" ind1="0" ind2=" ">
+    <subfield code="a">Melville</subfield>
+    <subfield code="4">aut</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Political Atlas of the Modern World</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">1</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="b">John Wiley &amp; Sons, Inc</subfield>
+    <subfield code="c">2010-08-13</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 Online-Ressource</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">c</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">cr</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2=" ">
+    <subfield code="u">https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540</subfield>
+  </datafield>
+  <datafield tag="912" ind1=" " ind2=" ">
+    <subfield code="a">ZDB-35-Wiley-EBA</subfield>
+  </datafield>
+  <datafield tag="962" ind1=" " ind2=" ">
+    <subfield code="e">ZDB-35-Wiley-EBA</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">m|||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="i">
+    <subfield code="I">marc-FMT via MAB2MARC</subfield>
+    <subfield code="F">FMT</subfield>
+    <subfield code="A">BK</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">|||u|||||||17</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">||||||||g|||||</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(hbzERes_EBA-Wiley)10.1002/9781444327540</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT021352855</subfield>
+  </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="a">10.1002/9781444327540</subfield>
+    <subfield code="2">doi</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2=" ">
+    <subfield code="z">9781444335804</subfield>
+  </datafield>
+  <datafield tag="600" ind1="1" ind2="4">
+    <subfield code="a">Political Science</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99371314897806441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_FUH</subfield>
+    <subfield code="i">990016111720106464</subfield>
+    <subfield code="n">Fernuniversität Hagen</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_HSN</subfield>
+    <subfield code="i">9963707007916</subfield>
+    <subfield code="n">Hochschulbibliothek der Hochschule Niederrhein in Mönchengladbach/Krefeld</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_THK</subfield>
+    <subfield code="i">9975224207504</subfield>
+    <subfield code="n">Hochschulbibliothek der Technischen Hochschule Köln</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_KHO</subfield>
+    <subfield code="i">9950807407920</subfield>
+    <subfield code="n">Katholische Hochschule Nordrhein-Westfalen, Bibliothekszentrale und Abteilungsbibliotheken</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_UBO</subfield>
+    <subfield code="i">99323398007503</subfield>
+    <subfield code="n">Ruhr-Universität Bochum</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_ULB</subfield>
+    <subfield code="i">99390263207502</subfield>
+    <subfield code="n">Universitäts- und Landesbibliothek Bonn</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_UBK</subfield>
+    <subfield code="i">99437289707147</subfield>
+    <subfield code="n">Universitäts- und Stadtbibliothek Köln</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_ZBS</subfield>
+    <subfield code="i">9970050607146</subfield>
+    <subfield code="n">Zentralbibliothek der Sportwissenschaften, Köln</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">HBZ</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="h">20220715184200.0</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2022-08-02 09:29:25 Europe/Berlin</subfield>
+    <subfield code="g">HT021352855</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="b">2022-04-29 14:38:12 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">ebooks.NRW</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53769526120006441</subfield>
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="p">61767497870006441</subfield>
+    <subfield code="q">Wiley eBooks EBA bis 31.12.2023 (ZDB-35-Wiley-EBA)</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="B">Produktsigel: ZDB-35-Wiley-EBA
+NZ Phase 1 - Wave 2: NZ-P2E
+E-Book-Verfahren: eba-wiley?</subfield>
+    <subfield code="A">49HBZ_HBI</subfield>
+    <subfield code="A">49HBZ_DUE</subfield>
+    <subfield code="A">49HBZ_FHA</subfield>
+    <subfield code="A">49HBZ_UDE</subfield>
+    <subfield code="A">49HBZ_WHS</subfield>
+    <subfield code="A">49HBZ_RUW</subfield>
+    <subfield code="A">49HBZ_FHM</subfield>
+    <subfield code="A">49HBZ_PAD</subfield>
+    <subfield code="A">49HBZ_SIE</subfield>
+    <subfield code="A">49HBZ_WUP</subfield>
+    <subfield code="A">49HBZ_ULM</subfield>
+    <subfield code="A">49HBZ_UBD</subfield>
+    <subfield code="A">49HBZ_BRS</subfield>
+    <subfield code="A">49HBZ_FDO</subfield>
+    <subfield code="A">49HBZ_HBO</subfield>
+    <subfield code="A">49HBZ_BIE</subfield>
+    <subfield code="A">49HBZ_HSD</subfield>
+    <subfield code="A">49HBZ_FSW</subfield>
+    <subfield code="A">49HBZ_UBA</subfield>
+    <subfield code="y">2022-04-29 19:35:15 Europe/Berlin</subfield>
+    <subfield code="w">2022-04-29 19:35:11 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53769526120006441&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2022-04-29 17:35:11</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62767497860006441</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=99371314897806441</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="e">https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540</subfield>
+    <subfield code="8">53769526120006441</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="x">System</subfield>
+    <subfield code="a">53133004370006464</subfield>
+    <subfield code="h">EZProxy</subfield>
+    <subfield code="M">49HBZ_FUH</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="l">Zugriff nur im Hochschulnetz der FernUniversität Hagen bzw. für autorisierte Benutzer</subfield>
+    <subfield code="y">2022-07-05 07:21:38 Europe/Berlin</subfield>
+    <subfield code="w">2022-07-05 07:21:34 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53133004370006464&amp;Force_direct=true</subfield>
+    <subfield code="v">P2E_JOB</subfield>
+    <subfield code="z">2022-07-05 05:21:34</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="g">F0001</subfield>
+    <subfield code="S">52133004380006464</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=990016111720106464</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="e">https://ub-proxy.fernuni-hagen.de/login?url=https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540</subfield>
+    <subfield code="8">53133004370006464</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">N5001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">2221466720007916</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-24 02:36:03</subfield>
+    <subfield code="8">2221466720007916</subfield>
+    <subfield code="b">2023-02-24 02:36:03</subfield>
+    <subfield code="M">49HBZ_BRIDGE_HSN</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">Z9039</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">2216648660007920</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-24 02:36:56</subfield>
+    <subfield code="8">2216648660007920</subfield>
+    <subfield code="b">2023-02-24 02:36:56</subfield>
+    <subfield code="M">49HBZ_BRIDGE_KHO</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">B0001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">22132983340007503</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-24 02:36:12</subfield>
+    <subfield code="8">22132983340007503</subfield>
+    <subfield code="b">2023-02-24 02:36:12</subfield>
+    <subfield code="M">49HBZ_BRIDGE_UBO</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">Q0001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">22165237240007502</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-24 02:36:32</subfield>
+    <subfield code="8">22165237240007502</subfield>
+    <subfield code="b">2023-02-24 02:36:32</subfield>
+    <subfield code="M">49HBZ_BRIDGE_ULB</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">K0001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">22185267420007147</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-24 02:35:52</subfield>
+    <subfield code="8">22185267420007147</subfield>
+    <subfield code="b">2023-02-24 02:35:52</subfield>
+    <subfield code="M">49HBZ_BRIDGE_UBK</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">KP001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">2225159930007146</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-24 02:36:45</subfield>
+    <subfield code="8">2225159930007146</subfield>
+    <subfield code="b">2023-02-24 02:36:45</subfield>
+    <subfield code="M">49HBZ_BRIDGE_ZBS</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -65,7 +65,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.startDate:1993", /*->*/ 2 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "publication.location:Berlin AND publication.startDate:[1992 TO 2017]", /*->*/ 6 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 112 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 113 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },

--- a/web/test/tests/NestedQueryTests.java
+++ b/web/test/tests/NestedQueryTests.java
@@ -31,9 +31,11 @@ public class NestedQueryTests extends LocalIndexSetup {
 		return Arrays.asList(new Object[][] {
 			// Nested query: only return hits where query matches 1 nested pseudo-doc:
 			{ "contribution:contribution.agent.label:becker AND contribution.role.label:Beitragende", "", /*->*/ 1 },
+			{ "hasItem:hasItem.heldBy.isil:DE-38 AND hasItem.currentLocation:\"K0001 / UNASSIGNED\"", "", /*->*/ 1 },
 			// Nested query: don't match if query parts match different nested docs:
 			{ "contribution:contribution.agent.label:becker AND contribution.role.label:Herausgeber", "", /*->*/ 1 },
-            { "contribution:contribution.agent.label:becker AND contribution.role.label:Autor", "", /*->*/ 0 },
+			{ "contribution:contribution.agent.label:becker AND contribution.role.label:Autor", "", /*->*/ 0 },
+			{ "hasItem:hasItem.heldBy.isil:DE-38 AND hasItem.currentLocation:\"N5001 / UNASSIGNED\"", "", /*->*/ 0 },
 			// Normal query: return hits where query matches parent top-level doc:
 			{ "", "contribution.agent.label:becker AND contribution.role.label:Herausgeber", /*->*/ 1 },
 			// Same for 'spatial' nested field:
@@ -41,10 +43,8 @@ public class NestedQueryTests extends LocalIndexSetup {
 			{ "spatial:spatial.label:Dinslaken AND spatial.source.id:\"https://nwbib.de/subjects\",", "", /*->*/ 0 },
 			{ "", "subject.label:Westfalen AND subject.source.label:Sachsystematik", /*->*/ 1 },
 			// Same for 'subject.componentList' nested field:
-			{ "subject.componentList:subject.componentList.label:Ruhrgebiet AND subject.componentList.type:PlaceOrGeographicName",
-				"", /*->*/ 1 },
-			{ "subject.componentList:subject.componentList.label:Ruhrgebiet AND subject.componentList.type:SubjectHeading",
-				"", /*->*/ 0 },
+			{ "subject.componentList:subject.componentList.label:Ruhrgebiet AND subject.componentList.type:PlaceOrGeographicName", "", /*->*/ 1 },
+			{ "subject.componentList:subject.componentList.label:Ruhrgebiet AND subject.componentList.type:SubjectHeading", "", /*->*/ 0 },
 			{ "", "subject.componentList.label:Ruhrgebiet AND subject.componentList.type:SubjectHeading", /*->*/ 1 }
 		});
 	} // @formatter:on
@@ -54,28 +54,30 @@ public class NestedQueryTests extends LocalIndexSetup {
 	private Search index;
 
 	public NestedQueryTests(String nestedString, String queryString,
-			int resultCount) {
+		int resultCount) {
 		this.nestedString = nestedString;
 		this.expectedResultCount = resultCount;
 		this.index = new Search.Builder()
-				.query(
-						new Queries.Builder().q(queryString).nested(nestedString).build())
-				.size(1).build();
+			.query(
+				new Queries.Builder().q(queryString).nested(nestedString).build())
+			.size(1).build();
 	}
 
 	@Test
 	public void testResultCount() {
 		running(fakeApplication(), () -> {
-			if (expectedResultCount == 1)
+			if (expectedResultCount == 1) {
 				assertThat(hitsForQuery()).isGreaterThanOrEqualTo(expectedResultCount);
-			else
+			}
+			else {
 				assertThat(hitsForQuery()).isEqualTo(expectedResultCount);
+			}
 		});
 	}
 
 	private long hitsForQuery() {
 		return nestedString.isEmpty() ? index.totalHits()
-				: index.queryResources().getTotal();
+			: index.queryResources().getTotal();
 	}
 
 }


### PR DESCRIPTION
(As per a discussion about querying inventories for sublibraries)
Especially relevant after the Alma data migration, where the mapping of sublibrary codes has been broken out of control of Lobid.

This will allow custom queries like `?nested=hasItem:hasItem.currentLocation:"K1144+%2F+00009001"`

Bonus: Change `include_in_parent` property to boolean type. Was inconsistent between string and bool but the [ElasticSearch documentation specifies boolean](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html#nested-params)