### PR TITLE
1761-gndAndMacro

### DIFF
--- a/src/main/resources/alma/alma.fix
+++ b/src/main/resources/alma/alma.fix
@@ -1,8 +1,9 @@
 add_field("@context","http://lobid.org/resources/context.jsonld")
 
 # Add maps
-do once("maps")
+do once("mapsAndMacros")
   include ("./fix/maps.fix")
+  include ("./fix/macros.fix")
 end
 # Add vars
 do once("vars")

--- a/src/main/resources/alma/alma.fix
+++ b/src/main/resources/alma/alma.fix
@@ -1,17 +1,14 @@
-add_field("@context","http://lobid.org/resources/context.jsonld")
-
-# Add maps
-do once("mapsAndMacros")
+# Setup adds maps, macros and vars once
+do once("setup")
   include ("./fix/maps.fix")
   include ("./fix/macros.fix")
-end
-# Add vars
-do once("vars")
   put_var("member", "-")
 end
 
 # drop all local fields #1687
 de.hbz.lobid.helper.DropLocal()
+
+add_field("@context","http://lobid.org/resources/context.jsonld")
 
 include ("./fix/identifiers.fix")
 include ("./fix/titleRelatedFields.fix")

--- a/src/main/resources/alma/fix/contribution.fix
+++ b/src/main/resources/alma/fix/contribution.fix
@@ -55,13 +55,7 @@ do list(path:"100[01] ", "var":"$i")
           end
         end
         # name
-        set_array("$i.@combinedLabel")
-        copy_field("$i.a","$i.@combinedLabel.$append")
-        copy_field("$i.b","$i.@combinedLabel.$append")
-        join_field("$i.@combinedLabel", " ")
-        if exists("$i.c")
-          paste("$i.@combinedLabel", "$i.@combinedLabel", "~, ", "$i.c", join_char:"")
-        end
+        call_macro("gndPersonCombinedLabel",field:"$i") 
         copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
         # type
         set_array("contribution[].$last.agent.type[]","Person")
@@ -111,13 +105,7 @@ do list(path:"700[01] ", "var":"$i")
           end
         end
         # name
-        set_array("$i.@combinedLabel")
-        copy_field("$i.a","$i.@combinedLabel.$append")
-        copy_field("$i.b","$i.@combinedLabel.$append")
-        join_field("$i.@combinedLabel", " ")
-        if exists("$i.c")
-          paste("$i.@combinedLabel", "$i.@combinedLabel", "~, ", "$i.c", join_char:"")
-        end
+        call_macro("gndPersonCombinedLabel",field:"$i") 
         copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
         # type
         set_array("contribution[].$last.agent.type[]","Person")
@@ -177,19 +165,7 @@ do list(path:"110[012] ", "var":"$i")
           end
         end
         # name
-          set_array("$i.@combinedLabel")  # check if GND concept has combined variant
-          copy_field("$i.a","$i.@combinedLabel.$append")
-          copy_field("$i.b","$i.@combinedLabel.$append")
-          join_field("$i.@combinedLabel", ". ")
-          if exists("$i.c")
-            paste("$i.@combinedLabel", "$i.@combinedLabel", "~, ", "$i.c", join_char:"")
-          end
-          if exists("$i.g")
-            paste("$i.@combinedLabel", "$i.@combinedLabel", "~ (", "$i.g", "~)", join_char:"")
-          end
-          if exists("$i.x")
-            paste("$i.@combinedLabel", "$i.@combinedLabel", "~/","$i.x")
-          end
+          call_macro("gndNonPersonCombinedLabel",field:"$i")
           copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
         # type
         set_array("contribution[].$last.agent.type[]","CorporateBody")
@@ -238,19 +214,7 @@ do list(path:"710[012] ", "var":"$i")
           end
         end
         # name
-          set_array("$i.@combinedLabel")  # check if GND concept has combined variant
-          copy_field("$i.a","$i.@combinedLabel.$append")
-          copy_field("$i.b","$i.@combinedLabel.$append")
-          join_field("$i.@combinedLabel", ". ")
-          if exists("$i.c")
-            paste("$i.@combinedLabel", "$i.@combinedLabel", "~, ", "$i.c", join_char:"")
-          end
-          if exists("$i.g")
-            paste("$i.@combinedLabel", "$i.@combinedLabel", "~ (", "$i.g", "~)", join_char:"")
-          end
-          if exists("$i.x")
-            paste("$i.@combinedLabel", "$i.@combinedLabel", "~/","$i.x")
-          end
+          call_macro("gndNonPersonCombinedLabel",field:"$i")
           copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
         # type
         set_array("contribution[].$last.agent.type[]","CorporateBody")
