### PR TITLE
Add subfield $z for other gnd labels and altLabels

### DIFF
--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -57,6 +57,9 @@ do put_macro("gndOtherCombinedLabel")
   if exists("$[field].t")
     paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~: ","$[field].t", join_char:"")
   end
+  if exists("$[field].z")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].z", "~)", join_char:"")
+  end
 end
 
 # for describedBy provenance info

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -116,10 +116,10 @@
     } ]
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Niedersachsen",
+    "label" : "Niedersachsen (Süd)",
     "componentList" : [ {
       "type" : [ "PlaceOrGeographicName" ],
-      "label" : "Niedersachsen",
+      "label" : "Niedersachsen (Süd)",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",
         "id" : "https://d-nb.info/gnd/7749153-1"
@@ -148,7 +148,7 @@
       }
     }
   } ],
-  "subjectslabels" : [ "Nordrhein-Westfalen", "Niedersachsen" ],
+  "subjectslabels" : [ "Nordrhein-Westfalen", "Niedersachsen (Süd)" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -117,7 +117,7 @@
       },
       "id" : "https://d-nb.info/gnd/4050926-6",
       "gndIdentifier" : "4050926-6",
-      "altLabel" : [ "Ruhr", "Ruhr-Gebiet", "Ruhrrevier", "Metropole Ruhr" ]
+      "altLabel" : [ "Ruhr (Region)", "Ruhr-Gebiet", "Ruhrrevier", "Metropole Ruhr" ]
     }, {
       "type" : [ "SubjectHeading" ],
       "label" : "Heimatkunde",


### PR DESCRIPTION
I use the representation as in the GND with brackets, not separated by comma: https://lobid.org/gnd/4115393-5 = > [Niedersachsen (Süd)](https://lobid.org/gnd/4115393-5#)

REsolves #1787 
