### PR TITLE
1757-fullTextOnline

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -86,8 +86,10 @@ end
 # 1. Indicator: 4 = HTTP
 do list(path:"8564?", "var":"$i")
   if any_contain("$i.u","doi")
-    copy_field("$i.u", "doi[].$append")
-    replace_all("doi[].$last", "^.*doi.org/(.*)$", "$1")
+    if all_match("$i.u", ".*(10\\.(\\d)+/(\\S)+).*") # Volltext
+      copy_field("$i.u", "doi[].$append")
+      replace_all("doi[].$last", ".*(10\\.(\\d)+/(\\S)+).*", "$1")
+    end
   end
 end
 uniq("doi[]")

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -85,11 +85,9 @@ end
 # 856 - Electronic Location and Access (R) - Subfield: $u (R) $3 (NR)
 # 1. Indicator: 4 = HTTP
 do list(path:"8564?", "var":"$i")
-  if any_contain("$i.u","doi")
-    if all_match("$i.u", ".*(10\\.(\\d)+/(\\S)+).*") # Volltext
-      copy_field("$i.u", "doi[].$append")
-      replace_all("doi[].$last", ".*(10\\.(\\d)+/(\\S)+).*", "$1")
-    end
+  if all_match("$i.u", ".*(10\\.(\\d)+/(\\S)+).*") # Volltext
+    copy_field("$i.u", "doi[].$append")
+    replace_all("doi[].$last", ".*(10\\.(\\d)+/(\\S)+).*", "$1")
   end
 end
 uniq("doi[]")

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -14,7 +14,19 @@ do list(path: "0247?", "var": "$i")
   end
 end
 
+# Sometimes urn are not set in 024 then we could pick up the missing from 856.
+# 856 - Electronic Location and Access (R) - Subfield: $u (R) $3 (NR)
+# 1. Indicator: 4 = HTTP
+do list(path:"8564?", "var":"$i")
+  if all_match("$i.u", "^http:\\/\\/nbn-resolving.de\\/(.*)")
+    copy_field("$i.u", "urn[].$append")
+    replace_all("urn[].$last", "^http:\\/\\/nbn-resolving.de\\/(.*)", "$1")
+  end
+end
+
 replace_all("urn[].*","^(nbn:de:.*\\d)$","urn:$1")
+
+uniq("urn[]")
 
 # 035 - System Control Number (R) - Subfield: $a (NR)
 

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -244,19 +244,21 @@ set_array("fulltextOnline[]")
 
 do list(path: "8564?", "var":"$i")
   unless exists("$i.M")
-    if all_equal("$i.z", "kostenfrei") # kostenfrei, added Digitalisierung not only Verlag or Agentur as filter
-      if all_match("$i.x", "Verlag|Agentur|Digitalisierung")
+    unless any_match("$i.u",".*(doi.org|nbn-resolving).*")
+      if all_equal("$i.z", "kostenfrei") # kostenfrei, added Digitalisierung not only Verlag or Agentur as filter
+        if all_match("$i.x", "Verlag|Agentur|Digitalisierung")
+          copy_field("$i.x", "fulltextOnline[].$append.label")
+          copy_field("$i.u", "fulltextOnline[].$last.id")
+        end
+      end
+      if all_match("$i.x", ".*(Archivierte Online|EZB|Online-Ausg|Resolving-System|Volltext).*")
         copy_field("$i.x", "fulltextOnline[].$append.label")
         copy_field("$i.u", "fulltextOnline[].$last.id")
       end
-    end
-    if all_match("$i.x", ".*(Archivierte Online|EZB|Online-Ausg|Resolving-System|Volltext).*")
-      copy_field("$i.x", "fulltextOnline[].$append.label")
-      copy_field("$i.u", "fulltextOnline[].$last.id")
-    end
-    if all_match("$i.3", "^[vV][oO][lL].*") # Volltext
-      copy_field("$i.3", "fulltextOnline[].$append.label")
-      copy_field("$i.u", "fulltextOnline[].$last.id")
+      if all_match("$i.3", "^[vV][oO][lL].*") # Volltext
+        copy_field("$i.3", "fulltextOnline[].$append.label")
+        copy_field("$i.u", "fulltextOnline[].$last.id")
+      end
     end
   end
 end

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -258,16 +258,22 @@ do list(path: "8564?", "var":"$i")
       copy_field("$i.3", "fulltextOnline[].$append.label")
       copy_field("$i.u", "fulltextOnline[].$last.id")
     end