@@ -379,38 +343,14 @@ do list (path: "contribution[]", "var": "$i")
   set_array("$i.agent.altLabel[]")
   do list(path:"GPN??", "var": "$z")
     if in ("$i.agent.@gndIdn", "$z.B") # Person labels have no character between $a (Name) and $b (Number).
-      set_array("$z.@combinedLabel")
-      copy_field("$z.a","$z.@combinedLabel.$append")
-      copy_field("$z.b","$z.@combinedLabel.$append")
-      join_field("$z.@combinedLabel", " ")
-      if exists("$z.c")
-        paste("$z.@combinedLabel", "$z.@combinedLabel", "~, ", "$z.c", join_char:"")
-      end
-      if exists("$z.g")
-        paste("$z.@combinedLabel", "$z.@combinedLabel", "~ (", "$z.g", "~)", join_char:"")
-      end
-      if exists("$z.x")
-        paste("$z.@combinedLabel", "$z.@combinedLabel", "~/","$z.x")
-      end
+      call_macro("gndPersonCombinedLabel",field:"$z") 
       copy_field("$z.@combinedLabel", "$i.agent.altLabel[].$append")
     end
   end
   do list(path:"GEL??|GKT??|GKS??|GST??|GGN??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
     unless any_equal("$z.i","Spitzenorgan")
       if in ("$i.agent.@gndIdn", "$z.B")
-        set_array("$z.@combinedLabel")  # check if GND concept has combined variant
-        copy_field("$z.a","$z.@combinedLabel.$append")
-        copy_field("$z.b","$z.@combinedLabel.$append")
-        join_field("$z.@combinedLabel", ". ")
-        if exists("$z.c")
-          paste("$z.@combinedLabel", "$z.@combinedLabel", "~, ", "$z.c", join_char:"")
-        end
-        if exists("$z.g")
-          paste("$z.@combinedLabel", "$z.@combinedLabel", "~ (", "$z.g", "~)", join_char:"")
-        end
-        if exists("$z.x")
-          paste("$z.@combinedLabel", "$z.@combinedLabel", "~/","$z.x")
-        end
+        call_macro("gndNonPersonCombinedLabel",field:"$z")
         copy_field("$z.@combinedLabel", "$i.agent.altLabel[].$append")
       end
     end

--- a/src/main/resources/alma/fix/contribution.fix
+++ b/src/main/resources/alma/fix/contribution.fix
@@ -165,7 +165,7 @@ do list(path:"110[012] ", "var":"$i")
           end
         end
         # name
-          call_macro("gndNonPersonCombinedLabel",field:"$i")
+          call_macro("gndOtherCombinedLabel",field:"$i")
           copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
         # type
         set_array("contribution[].$last.agent.type[]","CorporateBody")
@@ -214,7 +214,7 @@ do list(path:"710[012] ", "var":"$i")
           end
         end
         # name
-          call_macro("gndNonPersonCombinedLabel",field:"$i")
+          call_macro("gndOtherCombinedLabel",field:"$i")
           copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
         # type
         set_array("contribution[].$last.agent.type[]","CorporateBody")
@@ -263,11 +263,8 @@ do list(path:"111[012] |711[012] ", "var":"$i")
           end
         end
         # name
-        paste("contribution[].$last.agent.label", "$i.a", "~ (", "$i.n", "~ : ", "$i.d", "~ : ", "$i.c", "~)", join_char: "")
-        replace_all("contribution[].$last.agent.label"," \\( :  : \\)","")
-        replace_all("contribution[].$last.agent.label",":  :",":")
-        replace_all("contribution[].$last.agent.label"," \\( : | \\( :  : "," \\(")
-        replace_all("contribution[].$last.agent.label"," : \\)|:  : \\)","\\)")
+        call_macro("gndEventCombinedLabel",field:"$i")
+        copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")        
         # type
         set_array("contribution[].$last.agent.type[]","ConferenceOrEvent")
         # role
@@ -347,10 +344,18 @@ do list (path: "contribution[]", "var": "$i")
       copy_field("$z.@combinedLabel", "$i.agent.altLabel[].$append")
     end
   end
-  do list(path:"GEL??|GKT??|GKS??|GST??|GGN??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
+    do list(path:"GKS??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
     unless any_equal("$z.i","Spitzenorgan")
       if in ("$i.agent.@gndIdn", "$z.B")
-        call_macro("gndNonPersonCombinedLabel",field:"$z")
+        call_macro("gndEventCombinedLabel",field:"$z")
+        copy_field("$z.@combinedLabel", "$i.agent.altLabel[].$append")
+      end
+    end
+  end
+  do list(path:"GEL??|GKT??|GST??|GGN??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
+    unless any_equal("$z.i","Spitzenorgan")
+      if in ("$i.agent.@gndIdn", "$z.B")
+        call_macro("gndOtherCombinedLabel",field:"$z")
         copy_field("$z.@combinedLabel", "$i.agent.altLabel[].$append")
       end
     end

--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -92,33 +92,6 @@ set_array("describedBy.resultOf.object.modifiedBy[]")
 
 end
 
-do once("provenanceLinksMacro")
-  do put_macro("provenanceLinks")
-    lookup("$[field]","sigel2isilMap")
-    replace_all("$[field]", " ", "")
-    replace_all("$[field]", "\\/Inst","")
-    if any_match("$[field]",".*(hbz|HBZ).*")
-      replace_all("$[field]", "^.*$", "DE-605")
-    elsif any_match("$[field]","^NRW$|^NRW\\/Hist.Buch$")
-      replace_all("$[field]", "^.*$", "DE-605")
-    elsif any_match("$[field]","^292$")
-      replace_all("$[field]", "^292$", "DE-101b")
-    elsif any_match("$[field]","(.*)\\/NWBib$")
-      replace_all("describedBy.resultOf.object.sourceOrganization.id", "(.*)\\/NWBib$", "DE-$1")
-    elsif any_match("$[field]",".*(dnb|DNB|GWDNB|GWDEB|GWDDB|DEDNM|DEDND).*")
-      replace_all("$[field]", "^.*$", "DE-101")
-    elsif any_match("$[field]", "^\\d{4}$")
-      lookup("$[field]", "picaCreatorId2Isil")
-    end
-    unless any_match("$[field]","[A-Za-z]{2}-.*")
-      prepend("$[field]","DE-")
-    end
-    prepend("$[field]", "http://lobid.org/organisations/")
-    append("$[field]", "#!")
-  end
-end
-
-
 call_macro("provenanceLinks",field: "describedBy.resultOf.object.sourceOrganization.id")
 copy_field("describedBy.resultOf.object.sourceOrganization.id","describedBy.resultOf.object.sourceOrganization.label")
 lookup("describedBy.resultOf.object.sourceOrganization.label","lobidOrgLabels",delete:"true")

--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -1,0 +1,150 @@
+# Macro for combinedLabel Person
+
+do put_macro("gndPersonCombinedLabel")
+    set_array("$[field].@combinedLabel")  # check if GND concept has combined variant
+    copy_field("$[field].a","$[field].@combinedLabel.$append")
+    copy_field("$[field].b","$[field].@combinedLabel.$append")
+    join_field("$[field].@combinedLabel", " ") # This is the difference to gnd non person
+    if exists("$[field].c")
+      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ", "$[field].c", join_char:"")
+    end
+    if exists("$[field].g")
+      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].g", "~)", join_char:"")
+    end
+    if exists("$[field].x")
+      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~/","$[field].x")
+    end
+end
+
+
+# Macro for combinedLabel Non-Person
+
+do put_macro("gndNonPersonCombinedLabel")
+  set_array("$[field].@combinedLabel")  # check if GND concept has combined variant
+  copy_field("$[field].a","$[field].@combinedLabel.$append")
+  copy_field("$[field].b","$[field].@combinedLabel.$append")
+  join_field("$[field].@combinedLabel", ". ") # This is the difference to gnd person
+  if exists("$[field].d") # special move for events
+    set_array("$[field].@combinedDetailsForEvents") 
+    if exists("$[field].g")
+      paste("$[field].@combinedDetailsForEvents", "$[field].g", join_char:"")
+    end
+    if exists("$[field].d")
+      paste("$[field].@combinedDetailsForEvents", "$[field].@combinedDetailsForEvents", "~ : ", "$[field].d", join_char:"")
+    end
+    if exists("$[field].c")
+      paste("$[field].@combinedDetailsForEvents", "$[field].@combinedDetailsForEvents", "~ : ", "$[field].c", join_char:"")
+    end
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].@combinedDetailsForEvents", "~)", join_char:"")
+  else
+    if exists("$[field].c")
+      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ", "$[field].c", join_char:"")
+    end
+    if exists("$[field].g")
+      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].g", "~)", join_char:"")
+    end
+  end
+  if exists("$[field].n")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ","$[field].n", join_char:"")
+  end
+  if exists("$[field].x")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~/","$[field].x")
+  end
+  if exists("$[field].t")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~: ","$[field].t", join_char:"")
+  end
+end
+
+# for describedBy provenance info
+
+do put_macro("provenanceLinks")
+  lookup("$[field]","sigel2isilMap")
+  replace_all("$[field]", " ", "")
+  replace_all("$[field]", "\\/Inst","")
+  if any_match("$[field]",".*(hbz|HBZ).*")
+    replace_all("$[field]", "^.*$", "DE-605")
+  elsif any_match("$[field]","^NRW$|^NRW\\/Hist.Buch$")
+    replace_all("$[field]", "^.*$", "DE-605")
+  elsif any_match("$[field]","^292$")
+    replace_all("$[field]", "^292$", "DE-101b")
+  elsif any_match("$[field]","(.*)\\/NWBib$")
+    replace_all("describedBy.resultOf.object.sourceOrganization.id", "(.*)\\/NWBib$", "DE-$1")
+  elsif any_match("$[field]",".*(dnb|DNB|GWDNB|GWDEB|GWDDB|DEDNM|DEDND).*")
+    replace_all("$[field]", "^.*$", "DE-101")
+  elsif any_match("$[field]", "^\\d{4}$")
+    lookup("$[field]", "picaCreatorId2Isil")
+  end
+  unless any_match("$[field]","[A-Za-z]{2}-.*")
+    prepend("$[field]","DE-")
+  end
+  prepend("$[field]", "http://lobid.org/organisations/")
+  append("$[field]", "#!")
+end
+
+# for Schlagwortfolgen
+
+do put_macro("schlagwortfolge")
+  if exists("$[field]")
+    set_array("subject[].$append.type[]","ComplexSubject")
+    set_array("subject[].$last.label")
+    set_array("subject[].$last.componentList[]")
+    do list(path:"$[field]", "var":"$i")
+      set_array("subject[].$last.componentList[].$append.type[]")
+      do list(path: "$i.D", "var": "$k")
+        copy_field("$k","subject[].$last.componentList[].$last.type[].$append")
+      end
+      if any_equal("subject[].$last.componentList[].$last.type[]","p")
+        call_macro("gndPersonCombinedLabel",field:"$i") 
+      else
+        call_macro("gndNonPersonCombinedLabel",field:"$i")
+      end
+      copy_field("$i.@combinedLabel", "subject[].$last.componentList[].$last.label")
+      unless any_equal("subject[].$last.componentList[].$last.label","")
+        copy_field("subject[].$last.componentList[].$last.label","subject[].$last.label.$append")
+      end
+      do list(path:"$i.0", "var": "$j")
+        if any_match("$j","^\\(DE-588\\)(.*)$")
+          add_field("subject[].$last.componentList[].$last.source.label","Gemeinsame Normdatei (GND)")
+          add_field("subject[].$last.componentList[].$last.source.id","https://d-nb.info/gnd/7749153-1")
+          copy_field("$j", "subject[].$last.componentList[].$last.id")
+          replace_all("subject[].$last.componentList[].$last.id","^\\(DE-588\\)(.*)$","https://d-nb.info/gnd/$1")
+          copy_field("$j", "subject[].$last.componentList[].$last.gndIdentifier")
+          replace_all("subject[].$last.componentList[].$last.gndIdentifier","^\\(DE-588\\)(.*)$","$1")
+        end
+        # GND idn as variable
+        if exists("$i.B")
+          do list(path: "$i.B","var":"$gnd")
+            unless exists("subject[].$last.componentList[].$last.@gndIdn")
+              copy_field("$gnd","subject[].$last.componentList[].$last.@gndIdn")
+            end
+          end
+        elsif any_match("$j","^.*DNB\\|(.*)$")
+          copy_field("$j", "subject[].$last.componentList[].$last.@gndIdn")
+          replace_all("subject[].$last.componentList[].$last.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+        elsif any_match("$j","^\\(DE-101\\)(.*)$")
+            copy_field("$j", "subject[].$last.componentList[].$last.@gndIdn")
+            replace_all("subject[].$last.componentList[].$last.@gndIdn", "^\\(DE-101\\)(.*)$","GND-$1")
+        end
+      end
+      copy_field("$i.d","subject[].$last.componentList[].$last.dateOfBirthAndDeath") # dates will be differentiated later in the process
+    end
+    join_field("subject[].$last.label"," | ")
+  end
+end
+
+
+do put_macro("subjectLabel")
+  set_array("subject[].$last.label")
+  set_array("$i.@name")
+  copy_field("$i.a","$i.@name.$append")
+  copy_field("$i.b","$i.@name.$append")
+  copy_field("$i.c","$i.@name.$append")
+  copy_field("$i.d","$i.@name.$append")
+  join_field("$i.@name")
+  copy_field("$i.@name","subject[].$last.label.$append")
+  copy_field("$i.x","subject[].$last.label.$append")
+  copy_field("$i.y","subject[].$last.label.$append")
+  copy_field("$i.z","subject[].$last.label.$append")
+  copy_field("$i.v","subject[].$last.label.$append")
+  join_field("subject[].$last.label"," / ")
+end

--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -25,7 +25,6 @@ do put_macro("gndNonPersonCombinedLabel")
   copy_field("$[field].b","$[field].@combinedLabel.$append")
   join_field("$[field].@combinedLabel", ". ") # This is the difference to gnd person
   if exists("$[field].d") # special move for events
-    set_array("$[field].@combinedDetailsForEvents") 
     if exists("$[field].g")
       paste("$[field].@combinedDetailsForEvents", "$[field].g", join_char:"")
     end

--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -1,3 +1,21 @@
+# Macro for combinedLabel Event / Meeting
+
+do put_macro("gndEventCombinedLabel")
+  set_array("$[field].@combinedLabel")  # check if GND concept has combined variant
+  copy_field("$[field].a","$[field].@combinedLabel.$append")
+  copy_field("$[field].b","$[field].@combinedLabel.$append")
+  join_field("$[field].@combinedLabel", ". ") # This is the difference to gnd person
+  set_array("$[field].@combinedDetailsForEvents")
+  copy_field("$[field].n","$[field].@combinedDetailsForEvents.$append")  
+  copy_field("$[field].g","$[field].@combinedDetailsForEvents.$append")
+  copy_field("$[field].d","$[field].@combinedDetailsForEvents.$append")
+  copy_field("$[field].c","$[field].@combinedDetailsForEvents.$append")        
+  join_field("$[field].@combinedDetailsForEvents"," : ")
+  unless is_empty("$[field].@combinedDetailsForEvents.")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].@combinedDetailsForEvents", "~)", join_char:"")
+  end
+end
+
 # Macro for combinedLabel Person
 
 do put_macro("gndPersonCombinedLabel")
