### PR TITLE
Fix `describedBy.resultOf` URLs to point to `/marcxml/` instead of `hbz01`

### DIFF
--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -29,7 +29,7 @@ set_array("describedBy.resultOf.instrument.type[]", "SoftwareApplication")
 add_field("describedBy.resultOf.instrument.label","Software lobid-resources")
 
 copy_field("almaMmsId","describedBy.resultOf.object.id")
-prepend("describedBy.resultOf.object.id","https://lobid.org/hbz01/")
+prepend("describedBy.resultOf.object.id","https://lobid.org/marcxml/")
 
 # MNG is a ALMA-specific element
 

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990001412590206441",
+        "id" : "https://lobid.org/marcxml/990001412590206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990011470300206441",
+        "id" : "https://lobid.org/marcxml/990011470300206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990014830510206441",
+        "id" : "https://lobid.org/marcxml/990014830510206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990015048200206447.json
+++ b/src/test/resources/alma-fix/990015048200206447.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990015048200206447",
+        "id" : "https://lobid.org/marcxml/990015048200206447",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-24",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990015940770206447.json
+++ b/src/test/resources/alma-fix/990015940770206447.json
@@ -33,7 +33,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990015940770206447",
+        "id" : "https://lobid.org/marcxml/990015940770206447",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-15",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990016782920206441",
+        "id" : "https://lobid.org/marcxml/990016782920206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990021367710206441",
+        "id" : "https://lobid.org/marcxml/990021367710206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990021974470206441",
+        "id" : "https://lobid.org/marcxml/990021974470206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990030574430206441",
+        "id" : "https://lobid.org/marcxml/990030574430206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-06-06",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990033263300206441",
+        "id" : "https://lobid.org/marcxml/990033263300206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -36,7 +36,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990035016180206441",
+        "id" : "https://lobid.org/marcxml/990035016180206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-10-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990041403870206441",
+        "id" : "https://lobid.org/marcxml/990041403870206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990050000600206441",
+        "id" : "https://lobid.org/marcxml/990050000600206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990051552280206441",
+        "id" : "https://lobid.org/marcxml/990051552280206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-02-15",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990051708340206441",
+        "id" : "https://lobid.org/marcxml/990051708340206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990052965140206441",
+        "id" : "https://lobid.org/marcxml/990052965140206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-11-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -46,7 +46,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990053976760206441",
+        "id" : "https://lobid.org/marcxml/990053976760206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -34,7 +34,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990054215550206441",
+        "id" : "https://lobid.org/marcxml/990054215550206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2023-01-01",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -34,7 +34,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990054301770206441",
+        "id" : "https://lobid.org/marcxml/990054301770206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990058434730206441",
+        "id" : "https://lobid.org/marcxml/990058434730206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-09-13",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990059571560206441",
+        "id" : "https://lobid.org/marcxml/990059571560206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990063549080206441",
+        "id" : "https://lobid.org/marcxml/990063549080206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990065341720206441",
+        "id" : "https://lobid.org/marcxml/990065341720206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990075429930206441",
+        "id" : "https://lobid.org/marcxml/990075429930206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-03-14",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990075538650206441",
+        "id" : "https://lobid.org/marcxml/990075538650206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2023-02-10",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -34,7 +34,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990103770440206441",
+        "id" : "https://lobid.org/marcxml/990103770440206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-24",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -32,7 +32,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990103899140206441",
+        "id" : "https://lobid.org/marcxml/990103899140206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-09-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -35,7 +35,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990104908070206441",
+        "id" : "https://lobid.org/marcxml/990104908070206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-09-07",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -46,7 +46,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990108740950206441",
+        "id" : "https://lobid.org/marcxml/990108740950206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -32,7 +32,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990108873860206441",
+        "id" : "https://lobid.org/marcxml/990108873860206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-15",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -32,7 +32,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990108874370206441",
+        "id" : "https://lobid.org/marcxml/990108874370206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990110509950206441",
+        "id" : "https://lobid.org/marcxml/990110509950206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -25,7 +25,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990110714900206441",
+        "id" : "https://lobid.org/marcxml/990110714900206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -25,7 +25,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990110881770206441",
+        "id" : "https://lobid.org/marcxml/990110881770206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990112067120206441",
+        "id" : "https://lobid.org/marcxml/990112067120206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990113537330206441",
+        "id" : "https://lobid.org/marcxml/990113537330206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990114098170206441",
+        "id" : "https://lobid.org/marcxml/990114098170206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990114617880206441",
+        "id" : "https://lobid.org/marcxml/990114617880206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-15",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -34,7 +34,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990118562160206441",
+        "id" : "https://lobid.org/marcxml/990118562160206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990122511970206441",
+        "id" : "https://lobid.org/marcxml/990122511970206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-06-10",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990123613330206441",
+        "id" : "https://lobid.org/marcxml/990123613330206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990124590390206441",
+        "id" : "https://lobid.org/marcxml/990124590390206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-09-26",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990126276700206441",
+        "id" : "https://lobid.org/marcxml/990126276700206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990133067580206441",
+        "id" : "https://lobid.org/marcxml/990133067580206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-27",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -38,7 +38,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990136041660206441",
+        "id" : "https://lobid.org/marcxml/990136041660206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-22",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990139686910206441",
+        "id" : "https://lobid.org/marcxml/990139686910206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-06-03",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990141342350206441",
+        "id" : "https://lobid.org/marcxml/990141342350206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-09-14",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990143325070206441",
+        "id" : "https://lobid.org/marcxml/990143325070206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-11-26",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990150856900206441",
+        "id" : "https://lobid.org/marcxml/990150856900206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-07-23",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -25,7 +25,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990156027740206441",
+        "id" : "https://lobid.org/marcxml/990156027740206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-10-29",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990167595410206441",
+        "id" : "https://lobid.org/marcxml/990167595410206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-09-14",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990171142550206441",
+        "id" : "https://lobid.org/marcxml/990171142550206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990172512030206441.json
+++ b/src/test/resources/alma-fix/990172512030206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990172512030206441",
+        "id" : "https://lobid.org/marcxml/990172512030206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-16",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990173811970206441",
+        "id" : "https://lobid.org/marcxml/990173811970206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990181275760206441",
+        "id" : "https://lobid.org/marcxml/990181275760206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-07-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -37,7 +37,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990183054020206441",
+        "id" : "https://lobid.org/marcxml/990183054020206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-10-31",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990183092590206441",
+        "id" : "https://lobid.org/marcxml/990183092590206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-11-11",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -33,7 +33,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990184127410206441",
+        "id" : "https://lobid.org/marcxml/990184127410206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-27",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990185607520206441",
+        "id" : "https://lobid.org/marcxml/990185607520206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-17",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990185619180206441",
+        "id" : "https://lobid.org/marcxml/990185619180206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-02-23",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990189160110206441",
+        "id" : "https://lobid.org/marcxml/990189160110206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -25,7 +25,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990190567380206441",
+        "id" : "https://lobid.org/marcxml/990190567380206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-08-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990193094010206441",
+        "id" : "https://lobid.org/marcxml/990193094010206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -46,7 +46,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990193229450206441",
+        "id" : "https://lobid.org/marcxml/990193229450206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-27",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990193806600206441",
+        "id" : "https://lobid.org/marcxml/990193806600206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2023-01-01",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990194668760206441",
+        "id" : "https://lobid.org/marcxml/990194668760206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990194744870206441",
+        "id" : "https://lobid.org/marcxml/990194744870206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -41,7 +41,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990196925330206441",
+        "id" : "https://lobid.org/marcxml/990196925330206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-08-02",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -37,7 +37,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990197023370206441",
+        "id" : "https://lobid.org/marcxml/990197023370206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -35,7 +35,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990197067610206441",
+        "id" : "https://lobid.org/marcxml/990197067610206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -32,7 +32,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990197293880206441",
+        "id" : "https://lobid.org/marcxml/990197293880206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990198383780206441",
+        "id" : "https://lobid.org/marcxml/990198383780206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990199611280206441",
+        "id" : "https://lobid.org/marcxml/990199611280206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-08",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990204246530206441",
+        "id" : "https://lobid.org/marcxml/990204246530206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990206060640206441",
+        "id" : "https://lobid.org/marcxml/990206060640206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990207668220206441",
+        "id" : "https://lobid.org/marcxml/990207668220206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990207856340206441",
+        "id" : "https://lobid.org/marcxml/990207856340206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990209515320206441",
+        "id" : "https://lobid.org/marcxml/990209515320206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-11-14",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990209817770206441",
+        "id" : "https://lobid.org/marcxml/990209817770206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210093550206441",
+        "id" : "https://lobid.org/marcxml/990210093550206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-11-18",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210237770206441",
+        "id" : "https://lobid.org/marcxml/990210237770206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-16",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210285400206441",
+        "id" : "https://lobid.org/marcxml/990210285400206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-08-21",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210312460206441",
+        "id" : "https://lobid.org/marcxml/990210312460206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-22",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210667610206441",
+        "id" : "https://lobid.org/marcxml/990210667610206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210781980206441",
+        "id" : "https://lobid.org/marcxml/990210781980206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-02-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -31,7 +31,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990210950050206441",
+        "id" : "https://lobid.org/marcxml/990210950050206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990213367870206441",
+        "id" : "https://lobid.org/marcxml/990213367870206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-06-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -35,7 +35,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990213906490206441",
+        "id" : "https://lobid.org/marcxml/990213906490206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-12-01",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990217478660206441",
+        "id" : "https://lobid.org/marcxml/990217478660206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990217495840206441",
+        "id" : "https://lobid.org/marcxml/990217495840206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-08-13",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990219911120206441",
+        "id" : "https://lobid.org/marcxml/990219911120206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-18",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990220027540206441.json
+++ b/src/test/resources/alma-fix/990220027540206441.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990220027540206441",
+        "id" : "https://lobid.org/marcxml/990220027540206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-29",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990223521400206441",
+        "id" : "https://lobid.org/marcxml/990223521400206441",
         "dateCreated" : "2021-04-06",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990225056670206441",