-    if all_match("$i.u", "^http:\\/\\/dx.doi.org\\/.*") # Volltext
-      copy_field("$i.u", "fulltextOnline[].$append.id")
-      add_field("fulltextOnline[].$last.label", "DOI-Link")
-    end
     if all_match("$i.u", "^http:\\/\\/nbn-resolving.de\\/urn.*") # Volltext
       copy_field("$i.u", "fulltextOnline[].$append.id")
       add_field("fulltextOnline[].$last.label", "URN-Link")
     end
   end
 end
+
+# doi for fullTextOnline and sameAs
+
+do list(path:"doi[]","var":"$i")
+  copy_field("$i", "fulltextOnline[].$append.id")
+  prepend("fulltextOnline[].$last.id","https://doi.org/")
+  copy_field("fulltextOnline[].$last.id", "sameAs[].$append.id")
+  add_field("fulltextOnline[].$last.label", "DOI-Link")
+end
+
 
 
 # TODO: hasVersion is outcommented since it needs some remodelling
@@ -491,11 +497,6 @@ end
 
 set_array("inCollection[].*.type[]","Collection")
 
-
-do list(path:"doi[]", "var":"$i")
-  copy_field("$i", "sameAs[].$append.id")
-  replace_all("sameAs[].$last.id", "^(.*)$","http://dx.doi.org/$1")
-end
 
 do list(path:"urn[]", "var":"$i")
   copy_field("$i", "sameAs[].$append.id")

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -258,10 +258,6 @@ do list(path: "8564?", "var":"$i")
       copy_field("$i.3", "fulltextOnline[].$append.label")
       copy_field("$i.u", "fulltextOnline[].$last.id")
     end
-    if all_match("$i.u", "^http:\\/\\/nbn-resolving.de\\/urn.*") # Volltext
-      copy_field("$i.u", "fulltextOnline[].$append.id")
-      add_field("fulltextOnline[].$last.label", "URN-Link")
-    end
   end
 end
 
@@ -274,7 +270,14 @@ do list(path:"doi[]","var":"$i")
   add_field("fulltextOnline[].$last.label", "DOI-Link")
 end
 
+# urn for fullTextOnline and sameAs
 
+do list(path:"urn[]","var":"$i")
+  copy_field("$i", "fulltextOnline[].$append.id")
+  prepend("fulltextOnline[].$last.id","https://nbn-resolving.de/")
+  copy_field("fulltextOnline[].$last.id", "sameAs[].$append.id")
+  add_field("fulltextOnline[].$last.label", "URN-Link")
+end
 
 # TODO: hasVersion is outcommented since it needs some remodelling
 # See https://github.com/hbz/lobid-resources/issues/1242
@@ -496,12 +499,6 @@ end
 
 
 set_array("inCollection[].*.type[]","Collection")
-
-
-do list(path:"urn[]", "var":"$i")
-  copy_field("$i", "sameAs[].$append.id")
-  replace_all("sameAs[].$last.id", "^(.*)$","http://nbn-resolving.de/$1")
-end
 
 
 # predecessor

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -250,6 +250,10 @@ do list(path: "8564?", "var":"$i")
         copy_field("$i.u", "fulltextOnline[].$last.id")
       end
     end