@@ -17,31 +35,18 @@ do put_macro("gndPersonCombinedLabel")
 end
 
 
-# Macro for combinedLabel Non-Person
+# Macro for combinedLabel Non-Person and Non-Event
 
-do put_macro("gndNonPersonCombinedLabel")
+do put_macro("gndOtherCombinedLabel")
   set_array("$[field].@combinedLabel")  # check if GND concept has combined variant
   copy_field("$[field].a","$[field].@combinedLabel.$append")
   copy_field("$[field].b","$[field].@combinedLabel.$append")
   join_field("$[field].@combinedLabel", ". ") # This is the difference to gnd person
-  if exists("$[field].d") # special move for events
-    if exists("$[field].g")
-      paste("$[field].@combinedDetailsForEvents", "$[field].g", join_char:"")
-    end
-    if exists("$[field].d")
-      paste("$[field].@combinedDetailsForEvents", "$[field].@combinedDetailsForEvents", "~ : ", "$[field].d", join_char:"")
-    end
-    if exists("$[field].c")
-      paste("$[field].@combinedDetailsForEvents", "$[field].@combinedDetailsForEvents", "~ : ", "$[field].c", join_char:"")
-    end
-    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].@combinedDetailsForEvents", "~)", join_char:"")
-  else
-    if exists("$[field].c")
-      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ", "$[field].c", join_char:"")
-    end
-    if exists("$[field].g")
-      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].g", "~)", join_char:"")
-    end
+  if exists("$[field].c")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ", "$[field].c", join_char:"")
+  end
+  if exists("$[field].g")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].g", "~)", join_char:"")
   end
   if exists("$[field].n")
     paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ","$[field].n", join_char:"")