+        "id" : "https://lobid.org/marcxml/990225056670206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-07-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990226465800206441",
+        "id" : "https://lobid.org/marcxml/990226465800206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-09-14",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990226763120206441",
+        "id" : "https://lobid.org/marcxml/990226763120206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990363946050206441",
+        "id" : "https://lobid.org/marcxml/990363946050206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-05",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990365842280206441",
+        "id" : "https://lobid.org/marcxml/990365842280206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-08-02",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990366394400206441",
+        "id" : "https://lobid.org/marcxml/990366394400206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990367731740206441",
+        "id" : "https://lobid.org/marcxml/990367731740206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2022-12-04",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -27,7 +27,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/990368743120206441",
+        "id" : "https://lobid.org/marcxml/990368743120206441",
         "dateCreated" : "2021-04-05",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/991000688209706449.json
+++ b/src/test/resources/alma-fix/991000688209706449.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/991000688209706449",
+        "id" : "https://lobid.org/marcxml/991000688209706449",
         "dateCreated" : "2022-07-11",
         "dateModified" : "2022-11-21",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/991002103529706485.json
+++ b/src/test/resources/alma-fix/991002103529706485.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/991002103529706485",
+        "id" : "https://lobid.org/marcxml/991002103529706485",
         "dateCreated" : "2022-07-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991002103529706485 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -35,7 +35,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/991005935279706485",
