### PR TITLE
Introduce lookup for deprecatedUri based on mapping from zdbId

### DIFF
--- a/src/main/java/org/lobid/resources/run/AlmaMarcXmlFix2lobidJsonEs.java
+++ b/src/main/java/org/lobid/resources/run/AlmaMarcXmlFix2lobidJsonEs.java
@@ -132,7 +132,7 @@ public class AlmaMarcXmlFix2lobidJsonEs {
                 fixVariables.put("rpb2.ttl", "./maps/rpb2.ttl");
                 fixVariables.put("rpb-spatial.ttl", "./maps/rpb-spatial.ttl");
                 fixVariables.put("rpb.ttl", "./maps/rpb.ttl");
-                fixVariables.put("hbzId2zdbId.tsv", "./maps/hbzId2zdbId.tsv");
+                fixVariables.put("hbzId2zdbId.tsv", "./maps/hbzId2zdbId.tsv.gz");
 
                 XmlElementSplitter xmlElementSplitter = new XmlElementSplitter();
                 xmlElementSplitter.setElementName("record");

--- a/src/main/java/org/lobid/resources/run/AlmaMarcXmlFix2lobidJsonEs.java
+++ b/src/main/java/org/lobid/resources/run/AlmaMarcXmlFix2lobidJsonEs.java
@@ -132,6 +132,7 @@ public class AlmaMarcXmlFix2lobidJsonEs {
                 fixVariables.put("rpb2.ttl", "./maps/rpb2.ttl");
                 fixVariables.put("rpb-spatial.ttl", "./maps/rpb-spatial.ttl");
                 fixVariables.put("rpb.ttl", "./maps/rpb.ttl");
+                fixVariables.put("hbzId2zdbId.tsv", "./maps/hbzId2zdbId.tsv");
 
                 XmlElementSplitter xmlElementSplitter = new XmlElementSplitter();
                 xmlElementSplitter.setElementName("record");

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -155,3 +155,4 @@ lookup("@hbzId","zdbId2oldHbzId",delete:"true")
 if exists("@hbzId")
   paste("deprecatedUri", "~http://lobid.org/resources/", "@hbzId", "~#!", join_char: "")
 end
+copy_field("@hbzId","hbzId")

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -43,6 +43,7 @@ if exists("hbzId")
   paste("deprecatedUri", "~http://lobid.org/resources/", "hbzId", "~#!", join_char: "")
 end
 
+
 # 020 - International Standard Book Number (R) - $a (NR)
 # source data sometimes provides repeated subfield $a even if this is not valid marc
 
@@ -148,3 +149,9 @@ replace_all("zdbId", " ","-") # CZ entries have incorrect spaces sometimes in th
 copy_field("almaMmsId","rpbId")
 lookup("rpbId","almaMmsId2rpbId",delete:"true")
 replace_all("rpbId", "^RPB","")
+
+copy_field("zdbId","@hbzId")
+lookup("@hbzId","zdbId2oldHbzId",delete:"true")
+if exists("@hbzId")
+  paste("deprecatedUri", "~http://lobid.org/resources/", "@hbzId", "~#!", join_char: "")
+end

--- a/src/main/resources/alma/fix/maps.fix
+++ b/src/main/resources/alma/fix/maps.fix
@@ -35,6 +35,8 @@ put_filemap("$[almaMmsId2rpbId]","almaMmsId2rpbId", sep_char:"\t",key_column:"0"
 # lobid Organisations id -> label
 put_filemap("$[lobidOrgLabels]","lobidOrgLabels", sep_char:"\t",key_column:"0",value_column:"1",expected_columns:"-1")
 
+# map zdbId to old hbzId(HT Nummer) based on the last aleph transformation
+put_filemap("$[hbzId2zdbId.tsv]","zdbId2oldHbzId", sep_char:"\t",key_column:"1",value_column:"0",expected_columns:"-1")
 
 put_map("rswk-indicator",
   "p": "Person",

--- a/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonMetafixTest.java
+++ b/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonMetafixTest.java
@@ -75,6 +75,7 @@ public final class AlmaMarc21XmlToLobidJsonMetafixTest {
         fixVariables.put("rpb2.ttl", "src/main/resources/alma/maps/rpb2.ttl");
         fixVariables.put("rpb-spatial.ttl", "src/main/resources/alma/maps/rpb-spatial.ttl");
         fixVariables.put("rpb.ttl", "src/main/resources/alma/maps/rpb.ttl");
+        fixVariables.put("hbzId2zdbId.tsv", "src/main/resources/alma/maps/hbzId2zdbId.tsv");
     }
 
     /**

--- a/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonMetafixTest.java
+++ b/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonMetafixTest.java
@@ -75,7 +75,7 @@ public final class AlmaMarc21XmlToLobidJsonMetafixTest {
         fixVariables.put("rpb2.ttl", "src/main/resources/alma/maps/rpb2.ttl");
         fixVariables.put("rpb-spatial.ttl", "src/main/resources/alma/maps/rpb-spatial.ttl");
         fixVariables.put("rpb.ttl", "src/main/resources/alma/maps/rpb.ttl");
-        fixVariables.put("hbzId2zdbId.tsv", "src/main/resources/alma/maps/hbzId2zdbId.tsv");
+        fixVariables.put("hbzId2zdbId.tsv", "src/main/resources/alma/maps/hbzId2zdbId.tsv.gz");
     }
 
     /**

--- a/src/test/resources/alma-fix/990015940770206447.json
+++ b/src/test/resources/alma-fix/990015940770206447.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1071542664" ],
   "zdbId" : "2039693-4",
   "deprecatedUri" : "http://lobid.org/resources/HT013034988#!",
+  "hbzId" : "HT013034988",
   "title" : "zbMATH open",
   "alternativeTitle" : [ "Zentralblatt MATH", "ZMATH", "Zentralblatt MATH", "ZMATH", "Zentralblatt MATH database ( Haupttitel bis 2013 )", "zbMath ( Haupttitel 2014-2020 )" ],
   "otherTitleInformation" : [ "the first resource for mathematics" ],

--- a/src/test/resources/alma-fix/990015940770206447.json
+++ b/src/test/resources/alma-fix/990015940770206447.json
@@ -4,6 +4,7 @@
   "issn" : [ "14363429", "14363429" ],
   "oclcNumber" : [ "1071542664" ],
   "zdbId" : "2039693-4",
+  "deprecatedUri" : "http://lobid.org/resources/HT013034988#!",
   "title" : "zbMATH open",
   "alternativeTitle" : [ "Zentralblatt MATH", "ZMATH", "Zentralblatt MATH", "ZMATH", "Zentralblatt MATH database ( Haupttitel bis 2013 )", "zbMath ( Haupttitel 2014-2020 )" ],
   "otherTitleInformation" : [ "the first resource for mathematics" ],

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "123550-3",
   "dnbId" : "010694188",
   "deprecatedUri" : "http://lobid.org/resources/HT000312236#!",
+  "hbzId" : "HT000312236",
   "title" : "Physik in der Schule",
   "publication" : [ {
     "publicationHistory" : "2.1964,7 - 38.2000",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1367315083" ],
   "zdbId" : "123550-3",
   "dnbId" : "010694188",
+  "deprecatedUri" : "http://lobid.org/resources/HT000312236#!",
   "title" : "Physik in der Schule",
   "publication" : [ {
     "publicationHistory" : "2.1964,7 - 38.2000",

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "1257-9",
   "dnbId" : "010014802",
   "deprecatedUri" : "http://lobid.org/resources/HT002619538#!",
+  "hbzId" : "HT002619538",
   "title" : "Annual bulletin of transport statistics for Europe and North America",
   "alternativeTitle" : [ "Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord", "Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki", "Annual bulletin of transport statistics for Europe ( Hauptsacht. bis 44.1994 )", "Bulletin annuel de statistiques de transports européens ( Parallelsacht. bis 44.1994 )", "Ežegodnyj bjulleten' evropejskoj statistiki transporta ( Parallelsacht. bis 44.1994 )" ],
   "otherTitleInformation" : [ "= Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord = Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki" ],

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1367306405" ],
   "zdbId" : "1257-9",
   "dnbId" : "010014802",
+  "deprecatedUri" : "http://lobid.org/resources/HT002619538#!",
   "title" : "Annual bulletin of transport statistics for Europe and North America",
   "alternativeTitle" : [ "Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord", "Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki", "Annual bulletin of transport statistics for Europe ( Hauptsacht. bis 44.1994 )", "Bulletin annuel de statistiques de transports européens ( Parallelsacht. bis 44.1994 )", "Ežegodnyj bjulleten' evropejskoj statistiki transporta ( Parallelsacht. bis 44.1994 )" ],
   "otherTitleInformation" : [ "= Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord = Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki" ],

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "183206499" ],
   "zdbId" : "133469-4",
   "dnbId" : "010772626",
+  "deprecatedUri" : "http://lobid.org/resources/HT003176544#!",
   "title" : "Reisen in Deutschland, Band 2, Reisegebiete in Berlin (West), Bremen, Hamburg, Nordrhein-Westfalen, Niedersachsen, Rheinland-Pfalz, Saarland, Schleswig-Holstein",
   "alternativeTitle" : [ "Bayern ( Sachl. Benennung bis 25.1975 )" ],
   "otherTitleInformation" : [ "deutsches Handbuch für Fremdenverkehr" ],

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "133469-4",
   "dnbId" : "010772626",
   "deprecatedUri" : "http://lobid.org/resources/HT003176544#!",
+  "hbzId" : "HT003176544",
   "title" : "Reisen in Deutschland, Band 2, Reisegebiete in Berlin (West), Bremen, Hamburg, Nordrhein-Westfalen, Niedersachsen, Rheinland-Pfalz, Saarland, Schleswig-Holstein",
   "alternativeTitle" : [ "Bayern ( Sachl. Benennung bis 25.1975 )" ],
   "otherTitleInformation" : [ "deutsches Handbuch für Fremdenverkehr" ],

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "985104571" ],
   "zdbId" : "619424-2",
   "dnbId" : "01359009X",
+  "deprecatedUri" : "http://lobid.org/resources/HT003497718#!",
   "title" : "Eilendorfer Heimatblätter",
   "otherTitleInformation" : [ "Jahresschrift des Heimatvereins Eilendorf 1983 e.V" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "619424-2",
   "dnbId" : "01359009X",
   "deprecatedUri" : "http://lobid.org/resources/HT003497718#!",
+  "hbzId" : "HT003497718",
   "title" : "Eilendorfer Heimatblätter",
   "otherTitleInformation" : [ "Jahresschrift des Heimatvereins Eilendorf 1983 e.V" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "1089874-8",
   "dnbId" : "01620476X",
   "deprecatedUri" : "http://lobid.org/resources/HT007048176#!",
+  "hbzId" : "HT007048176",
   "title" : "Bochumer Zeitpunkte",
   "otherTitleInformation" : [ "Beiträge zur Stadtgeschichte, Heimatkunde und Denkmalpflege" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "724554237" ],
   "zdbId" : "1089874-8",
   "dnbId" : "01620476X",
+  "deprecatedUri" : "http://lobid.org/resources/HT007048176#!",
   "title" : "Bochumer Zeitpunkte",
   "otherTitleInformation" : [ "Beiträge zur Stadtgeschichte, Heimatkunde und Denkmalpflege" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "84900090" ],
   "zdbId" : "565380-0",
   "dnbId" : "013165410",
+  "deprecatedUri" : "http://lobid.org/resources/HT012224491#!",
   "title" : "Wettersbacher Anzeiger",
   "publication" : [ {
     "publicationHistory" : "Nachgewiesen 1979 -",

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "565380-0",
   "dnbId" : "013165410",
   "deprecatedUri" : "http://lobid.org/resources/HT012224491#!",
+  "hbzId" : "HT012224491",
   "title" : "Wettersbacher Anzeiger",
   "publication" : [ {
     "publicationHistory" : "Nachgewiesen 1979 -",

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "590016-5",
   "dnbId" : "01335941X",
   "deprecatedUri" : "http://lobid.org/resources/HT012237361#!",
+  "hbzId" : "HT012237361",
   "title" : "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz, L. IV. 6: Finanzen und Steuern. Einheitswerte des Grundvermögens nach der Hauptfeststellung : Gemeindeergebnisse",
   "publication" : [ {
     "publicationHistory" : "1964(1975); damit Ersch. eingest.",

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1367753905" ],
   "zdbId" : "590016-5",
   "dnbId" : "01335941X",
+  "deprecatedUri" : "http://lobid.org/resources/HT012237361#!",
   "title" : "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz, L. IV. 6: Finanzen und Steuern. Einheitswerte des Grundvermögens nach der Hauptfeststellung : Gemeindeergebnisse",
   "publication" : [ {
     "publicationHistory" : "1964(1975); damit Ersch. eingest.",

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "903128-5",
   "dnbId" : "014967758",
   "deprecatedUri" : "http://lobid.org/resources/HT012338254#!",
+  "hbzId" : "HT012338254",
   "title" : "Appropriation acts of the General Assembly of the Commonwealth of Pennsylvania",
   "alternativeTitle" : [ "Appropriation acts ( Nebent. d. Mikrofiche-Ausg. )" ],
   "otherTitleInformation" : [ "passed at the session of ..." ],

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1367906311" ],
   "zdbId" : "903128-5",
   "dnbId" : "014967758",
+  "deprecatedUri" : "http://lobid.org/resources/HT012338254#!",
   "title" : "Appropriation acts of the General Assembly of the Commonwealth of Pennsylvania",
   "alternativeTitle" : [ "Appropriation acts ( Nebent. d. Mikrofiche-Ausg. )" ],
   "otherTitleInformation" : [ "passed at the session of ..." ],

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "313580279" ],
   "zdbId" : "1484300-6",
   "dnbId" : "019771649",
+  "deprecatedUri" : "http://lobid.org/resources/HT012721542#!",
   "title" : "Tauben- und Hühnerzeitung",
   "otherTitleInformation" : [ "Organ der gesammten Haus-Federviehzucht, mit Inbegriff der Sangvögel" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "1484300-6",
   "dnbId" : "019771649",
   "deprecatedUri" : "http://lobid.org/resources/HT012721542#!",
+  "hbzId" : "HT012721542",
   "title" : "Tauben- und Hühnerzeitung",
   "otherTitleInformation" : [ "Organ der gesammten Haus-Federviehzucht, mit Inbegriff der Sangvögel" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1368120672" ],
   "zdbId" : "1500025-4",
   "dnbId" : "019926944",
+  "deprecatedUri" : "http://lobid.org/resources/HT012734833#!",
   "title" : "Behavioural pharmacology",
   "publication" : [ {
     "publicationHistory" : "1.1989 -",

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "1500025-4",
   "dnbId" : "019926944",
   "deprecatedUri" : "http://lobid.org/resources/HT012734833#!",
+  "hbzId" : "HT012734833",
   "title" : "Behavioural pharmacology",
   "publication" : [ {
     "publicationHistory" : "1.1989 -",

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "1500079-5",
   "dnbId" : "019927487",
   "deprecatedUri" : "http://lobid.org/resources/HT012734884#!",
+  "hbzId" : "HT012734884",
   "title" : "Yearbook of anthropology",
   "publication" : [ {
     "publicationHistory" : "1.1955",

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1368065947" ],
   "zdbId" : "1500079-5",
   "dnbId" : "019927487",
+  "deprecatedUri" : "http://lobid.org/resources/HT012734884#!",
   "title" : "Yearbook of anthropology",
   "publication" : [ {
     "publicationHistory" : "1.1955",

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2000012-1",
   "dnbId" : "02000043X",
   "deprecatedUri" : "http://lobid.org/resources/HT012819873#!",
+  "hbzId" : "HT012819873",
   "title" : "Bonner Beethoven-Studien",
   "otherTitleInformation" : [ "Mitteilungen aus dem Beethoven-Haus und Beethoven-Archiv Bonn" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "614914125" ],
   "zdbId" : "2000012-1",
   "dnbId" : "02000043X",
+  "deprecatedUri" : "http://lobid.org/resources/HT012819873#!",
   "title" : "Bonner Beethoven-Studien",
   "otherTitleInformation" : [ "Mitteilungen aus dem Beethoven-Haus und Beethoven-Archiv Bonn" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -6,6 +6,7 @@
   "dnbId" : "021118205",
   "rpbId" : "036t000472",
   "deprecatedUri" : "http://lobid.org/resources/HT013026834#!",
+  "hbzId" : "HT013026834",
   "title" : "Mainz",
   "otherTitleInformation" : [ "Programm" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2033740-1",
   "dnbId" : "021118205",
   "rpbId" : "036t000472",
+  "deprecatedUri" : "http://lobid.org/resources/HT013026834#!",
   "title" : "Mainz",
   "otherTitleInformation" : [ "Programm" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2163340-X",
   "dnbId" : "026537966",
   "deprecatedUri" : "http://lobid.org/resources/HT014176012#!",
+  "hbzId" : "HT014176012",
   "title" : "Nordrhein-Westfälische Bibliographie",
   "otherTitleInformation" : [ "Regionale Literaturdokumentation ab Berichtsjahr  ..." ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1183389769" ],
   "zdbId" : "2163340-X",
   "dnbId" : "026537966",
+  "deprecatedUri" : "http://lobid.org/resources/HT014176012#!",
   "title" : "Nordrhein-Westfälische Bibliographie",
   "otherTitleInformation" : [ "Regionale Literaturdokumentation ab Berichtsjahr  ..." ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2189310-X",
   "dnbId" : "027510077",
   "deprecatedUri" : "http://lobid.org/resources/HT014388022#!",
+  "hbzId" : "HT014388022",
   "title" : "Blick aktuell, Vallendar : Heimatzeitung für die Verbandsgemeinde Vallendar",
   "alternativeTitle" : [ "Die Heimatzeitung", "Heimatzeitung für die Verbandsgemeinde Vallendar" ],
   "otherTitleInformation" : [ "die Heimatzeitung" ],

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "724776703" ],
   "zdbId" : "2189310-X",
   "dnbId" : "027510077",
+  "deprecatedUri" : "http://lobid.org/resources/HT014388022#!",
   "title" : "Blick aktuell, Vallendar : Heimatzeitung für die Verbandsgemeinde Vallendar",
   "alternativeTitle" : [ "Die Heimatzeitung", "Heimatzeitung für die Verbandsgemeinde Vallendar" ],
   "otherTitleInformation" : [ "die Heimatzeitung" ],

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2581964-1",
   "dnbId" : "1008326801",
   "deprecatedUri" : "http://lobid.org/resources/HT016604323#!",
+  "hbzId" : "HT016604323",
   "title" : "Bericht der Beschwerdekommission",
   "alternativeTitle" : [ "LWL - für die Menschen. Für Westfalen-Lippe" ],
   "otherTitleInformation" : [ "für das Jahr ..." ],

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "724687131" ],
   "zdbId" : "2581964-1",
   "dnbId" : "1008326801",
+  "deprecatedUri" : "http://lobid.org/resources/HT016604323#!",
   "title" : "Bericht der Beschwerdekommission",
   "alternativeTitle" : [ "LWL - für die Menschen. Für Westfalen-Lippe" ],
   "otherTitleInformation" : [ "für das Jahr ..." ],

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "2594002-8",
   "dnbId" : "1009982311",
   "deprecatedUri" : "http://lobid.org/resources/HT016709661#!",
+  "hbzId" : "HT016709661",
   "title" : "Wohnungsmarktbericht",
   "otherTitleInformation" : [ "Fortschreibung mit Stand ..." ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1184284280" ],
   "zdbId" : "2594002-8",
   "dnbId" : "1009982311",
+  "deprecatedUri" : "http://lobid.org/resources/HT016709661#!",
   "title" : "Wohnungsmarktbericht",
   "otherTitleInformation" : [ "Fortschreibung mit Stand ..." ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1368849286" ],
   "zdbId" : "2685248-2",
   "dnbId" : "1026654807",
+  "deprecatedUri" : "http://lobid.org/resources/HT017411546#!",
   "title" : "Westfälische Bibliographie zur Geschichte, Landeskunde und Volkskunde",
   "alternativeTitle" : [ "Veröffentlichungen der Historischen Kommission für Westfalen / Westfälische Bibliographie zur Geschichte, Landeskunde und Volkskunde" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "2685248-2",
   "dnbId" : "1026654807",
   "deprecatedUri" : "http://lobid.org/resources/HT017411546#!",
+  "hbzId" : "HT017411546",
   "title" : "Westfälische Bibliographie zur Geschichte, Landeskunde und Volkskunde",
   "alternativeTitle" : [ "Veröffentlichungen der Historischen Kommission für Westfalen / Westfälische Bibliographie zur Geschichte, Landeskunde und Volkskunde" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2717847-X",
   "dnbId" : "1035221519",
   "deprecatedUri" : "http://lobid.org/resources/HT017655416#!",
+  "hbzId" : "HT017655416",
   "title" : "The Geneva gazette",
   "alternativeTitle" : [ "Early American newspapers / The Geneva gazette" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1368511354" ],
   "zdbId" : "2717847-X",
   "dnbId" : "1035221519",
+  "deprecatedUri" : "http://lobid.org/resources/HT017655416#!",
   "title" : "The Geneva gazette",
   "alternativeTitle" : [ "Early American newspapers / The Geneva gazette" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2719150-3",
   "dnbId" : "103553455X",
   "deprecatedUri" : "http://lobid.org/resources/HT017664407#!",
+  "hbzId" : "HT017664407",
   "title" : "Aegyptische Nachrichten",
   "publication" : [ {
     "publicationHistory" : "1912,Jan.-Dez.; mehr nicht digitalisiert",

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1368578470" ],
   "zdbId" : "2719150-3",
   "dnbId" : "103553455X",
+  "deprecatedUri" : "http://lobid.org/resources/HT017664407#!",
   "title" : "Aegyptische Nachrichten",
   "publication" : [ {
     "publicationHistory" : "1912,Jan.-Dez.; mehr nicht digitalisiert",

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -6,6 +6,7 @@
   "zdbId" : "2842926-6",
   "dnbId" : "1080276114",
   "deprecatedUri" : "http://lobid.org/resources/HT018839495#!",
+  "hbzId" : "HT018839495",
   "title" : "Classics in linguistics",
   "publication" : [ {
     "publicationHistory" : "1-",

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1368988510" ],
   "zdbId" : "2842926-6",
   "dnbId" : "1080276114",
+  "deprecatedUri" : "http://lobid.org/resources/HT018839495#!",
   "title" : "Classics in linguistics",
   "publication" : [ {
     "publicationHistory" : "1-",

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -5,6 +5,7 @@
   "zdbId" : "2872005-2",
   "dnbId" : "1116734109",
   "deprecatedUri" : "http://lobid.org/resources/HT019128882#!",
+  "hbzId" : "HT019128882",
   "title" : "Das Lied von Eis und Feuer",
   "publication" : [ {
     "publicationHistory" : "Band 1, Heft 1 (2016)-Band 10, Heft 19 (2019) = Ausgabe 1-Ausgabe 46 ; damit Erscheinen eingestellt",

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "962081299" ],
   "zdbId" : "2872005-2",
   "dnbId" : "1116734109",
+  "deprecatedUri" : "http://lobid.org/resources/HT019128882#!",
   "title" : "Das Lied von Eis und Feuer",
   "publication" : [ {
     "publicationHistory" : "Band 1, Heft 1 (2016)-Band 10, Heft 19 (2019) = Ausgabe 1-Ausgabe 46 ; damit Erscheinen eingestellt",

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -6,6 +6,7 @@
   "dnbId" : "011156414",
   "zdbId" : "202777-X",
   "deprecatedUri" : "http://lobid.org/resources/HT002212588#!",
+  "hbzId" : "HT002212588",
   "title" : "Wirtschaft & Erziehung",
   "alternativeTitle" : [ "Wirtschaft und Erziehung", "Organ für kaufmännisches Bildungswesen", "Monatsschrift des Bundesverbandes der Lehrerinnen und Lehrer an Wirtschaftsschulen (VLW) e.V.", "Wirtschaft und Erziehung ( Hauptsacht. bis 64.2012,6 )" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "643524510" ],
   "dnbId" : "011156414",
   "zdbId" : "202777-X",
+  "deprecatedUri" : "http://lobid.org/resources/HT002212588#!",
   "title" : "Wirtschaft & Erziehung",
   "alternativeTitle" : [ "Wirtschaft und Erziehung", "Organ für kaufmännisches Bildungswesen", "Monatsschrift des Bundesverbandes der Lehrerinnen und Lehrer an Wirtschaftsschulen (VLW) e.V.", "Wirtschaft und Erziehung ( Hauptsacht. bis 64.2012,6 )" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "60625631" ],
   "zdbId" : "2598795-1",
   "deprecatedUri" : "http://lobid.org/resources/HT016745965#!",
+  "hbzId" : "HT016745965",
   "title" : "ABI-Technik",
   "alternativeTitle" : [ "A.B.I.-Technik" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -4,6 +4,7 @@
   "issn" : [ "21914664" ],
   "oclcNumber" : [ "60625631" ],
   "zdbId" : "2598795-1",
+  "deprecatedUri" : "http://lobid.org/resources/HT016745965#!",
   "title" : "ABI-Technik",
   "alternativeTitle" : [ "A.B.I.-Technik" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "864921933" ],
   "dnbId" : "1045213144",
   "zdbId" : "2745694-8",
+  "deprecatedUri" : "http://lobid.org/resources/HT018103691#!",
   "title" : "Kirche weltweit",
   "alternativeTitle" : [ "Kirche weltweit", "Mitteilungsblatt des Leipziger Missionswerkes der Evangelisch-Lutherischen Landeskirchen Mecklenburgs, Sachsens, Thüringens" ],
   "otherTitleInformation" : [ "Mitteilungsblatt des Leipziger Missionswerkes der Evangelisch-Lutherischen Landeskirche Sachsens und der Evangelischen Kirche in Mitteldeutschland" ],

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -6,6 +6,7 @@
   "dnbId" : "1045213144",
   "zdbId" : "2745694-8",
   "deprecatedUri" : "http://lobid.org/resources/HT018103691#!",
+  "hbzId" : "HT018103691",
   "title" : "Kirche weltweit",
   "alternativeTitle" : [ "Kirche weltweit", "Mitteilungsblatt des Leipziger Missionswerkes der Evangelisch-Lutherischen Landeskirchen Mecklenburgs, Sachsens, Thüringens" ],
   "otherTitleInformation" : [ "Mitteilungsblatt des Leipziger Missionswerkes der Evangelisch-Lutherischen Landeskirche Sachsens und der Evangelischen Kirche in Mitteldeutschland" ],

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -5,6 +5,7 @@
   "oclcNumber" : [ "1184493801", "802544307" ],
   "dnbId" : "1023896001",
   "zdbId" : "2669828-6",
+  "deprecatedUri" : "http://lobid.org/resources/HT017306644#!",
   "title" : "Rheinform",
   "alternativeTitle" : [ "Informationen für die rheinischen Museen" ],
   "otherTitleInformation" : [ "Informationen für die rheinischen Museen" ],

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -6,6 +6,7 @@
   "dnbId" : "1023896001",
   "zdbId" : "2669828-6",
   "deprecatedUri" : "http://lobid.org/resources/HT017306644#!",
+  "hbzId" : "HT017306644",
   "title" : "Rheinform",
   "alternativeTitle" : [ "Informationen für die rheinischen Museen" ],
   "otherTitleInformation" : [ "Informationen für die rheinischen Museen" ],

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -4,6 +4,7 @@
   "oclcNumber" : [ "1184295229", "642992354" ],
   "dnbId" : "995821623",
   "zdbId" : "2508993-6",
+  "deprecatedUri" : "http://lobid.org/resources/HT016024273#!",
   "title" : "BUW-Output",
   "alternativeTitle" : [ "BUW-Output", "BUW-Output", "Output" ],
   "otherTitleInformation" : [ "Forschungsmagazin = Research bulletin / Universität Wuppertal ; hrsg. im Auftrag des Rektorates" ],

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -5,6 +5,7 @@
   "dnbId" : "995821623",
   "zdbId" : "2508993-6",
   "deprecatedUri" : "http://lobid.org/resources/HT016024273#!",
+  "hbzId" : "HT016024273",
   "title" : "BUW-Output",
   "alternativeTitle" : [ "BUW-Output", "BUW-Output", "Output" ],
   "otherTitleInformation" : [ "Forschungsmagazin = Research bulletin / Universität Wuppertal ; hrsg. im Auftrag des Rektorates" ],

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -4,6 +4,7 @@
   "issn" : [ "27318087" ],
   "zdbId" : "3154709-6",
   "dnbId" : "1284122735",
+  "deprecatedUri" : "http://lobid.org/resources/HT021793595#!",
   "title" : "Smart grids and sustainable energy",
   "alternativeTitle" : [ "Technology and economics of smart grids and sustainable energy ( Abweichender Titel in Volume 8, issue 1 (March 2023) teils )" ],
   "publication" : [ {

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -5,6 +5,7 @@
   "zdbId" : "3154709-6",
   "dnbId" : "1284122735",
   "deprecatedUri" : "http://lobid.org/resources/HT021793595#!",
+  "hbzId" : "HT021793595",
   "title" : "Smart grids and sustainable energy",
   "alternativeTitle" : [ "Technology and economics of smart grids and sustainable energy ( Abweichender Titel in Volume 8, issue 1 (March 2023) teils )" ],
   "publication" : [ {


### PR DESCRIPTION
In ALMA all zdb records loose their hbzId (aka HT Nummer). To keep at least their old record Id as deprecatedUri . I created a mapping file from the last aleph transformation and map the zdbId to the old hbzId. With this I create the deprecatedUri element.

The lookup holds 2.000.000 + key value pairs. I hope this is not to heavy on the performance.