+    if all_match("$i.x", ".*(Archivierte Online|EZB|Online-Ausg|Resolving-System|Volltext).*")
+      copy_field("$i.x", "fulltextOnline[].$append.label")
+      copy_field("$i.u", "fulltextOnline[].$last.id")
+    end
     if all_match("$i.3", "^[vV][oO][lL].*") # Volltext
       copy_field("$i.3", "fulltextOnline[].$append.label")
       copy_field("$i.u", "fulltextOnline[].$last.id")

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -65,6 +65,10 @@
     "id" : "http://ld.zdb-services.de/resource/1500025-4",
     "label" : "ZDB-Ressource"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "EZB",
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?1500025"
+  } ],
   "related" : [ {
     "id" : "http://lobid.org/resources/ZDB-1027374-8#!",
     "note" : [ "Druckausg." ],

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -65,6 +65,10 @@
     "id" : "http://ld.zdb-services.de/resource/1500079-5",
     "label" : "ZDB-Ressource"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "EZB",
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?1500079"
+  } ],
   "related" : [ {
     "id" : "http://lobid.org/resources/ZDB-402212-9#!",
     "note" : [ "Druckausg." ],

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -73,9 +73,6 @@
     "label" : "NWBib-Ressource"
   } ],
   "fulltextOnline" : [ {
-    "label" : "Resolving-System",
-    "id" : "https://nbn-resolving.org/urn:nbn:de:hbz:061:3-3091"
-  }, {
     "label" : "Verlag",
     "id" : "http://www.duesseldorf.de/wohnen/veroeffentlichung/index.shtml"
   }, {

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -66,11 +66,11 @@
     "id" : "http://ld.zdb-services.de/resource/2594002-8",
     "label" : "ZDB-Ressource"
   }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:061:3-3091",
+    "label" : "urn:nbn:de:hbz:061:3-3091"
+  }, {
     "id" : "http://nwbib.de/990184127410206441#!",
     "label" : "NWBib-Ressource"
-  }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:3-3091",
-    "label" : "urn:nbn:de:hbz:061:3-3091"
   } ],
   "fulltextOnline" : [ {
     "label" : "Resolving-System",
@@ -78,6 +78,9 @@
   }, {
     "label" : "Verlag",
     "id" : "http://www.duesseldorf.de/wohnen/veroeffentlichung/index.shtml"
+  }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:061:3-3091",
+    "label" : "URN-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -73,6 +73,9 @@
     "label" : "urn:nbn:de:hbz:061:3-3091"
   } ],
   "fulltextOnline" : [ {
+    "label" : "Resolving-System",
+    "id" : "https://nbn-resolving.org/urn:nbn:de:hbz:061:3-3091"
+  }, {
     "label" : "Verlag",
     "id" : "http://www.duesseldorf.de/wohnen/veroeffentlichung/index.shtml"
   } ],

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -90,6 +90,9 @@
     "note" : [ "Elektronische Reproduktion von" ]
   } ],
   "fulltextOnline" : [ {
+    "label" : "Resolving-System",
+    "id" : "https://nbn-resolving.org/urn:nbn:de:hbz:6-85659520092"
+  }, {
     "label" : "Digitalisierung",
     "id" : "http://sammlungen.ulb.uni-muenster.de/urn/urn:nbn:de:hbz:6-85659520092"
   } ],

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -78,11 +78,11 @@
     "id" : "http://ld.zdb-services.de/resource/2685248-2",
     "label" : "ZDB-Ressource"
   }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
+    "label" : "urn:nbn:de:hbz:6-85659520092"
+  }, {
     "id" : "http://nwbib.de/990193229450206441#!",
     "label" : "NWBib-Ressource"
-  }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
-    "label" : "urn:nbn:de:hbz:6-85659520092"
   } ],
   "primaryForm" : [ {
     "id" : "http://lobid.org/resources/ZDB-517706-6#!",
@@ -95,6 +95,9 @@
   }, {
     "label" : "Digitalisierung",
     "id" : "http://sammlungen.ulb.uni-muenster.de/urn/urn:nbn:de:hbz:6-85659520092"
+  }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:6-85659520092",
+    "label" : "URN-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -90,9 +90,6 @@
     "note" : [ "Elektronische Reproduktion von" ]
   } ],
   "fulltextOnline" : [ {
-    "label" : "Resolving-System",
-    "id" : "https://nbn-resolving.org/urn:nbn:de:hbz:6-85659520092"
-  }, {
     "label" : "Digitalisierung",
     "id" : "http://sammlungen.ulb.uni-muenster.de/urn/urn:nbn:de:hbz:6-85659520092"
   }, {

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -77,6 +77,9 @@
   "fulltextOnline" : [ {
     "label" : "Digitalisierung",
     "id" : "https://zefys.staatsbibliothek-berlin.de/list/title/zdb/27191503/"
+  }, {
+    "label" : "EZB",
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2719150"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -59,7 +59,7 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-CT003043468",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
     "label" : "urn:nbn:de:hbz:061:1-249692"
   } ],
   "primaryForm" : [ {
@@ -74,7 +74,7 @@
     "label" : "Volltext",
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -68,6 +68,9 @@
     "note" : [ "Elektronische Reproduktion von" ]
   } ],
   "fulltextOnline" : [ {
+    "label" : "Resolving-System",
+    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692"
+  }, {
     "label" : "Volltext",
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692"
   }, {

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -68,12 +68,6 @@
     "note" : [ "Elektronische Reproduktion von" ]
   } ],
   "fulltextOnline" : [ {
-    "label" : "Resolving-System",
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692"
-  }, {
-    "label" : "Volltext",
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692"
-  }, {
     "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:061:1-249692",
     "label" : "URN-Link"
   } ],

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -80,6 +80,9 @@
     } ]
   } ],
   "fulltextOnline" : [ {
+    "label" : "Resolving-System",
+    "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8"
+  }, {
     "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8",
     "label" : "DOI-Link"
   } ],

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -70,7 +70,7 @@
     "id" : "http://worldcat.org/oclc/857645183",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8",