@@ -93,9 +98,11 @@ do put_macro("schlagwortfolge")
         copy_field("$k","subject[].$last.componentList[].$last.type[].$append")
       end
       if any_equal("subject[].$last.componentList[].$last.type[]","p")
-        call_macro("gndPersonCombinedLabel",field:"$i") 
+        call_macro("gndPersonCombinedLabel",field:"$i")
+      elsif any_equal("subject[].$last.componentList[].$last.type[]","f")
+        call_macro("gndEventCombinedLabel",field:"$i")        
       else
-        call_macro("gndNonPersonCombinedLabel",field:"$i")
+        call_macro("gndOtherCombinedLabel",field:"$i")
       end
       copy_field("$i.@combinedLabel", "subject[].$last.componentList[].$last.label")
       unless any_equal("subject[].$last.componentList[].$last.label","")

--- a/src/main/resources/alma/fix/subjects.fix
+++ b/src/main/resources/alma/fix/subjects.fix
@@ -44,24 +44,6 @@ do list(path: "natureOfContent[]", "var":"$i")
   end
 end
 
-do once("subjectLabel")
-  do put_macro("subjectLabel")
-    set_array("subject[].$last.label")
-    set_array("$i.@name")
-    copy_field("$i.a","$i.@name.$append")
-    copy_field("$i.b","$i.@name.$append")
-    copy_field("$i.c","$i.@name.$append")
-    copy_field("$i.d","$i.@name.$append")
-    join_field("$i.@name")
-    copy_field("$i.@name","subject[].$last.label.$append")
-    copy_field("$i.x","subject[].$last.label.$append")
-    copy_field("$i.y","subject[].$last.label.$append")
-    copy_field("$i.z","subject[].$last.label.$append")
-    copy_field("$i.v","subject[].$last.label.$append")
-    join_field("subject[].$last.label"," / ")
-  end
-end
-
 set_array("subject[]")
 
 