+        "id" : "https://lobid.org/marcxml/991005935279706485",
         "dateCreated" : "2022-07-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991005935279706485 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -35,7 +35,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370682219806441",
+        "id" : "https://lobid.org/marcxml/99370682219806441",
         "dateCreated" : "2021-04-19",
         "dateModified" : "2022-12-16",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370699582506441",
+        "id" : "https://lobid.org/marcxml/99370699582506441",
         "dateCreated" : "2021-04-19",
         "dateModified" : "2021-04-19",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370738710506441.json
+++ b/src/test/resources/alma-fix/99370738710506441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370738710506441",
+        "id" : "https://lobid.org/marcxml/99370738710506441",
         "dateCreated" : "2021-04-29",
         "dateModified" : "2022-12-11",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370746459806441",
+        "id" : "https://lobid.org/marcxml/99370746459806441",
         "dateCreated" : "2021-04-29",
         "dateModified" : "2021-04-29",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -28,7 +28,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370763433806441",
+        "id" : "https://lobid.org/marcxml/99370763433806441",
         "dateCreated" : "2021-05-04",
         "dateModified" : "2022-03-29",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -30,7 +30,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370763882706441",
+        "id" : "https://lobid.org/marcxml/99370763882706441",
         "dateCreated" : "2021-05-04",
         "dateModified" : "2022-08-20",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370771475306441.json