+    "id" : "https://doi.org/10.1007/978-3-642-32079-8",
     "label" : "978-3-642-32079-8"
   } ],
   "isPartOf" : [ {
@@ -83,7 +83,7 @@
     "label" : "Resolving-System",
     "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8"
   }, {
-    "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8",
+    "id" : "https://doi.org/10.1007/978-3-642-32079-8",
     "label" : "DOI-Link"
   } ],
   "related" : [ {

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -80,9 +80,6 @@
     } ]
   } ],
   "fulltextOnline" : [ {
-    "label" : "Resolving-System",
-    "id" : "http://dx.doi.org/10.1007/978-3-642-32079-8"
-  }, {
     "id" : "https://doi.org/10.1007/978-3-642-32079-8",
     "label" : "DOI-Link"
   } ],

--- a/src/test/resources/alma-fix/990204253490206441.json
+++ b/src/test/resources/alma-fix/990204253490206441.json
@@ -63,12 +63,15 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018296675",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:1987",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:1987",
     "label" : "urn:nbn:de:hbz:929:02-edoweb:1987"
   } ],
   "fulltextOnline" : [ {
     "label" : "Archivierte Online-Ressource",
     "id" : "https://www.edoweb-rlp.de/resource/edoweb:198"
+  }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:1987",
+    "label" : "URN-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990204253490206441.json
+++ b/src/test/resources/alma-fix/990204253490206441.json
@@ -66,6 +66,10 @@
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:1987",
     "label" : "urn:nbn:de:hbz:929:02-edoweb:1987"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "Archivierte Online-Ressource",
+    "id" : "https://www.edoweb-rlp.de/resource/edoweb:198"
+  } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -61,18 +61,18 @@
     "id" : "http://worldcat.org/oclc/1075919546",
     "label" : "OCLC Ressource"
   }, {
+    "id" : "https://doi.org/10.7788/boehlau.9783412216689",
+    "label" : "boehlau.9783412216689"
+  }, {
     "id" : "http://nwbib.de/990206060640206441#!",
     "label" : "NWBib-Ressource"
-  }, {
-    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689",
-    "label" : "boehlau.9783412216689"
   } ],
   "description" : [ {
     "label" : "Inhaltstext",
     "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4535439&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "fulltextOnline" : [ {
-    "id" : "http://dx.doi.org/10.7788/boehlau.9783412216689",
+    "id" : "https://doi.org/10.7788/boehlau.9783412216689",
     "label" : "DOI-Link"
   } ],
   "related" : [ {

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -64,7 +64,7 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT018895767",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
     "label" : "urn:nbn:de:hbz:929:02-edoweb:70030352"
   } ],
   "isPartOf" : [ {
@@ -78,6 +78,9 @@
   "fulltextOnline" : [ {
     "label" : "Archivierte Online-Ressource",
     "id" : "https://www.edoweb-rlp.de/resource/edoweb:7003035"
+  }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:70030352",
+    "label" : "URN-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -75,6 +75,10 @@
     } ],
     "numbering" : "65"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "Archivierte Online-Ressource",
+    "id" : "https://www.edoweb-rlp.de/resource/edoweb:7003035"
+  } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -65,7 +65,7 @@
     "id" : "http://worldcat.org/oclc/1074423318",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006399748",
+    "id" : "https://doi.org/10.4126/FRL01-006399748",
     "label" : "FRL01-006399748"
   } ],
   "isPartOf" : [ {
@@ -75,6 +75,10 @@
       "label" : "lobid Ressource"
     } ],
     "numbering" : "1"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.4126/FRL01-006399748",
+    "label" : "DOI-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -67,6 +67,10 @@
     "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
     "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "Archivierte Online-Ressource",