@@ -116,25 +98,7 @@ do list(path:"600?7|610?7|611?7|630?7|648?7|650?7|651?7", "var":"$i")
   end
 end
 
-# Macro for combinedLabel Person
 
-do once("gndPersonCombinedLabel")
-  do put_macro("gndPersonCombinedLabel")
-      set_array("$[field].@combinedLabel")  # check if GND concept has combined variant
-      copy_field("$[field].a","$[field].@combinedLabel.$append")
-      copy_field("$[field].b","$[field].@combinedLabel.$append")
-      join_field("$[field].@combinedLabel", " ") # This is the difference to gnd non person
-      if exists("$[field].c")
-        paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ", "$[field].c", join_char:"")
-      end
-      if exists("$[field].g")
-        paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].g", "~)", join_char:"")
-      end
-      if exists("$[field].x")
-        paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~/","$[field].x")
-      end
-  end
-end
 
 do list(path:"600??", "var":"$i")
   if any_match("$i.0","^\\(DE-588\\)(.*)$")
@@ -168,45 +132,6 @@ do list(path:"600??", "var":"$i")
   end
 end
 
-# Macro for combinedLabel Non-Person
-
-do once("gndNonPersonCombinedLabel")
-  do put_macro("gndNonPersonCombinedLabel")
-    set_array("$[field].@combinedLabel")  # check if GND concept has combined variant
-    copy_field("$[field].a","$[field].@combinedLabel.$append")
-    copy_field("$[field].b","$[field].@combinedLabel.$append")
-    join_field("$[field].@combinedLabel", ". ") # This is the difference to gnd person
-    if exists("$[field].d") # special move for events
-      set_array("$[field].@combinedDetailsForEvents") 
-      if exists("$[field].g")
-        paste("$[field].@combinedDetailsForEvents", "$[field].g", join_char:"")
-      end
-      if exists("$[field].d")
-        paste("$[field].@combinedDetailsForEvents", "$[field].@combinedDetailsForEvents", "~ : ", "$[field].d", join_char:"")
-      end
-      if exists("$[field].c")
-        paste("$[field].@combinedDetailsForEvents", "$[field].@combinedDetailsForEvents", "~ : ", "$[field].c", join_char:"")
-      end
-      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].@combinedDetailsForEvents", "~)", join_char:"")
-    else
-      if exists("$[field].c")
-        paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ", "$[field].c", join_char:"")
-      end
-      if exists("$[field].g")
-        paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].g", "~)", join_char:"")
-      end
-    end
-    if exists("$[field].n")
-      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~, ","$[field].n", join_char:"")
-    end
-    if exists("$[field].x")
-      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~/","$[field].x")
-    end
-    if exists("$[field].t")
-      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~: ","$[field].t", join_char:"")
-    end
-  end
-end
 
 do list(path:"610??|611??|630??|648??|650??|651??", "var":"$i")
   if any_match("$i.0","^\\(DE-588\\)(.*)$")