+++ b/src/test/resources/alma-fix/99370771475306441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370771475306441",
+        "id" : "https://lobid.org/marcxml/99370771475306441",
         "dateCreated" : "2021-05-07",
         "dateModified" : "2023-01-02",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99370782520706441",
+        "id" : "https://lobid.org/marcxml/99370782520706441",
         "dateCreated" : "2021-05-28",
         "dateModified" : "2023-01-02",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -39,7 +39,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99371107766906441",
+        "id" : "https://lobid.org/marcxml/99371107766906441",
         "dateCreated" : "2021-12-20",
         "dateModified" : "2022-04-15",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -32,7 +32,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99371123630706441",
+        "id" : "https://lobid.org/marcxml/99371123630706441",
         "dateCreated" : "2022-01-11",
         "dateModified" : "2023-02-23",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99371314897806441",
+        "id" : "https://lobid.org/marcxml/99371314897806441",
         "dateCreated" : "2022-04-29",
         "dateModified" : "2022-08-02",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -29,7 +29,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99371447897606441",
+        "id" : "https://lobid.org/marcxml/99371447897606441",
         "dateCreated" : "2022-07-18",
         "dateModified" : "2022-12-17",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -26,7 +26,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99371449208306441",
+        "id" : "https://lobid.org/marcxml/99371449208306441",
         "dateCreated" : "2022-07-18",
         "dateModified" : "2022-07-18",
         "type" : [ "DataFeedItem" ],

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -35,7 +35,7 @@
         "label" : "Software lobid-resources"
       },
       "object" : {
-        "id" : "https://lobid.org/hbz01/99371981001306441",
+        "id" : "https://lobid.org/marcxml/99371981001306441",
         "dateCreated" : "2023-03-22",
         "dateModified" : "2023-04-01",
         "type" : [ "DataFeedItem" ],


### PR DESCRIPTION
As of writing this issue, the live data for Alma still points to `lobid.org/hbz01/${almaMmsId}` which throws an error.
Example at https://lobid.org/resources/99371014448006441?format=json:
```json
"id": "https://lobid.org/hbz01/99371014448006441",
"type": [
  "DataFeedItem"
],
"label": "hbz-Ressource 99371014448006441 im Exportformat MARC21 XML",
```

I updated all test resources accordingly. The script at https://github.com/hbz/lobid-resources/blob/master/src/test/resources/alma-fix/alephFilesFromIdsOfAlmaTestFiles/grepAlmaTestIdsAndLookupAlephJsonAndXml.sh#L10 likely also needs to be updated to point to `aleph.lobid.org` but I was unsure how to proceed there because (a) I don't know when this script is being used and (b) CURL likes throwing a tantrum when the SSL certificates are not properly configured (and you claimed that you won't maintain SSL for aleph.lobid.org)