+    "id" : "https://www.edoweb-rlp.de/resource/edoweb:88"
+  } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -64,12 +64,15 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT019248596",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
     "label" : "urn:nbn:de:hbz:929:02-edoweb:887"
   } ],
   "fulltextOnline" : [ {
     "label" : "Archivierte Online-Ressource",
     "id" : "https://www.edoweb-rlp.de/resource/edoweb:88"
+  }, {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:929:02-edoweb:887",
+    "label" : "URN-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -57,7 +57,7 @@
     "id" : "http://worldcat.org/oclc/1076035765",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.4126/FRL01-006410624",
+    "id" : "https://doi.org/10.4126/FRL01-006410624",
     "label" : "FRL01-006410624"
   } ],
   "isPartOf" : [ {
@@ -67,6 +67,10 @@
       "label" : "Texte / Umweltbundesamt"
     } ],
     "numbering" : "2018,55"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.4126/FRL01-006410624",
+    "label" : "DOI-Link"
   } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -65,7 +65,7 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT020202475",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.1628/978-3-16-154630-3",
+    "id" : "https://doi.org/10.1628/978-3-16-154630-3",
     "label" : "978-3-16-154630-3"
   } ],
   "fulltextOnline" : [ {
@@ -77,6 +77,9 @@
   }, {
     "label" : "Volltext",
     "id" : "https://www.mohrsiebeck.com/buch/kritische-theorie-9783161546303"
+  }, {
+    "id" : "https://doi.org/10.1628/978-3-16-154630-3",
+    "label" : "DOI-Link"
   } ],
   "related" : [ {
     "id" : "http://lobid.org/resources/HT019007872#!",

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -69,6 +69,9 @@
     "label" : "978-3-16-154630-3"
   } ],
   "fulltextOnline" : [ {
+    "label" : "Resolving-System",
+    "id" : "https://doi.org/10.1628/978-3-16-154630-3"
+  }, {
     "label" : "Volltext",
     "id" : "https://doi.org/10.1628/978-3-16-154630-3"
   }, {

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -69,12 +69,6 @@
     "label" : "978-3-16-154630-3"
   } ],
   "fulltextOnline" : [ {
-    "label" : "Resolving-System",
-    "id" : "https://doi.org/10.1628/978-3-16-154630-3"
-  }, {
-    "label" : "Volltext",
-    "id" : "https://doi.org/10.1628/978-3-16-154630-3"
-  }, {
     "label" : "Volltext",
     "id" : "https://www.mohrsiebeck.com/buch/kritische-theorie-9783161546303"
   }, {

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -71,9 +71,6 @@
     "numbering" : "no.67"
   } ],
   "fulltextOnline" : [ {
-    "label" : "Resolving-System",
-    "id" : "https://doi.org/10.1787/78acc736-fr"
-  }, {
     "id" : "https://doi.org/10.1787/78acc736-fr",
     "label" : "DOI-Link"
   } ],

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -70,6 +70,10 @@
     } ],
     "numbering" : "no.67"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "Resolving-System",