@@ -367,60 +292,8 @@ do list(path:"982  ", "var":"$i")
   end
 end
 
-
 # 689 RSWK Schlagwortfolgen fka: Schlagwortketten 1 - 10 - no info on repeatability
-do once("schlagwortfolgeMacro")
-  do put_macro("schlagwortfolge")
-    if exists("$[field]")
-      set_array("subject[].$append.type[]","ComplexSubject")
-      set_array("subject[].$last.label")
-      set_array("subject[].$last.componentList[]")
-      do list(path:"$[field]", "var":"$i")
-        set_array("subject[].$last.componentList[].$append.type[]")
-        do list(path: "$i.D", "var": "$k")
-          copy_field("$k","subject[].$last.componentList[].$last.type[].$append")
-        end
-        if any_equal("subject[].$last.componentList[].$last.type[]","p")
-          call_macro("gndPersonCombinedLabel",field:"$i") 
-        else
-          call_macro("gndNonPersonCombinedLabel",field:"$i")
-        end
-        copy_field("$i.@combinedLabel", "subject[].$last.componentList[].$last.label")
-        unless any_equal("subject[].$last.componentList[].$last.label","")
-          copy_field("subject[].$last.componentList[].$last.label","subject[].$last.label.$append")
-        end
-        do list(path:"$i.0", "var": "$j")
-          if any_match("$j","^\\(DE-588\\)(.*)$")
-            add_field("subject[].$last.componentList[].$last.source.label","Gemeinsame Normdatei (GND)")
-            add_field("subject[].$last.componentList[].$last.source.id","https://d-nb.info/gnd/7749153-1")
-            copy_field("$j", "subject[].$last.componentList[].$last.id")
-            replace_all("subject[].$last.componentList[].$last.id","^\\(DE-588\\)(.*)$","https://d-nb.info/gnd/$1")
-            copy_field("$j", "subject[].$last.componentList[].$last.gndIdentifier")
-            replace_all("subject[].$last.componentList[].$last.gndIdentifier","^\\(DE-588\\)(.*)$","$1")
-          end
-          # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("subject[].$last.componentList[].$last.@gndIdn")
-                copy_field("$gnd","subject[].$last.componentList[].$last.@gndIdn")
-              end
-            end
-          elsif any_match("$j","^.*DNB\\|(.*)$")
-            copy_field("$j", "subject[].$last.componentList[].$last.@gndIdn")
-            replace_all("subject[].$last.componentList[].$last.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$j","^\\(DE-101\\)(.*)$")
-              copy_field("$j", "subject[].$last.componentList[].$last.@gndIdn")
-              replace_all("subject[].$last.componentList[].$last.@gndIdn", "^\\(DE-101\\)(.*)$","GND-$1")
-          end
-        end
-        copy_field("$i.d","subject[].$last.componentList[].$last.dateOfBirthAndDeath") # dates will be differentiated later in the process
-      end
-      join_field("subject[].$last.label"," | ")
-    end
-  end
-end
 
-# 689 RSWK Schlagwortfolgen fka: Schlagwortketten 1 - 10
 call_macro("schlagwortfolge", field: "6890?")
 call_macro("schlagwortfolge", field: "6891?")
 call_macro("schlagwortfolge", field: "6892?")

--- a/src/main/resources/alma/fix/subjects.fix
+++ b/src/main/resources/alma/fix/subjects.fix
@@ -132,13 +132,44 @@ do list(path:"600??", "var":"$i")
   end
 end
 
-
-do list(path:"610??|611??|630??|648??|650??|651??", "var":"$i")
+do list(path:"611??", "var":"$i")
   if any_match("$i.0","^\\(DE-588\\)(.*)$")
     set_array("subject[].$append.type[]","Concept")
     add_field("subject[].$last.source.label","Gemeinsame Normdatei (GND)")
     add_field("subject[].$last.source.id","https://d-nb.info/gnd/7749153-1")
-    call_macro("gndNonPersonCombinedLabel",field:"$i")
+    call_macro("gndEventCombinedLabel",field:"$i")
+    copy_field("$i.@combinedLabel", "subject[].$last.label")
+    do list(path:"$i.0", "var":"$j")
+      if any_match("$j","^\\(DE-588\\)(.*)$")
+        copy_field("$j", "subject[].$last.id")
+        replace_all("subject[].$last.id","^\\(DE-588\\)(.*)$","https://d-nb.info/gnd/$1")
+        copy_field("$j", "subject[].$last.gndIdentifier")
+        replace_all("subject[].$last.gndIdentifier","^\\(DE-588\\)(.*)$","$1")
+      end
+      # GND idn as variable
+      if exists("$i.B")
+        do list(path: "$i.B","var":"$gnd")
+          unless exists("subject[].$last.@gndIdn")
+            copy_field("$gnd","subject[].$last.@gndIdn")
+          end
+        end
+      elsif any_match("$j","^.*DNB\\|(.*)$")
+        copy_field("$j", "subject[].$last.@gndIdn")
+        replace_all("subject[].$last.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+      elsif any_match("$j","^\\(DE-101\\)(.*)$")
+        copy_field("$j", "subject[].$last.@gndIdn")
+        replace_all("subject[].$last.@gndIdn", "^\\(DE-101\\)(.*)$","GND-$1")
+      end
+    end
+  end
+end
+
+do list(path:"610??|630??|648??|650??|651??", "var":"$i")
+  if any_match("$i.0","^\\(DE-588\\)(.*)$")
+    set_array("subject[].$append.type[]","Concept")
+    add_field("subject[].$last.source.label","Gemeinsame Normdatei (GND)")
+    add_field("subject[].$last.source.id","https://d-nb.info/gnd/7749153-1")
+    call_macro("gndOtherCombinedLabel",field:"$i")
     copy_field("$i.@combinedLabel", "subject[].$last.label")
     do list(path:"$i.0", "var":"$j")
       if any_match("$j","^\\(DE-588\\)(.*)$")
@@ -175,10 +206,18 @@ do list(path:"subject[]", "var":"$i")
       copy_field("$z.@combinedLabel", "$i.altLabel[].$append")
     end
   end
+  do list(path:"GKS??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
+    unless any_equal("$z.i","Spitzenorgan")
+      if in ("$i.@gndIdn", "$z.B")
+        call_macro("gndEventCombinedLabel",field:"$z")
+        copy_field("$z.@combinedLabel", "$i.altLabel[].$append")
+      end
+    end
+  end
   do list(path:"GEL??|GKT??|GKS??|GST??|GGN??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
     unless any_equal("$z.i","Spitzenorgan")
       if in ("$i.@gndIdn", "$z.B")
-        call_macro("gndNonPersonCombinedLabel",field:"$z")
+        call_macro("gndOtherCombinedLabel",field:"$z")
         copy_field("$z.@combinedLabel", "$i.altLabel[].$append")
       end
     end
@@ -375,7 +414,7 @@ do list (path: "subject[]", "var": "$i")
     do list(path:"GEL??|GKT??|GKS??|GST??|GGN??", "var": "$z")  # Other altLabels have a "," character between $a and $b.
       unless any_equal("$z.i","Spitzenorgan")
         if in ("$j.@gndIdn", "$z.B")  # check if GND concept has combined variant
-          call_macro("gndNonPersonCombinedLabel",field:"$z")
+          call_macro("gndOtherCombinedLabel",field:"$z")
           copy_field("$z.@combinedLabel", "$j.altLabel[].$append")
         end
       end

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -143,7 +143,7 @@
       "id" : "https://d-nb.info/gnd/5216315-5",
       "label" : "Shambaugh Conference on Political Theory (1981 : Iowa City, Iowa)",
       "type" : [ "ConferenceOrEvent" ],
-      "altLabel" : [ "Conference on Political Theory ( : 1981 : Iowa City, Iowa)" ]
+      "altLabel" : [ "Conference on Political Theory (1981 : Iowa City, Iowa)" ]
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/oth",

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -143,7 +143,7 @@
       "id" : "https://d-nb.info/gnd/5216315-5",
       "label" : "Shambaugh Conference on Political Theory (1981 : Iowa City, Iowa)",
       "type" : [ "ConferenceOrEvent" ],
-      "altLabel" : [ "Conference on Political Theory, Iowa City, Iowa" ]
+      "altLabel" : [ "Conference on Political Theory ( : 1981 : Iowa City, Iowa)" ]
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/oth",

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -124,7 +124,7 @@
       "id" : "https://d-nb.info/gnd/1230482-7",
       "label" : "International Ichthyology Congress (7 : 1991 : Den Haag)",
       "type" : [ "ConferenceOrEvent" ],
-      "altLabel" : [ "Congressus Europaeus Ichthyologorum, Den Haag", "CEI, Den Haag" ]
+      "altLabel" : [ "Congressus Europaeus Ichthyologorum ( : 1991 : Den Haag), 7", "CEI ( : 1991 : Den Haag), 7" ]
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/oth",

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -124,7 +124,7 @@
       "id" : "https://d-nb.info/gnd/1230482-7",
       "label" : "International Ichthyology Congress (7 : 1991 : Den Haag)",
       "type" : [ "ConferenceOrEvent" ],
-      "altLabel" : [ "Congressus Europaeus Ichthyologorum ( : 1991 : Den Haag), 7", "CEI ( : 1991 : Den Haag), 7" ]
+      "altLabel" : [ "Congressus Europaeus Ichthyologorum (7 : 1991 : Den Haag)", "CEI (7 : 1991 : Den Haag)" ]
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/oth",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -184,7 +184,7 @@
       "id" : "https://d-nb.info/gnd/3061200-7",
       "label" : "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht",
       "type" : [ "CorporateBody" ],
-      "altLabel" : [ "Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht (Rheinland-Pfalz)", "Landesamt für Umweltschutz, Wasserwirtschaft und Gewerbeaufsicht (Rheinland-Pfalz)", "LUWG", "Rheinland-Pfalz. Landesamt für Umweltschutz, Wasserwirtschaft und Gewerbeaufsicht", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Gewerbeaufsicht", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Abteilung", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Referat", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Referat Strahlenschutz" ]
+      "altLabel" : [ "Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht (Rheinland-Pfalz)", "Landesamt für Umweltschutz, Wasserwirtschaft und Gewerbeaufsicht (Rheinland-Pfalz)", "LUWG", "Rheinland-Pfalz. Landesamt für Umweltschutz, Wasserwirtschaft und Gewerbeaufsicht", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Gewerbeaufsicht", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Abteilung, 2", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Referat, 24", "Rheinland-Pfalz. Landesamt für Umwelt, Wasserwirtschaft und Gewerbeaufsicht. Referat Strahlenschutz" ]
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/aut",


### PR DESCRIPTION
Events and meetings have a specific structure for the label. In order to construct them from the Marc Subfields we had to introduce a separate transformation for events.

Also I have put all macros in a separate fix. @blackwinter can you have a look at this. Since I deleted all do once for the single macros but have put it in the maps do once in alma.fix

The macro.fix allows for the usage of the macros in subject.fix and contribution.fix.