+    "id" : "https://doi.org/10.1787/78acc736-fr"
+  } ],
   "related" : [ {
     "note" : [ "Parallelausgabe" ],
     "label" : "Why does the Sustainable Development Goal on Education (SDG 4) matter for OECD countries?"

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -60,7 +60,7 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT020391499",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.1787/78acc736-fr",
+    "id" : "https://doi.org/10.1787/78acc736-fr",
     "label" : "78acc736-fr"
   } ],
   "isPartOf" : [ {
@@ -73,6 +73,9 @@
   "fulltextOnline" : [ {
     "label" : "Resolving-System",
     "id" : "https://doi.org/10.1787/78acc736-fr"
+  }, {
+    "id" : "https://doi.org/10.1787/78acc736-fr",
+    "label" : "DOI-Link"
   } ],
   "related" : [ {
     "note" : [ "Parallelausgabe" ],

--- a/src/test/resources/alma-fix/991002103529706485.json
+++ b/src/test/resources/alma-fix/991002103529706485.json
@@ -61,7 +61,7 @@
     "id" : "http://worldcat.org/oclc/1277506540",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.36198/9783838557823",
+    "id" : "https://doi.org/10.36198/9783838557823",
     "label" : "9783838557823"
   } ],
   "isPartOf" : [ {
@@ -70,6 +70,10 @@
       "label" : "UTB ;"
     } ],
     "numbering" : "2878 ;Soziale Arbeit"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.36198/9783838557823",
+    "label" : "DOI-Link"
   } ],
   "related" : [ {
     "note" : [ "Erscheint auch als: Druck-Ausgabe" ],

--- a/src/test/resources/alma-fix/991002103529706485.json
+++ b/src/test/resources/alma-fix/991002103529706485.json
@@ -2,7 +2,7 @@
   "@context" : "http://lobid.org/resources/context.jsonld",
   "almaMmsId" : "991002103529706485",
   "isbn" : [ "9783838557823", "3838557824" ],
-  "doi" : [ "https://ezproxy.fh-muenster.de/login?url=https://elibrary.utb.de/doi/book/10.36198/9783838557823" ],
+  "doi" : [ "10.36198/9783838557823" ],
   "oclcNumber" : [ "1277506540" ],
   "title" : "Grundkurs Kinder- und Jugendhilferecht für die Soziale Arbeit",
   "otherTitleInformation" : [ "mit 62 Übersichten, 3 Tabellen, 14 Fallbeispielen und Musterlösungen" ],
@@ -61,7 +61,7 @@
     "id" : "http://worldcat.org/oclc/1277506540",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://dx.doi.org/https://ezproxy.fh-muenster.de/login?url=https://elibrary.utb.de/doi/book/10.36198/9783838557823",
+    "id" : "http://dx.doi.org/10.36198/9783838557823",
     "label" : "9783838557823"
   } ],
   "isPartOf" : [ {

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -67,8 +67,12 @@
     "id" : "http://worldcat.org/oclc/864921933",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:bsz:14-qucosa2-386112",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:bsz:14-qucosa2-386112",
     "label" : "urn:nbn:de:bsz:14-qucosa2-386112"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:bsz:14-qucosa2-386112",
+    "label" : "URN-Link"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -65,8 +65,12 @@
     "id" : "http://worldcat.org/oclc/802544307",
     "label" : "OCLC Ressource"
   }, {
-    "id" : "http://nbn-resolving.de/urn:nbn:de:hbz:5:2-53272",
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:5:2-53272",
     "label" : "urn:nbn:de:hbz:5:2-53272"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://nbn-resolving.de/urn:nbn:de:hbz:5:2-53272",
+    "label" : "URN-Link"
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -4,7 +4,7 @@
   "hbzId" : "HT021352855",
   "deprecatedUri" : "http://lobid.org/resources/HT021352855#!",
   "isbn" : [ "9781444327540", "1444327542" ],
-  "doi" : [ "10.1002/9781444327540", "https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540" ],
+  "doi" : [ "10.1002/9781444327540" ],
   "title" : "Political Atlas of the Modern World",
   "edition" : [ "1" ],
   "publication" : [ {
@@ -62,9 +62,6 @@
     "label" : "Culturegraph Ressource"
   }, {
     "id" : "http://dx.doi.org/10.1002/9781444327540",
-    "label" : "9781444327540"
-  }, {
-    "id" : "http://dx.doi.org/https://onlinelibrary.wiley.com/doi/book/10.1002/9781444327540",
     "label" : "9781444327540"
   } ],
   "related" : [ {

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -61,8 +61,12 @@
     "id" : "http://hub.culturegraph.org/resource/HBZ-HT021352855",
     "label" : "Culturegraph Ressource"
   }, {
-    "id" : "http://dx.doi.org/10.1002/9781444327540",
+    "id" : "https://doi.org/10.1002/9781444327540",
     "label" : "9781444327540"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.1002/9781444327540",
+    "label" : "DOI-Link"
   } ],
   "related" : [ {
     "isbn" : [ "9781444335804", "1444335804" ]

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -65,6 +65,10 @@
     "id" : "http://ld.zdb-services.de/resource/3154709-6",
     "label" : "ZDB-Ressource"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "EZB",
+    "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?3154709"
+  } ],
   "inCollection" : [ {
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",


### PR DESCRIPTION
Added more related links to fullTextOnline.
Also redid some mapping for urn and doi
Deleted duplicate fullTextOnline-Links.

Urn for edoweb do no resolve.

Compare to old morph: https://github.com/TobiasNx/oldAlephLobid/blob/98bba7f8a93c2ccac7ffd2566149e46dec12a886/morph-hbz01-to-lobid.xml