### PR TITLE
Use helper elements when creating HOL and MBD holdings

### DIFF
--- a/src/main/resources/alma/fix/item.fix
+++ b/src/main/resources/alma/fix/item.fix
@@ -1,5 +1,5 @@
 set_array("hasItem[]")
-
+set_array("@ITM-H") # Helper element for creating Holding from HOL ("PhysikalischerTitel")
 do list(path:"ITM  ", "var": "$i")
   add_field( "hasItem[].$append.test","")
   add_field("hasItem[].$last.label", "lobid Bestandsressource")
@@ -8,6 +8,7 @@ do list(path:"ITM  ", "var": "$i")
   unless exists("hasItem[].$last.callNumber")
     copy_field("$i.n", "hasItem[].$last.callNumber")
   end
+  copy_field("$i.H", "@ITM-H.$append")
   copy_field("$i.b", "hasItem[].$last.serialNumber")
   paste("hasItem[].$last.currentLocation", "$i.w", "~/", "$i.x")
   copy_field("$i.w","$i.@sublibraryIsil")
@@ -35,71 +36,47 @@ do list(path:"ITM  ", "var": "$i")
   paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
 end
 
+set_array("@HOL-M_POR-M") # Helper element for creating Holding from MBD ("NurTitel")
 do list(path: "HOL  ", "var": "$i")
-  unless in("$i.8", "ITM  .H")
-    unless in("$i.8", "ITM  .*.H")
-      add_field( "hasItem[].$append.test","")
-      add_field("hasItem[].$last.label", "lobid Bestandsressource")
-      set_array("hasItem[].$last.type[]", "Item","PhysikalischerTitel")
-      do list(path:"H52??", "var": "$H52")
-        if in("$i.8", "$H52.8")
-          paste("hasItem[].$last.currentLocation", "$H52.b", "~/", "$H52.c")
-          copy_field("$H52.h", "hasItem[].$last.callNumber")
-          copy_field("$H52.b","$i.@sublibraryIsil")
-          lookup("$i.@sublibraryIsil", "hbzowner2sigel",delete:"true")
-          lookup("$i.@sublibraryIsil", "sigel2isilMap",delete:"true") 
-          lookup("$i.@sublibraryIsil", "isilRedirect")       
-          # following fix checks for sublibrary codes and if they map to provided sublocation Isil
-          unless exists("$i.@sublibraryIsil")
-            paste("$i.@sublibraryIsil","$i.M","~+","$H52.b",join_char:"")
-            lookup("$i.@sublibraryIsil", "sublibraryIsil",delete:"true")
-          end
-        end
-      end
-      if exists("$i.@sublibraryIsil")
-        copy_field("$i.@sublibraryIsil", "hasItem[].$last.heldBy.id")
-      # if no mapping for a sublocation code is provided or no sublocation code exists ($i.w) the main library ISIL is used.
-      else
-        copy_field("$i.8", "hasItem[].$last.heldBy.id")
-        replace_all("hasItem[].$last.heldBy.id",".*(\\d{4})$","$1")
-        lookup("hasItem[].$last.heldBy.id", "alma-institution-code-to-isil")
-      end
-      copy_field("hasItem[].$last.heldBy.id","hasItem[].$last.heldBy.isil")
-      prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
-      append("hasItem[].$last.heldBy.id","#!")
-      copy_field("hasItem[].$last.heldBy.id", "hasItem[].$last.heldBy.label")
-      # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-      paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:","$i.8","~#!", join_char: "")
-    end
-  end
-end
-
-do list(path: "MBD  ", "var": "$i")
-  unless any_match("$i.M","49HBZ_NETWORK")
-    unless in("$i.M", "HOL  .M")
-      unless in("$i.M", "HOL  .*.M")
-        unless in("$i.M", "POR  .M")
-          unless in("$i.M", "POR  .*.M")
-            add_field( "hasItem[].$append.test","")
-            add_field("hasItem[].$last.label", "lobid Bestandsressource")
-            set_array("hasItem[].$last.type[]", "Item","NurTitel")
-            copy_field("$i.i", "hasItem[].$last.heldBy.id")
-            replace_all("hasItem[].$last.heldBy.id",".*(\\d{4})$","$1")
-            lookup("hasItem[].$last.heldBy.id", "alma-institution-code-to-isil")
-            copy_field("hasItem[].$last.heldBy.id","hasItem[].$last.heldBy.isil")
-            prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
-            append("hasItem[].$last.heldBy.id","#!")
-            copy_field("hasItem[].$last.heldBy.id", "hasItem[].$last.heldBy.label")
-            # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
-            paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.i", "~#!", join_char: "")
-          end
+  copy_field("$i.M","@HOL-M_POR-M.$append")
+  unless in("$i.8", "@ITM-H") # Checks if there is no corresponding ITM-Field
+    add_field( "hasItem[].$append.test","")
+    add_field("hasItem[].$last.label", "lobid Bestandsressource")
+    set_array("hasItem[].$last.type[]", "Item","PhysikalischerTitel")
+    do list(path:"H52??", "var": "$H52")
+      if in("$i.8", "$H52.8")
+        paste("hasItem[].$last.currentLocation", "$H52.b", "~/", "$H52.c")
+        copy_field("$H52.h", "hasItem[].$last.callNumber")
+        copy_field("$H52.b","$i.@sublibraryIsil")
+        lookup("$i.@sublibraryIsil", "hbzowner2sigel",delete:"true")
+        lookup("$i.@sublibraryIsil", "sigel2isilMap",delete:"true") 
+        lookup("$i.@sublibraryIsil", "isilRedirect")       
+        # following fix checks for sublibrary codes and if they map to provided sublocation Isil
+        unless exists("$i.@sublibraryIsil")
+          paste("$i.@sublibraryIsil","$i.M","~+","$H52.b",join_char:"")
+          lookup("$i.@sublibraryIsil", "sublibraryIsil",delete:"true")
         end
       end
     end
+    if exists("$i.@sublibraryIsil")
+      copy_field("$i.@sublibraryIsil", "hasItem[].$last.heldBy.id")
+    # if no mapping for a sublocation code is provided or no sublocation code exists ($i.w) the main library ISIL is used.
+    else
+      copy_field("$i.8", "hasItem[].$last.heldBy.id")
+      replace_all("hasItem[].$last.heldBy.id",".*(\\d{4})$","$1")
+      lookup("hasItem[].$last.heldBy.id", "alma-institution-code-to-isil")
+    end
+    copy_field("hasItem[].$last.heldBy.id","hasItem[].$last.heldBy.isil")
+    prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
+    append("hasItem[].$last.heldBy.id","#!")
+    copy_field("hasItem[].$last.heldBy.id", "hasItem[].$last.heldBy.label")
+    # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
+    paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:","$i.8","~#!", join_char: "")
   end
 end
 
 do list(path:"POR  ", "var": "$i")
+  copy_field("$i.M","@HOL-M_POR-M.$append")
 # entity for every POR  .a without POR  .A
   unless any_match("$i.a",".*6441$") # filter out hbz
     add_field( "hasItem[].$append.test","")
@@ -141,6 +118,25 @@ do list(path:"POR  ", "var": "$i")
       copy_field("hasItem[].$last.heldBy.id", "hasItem[].$last.heldBy.label")
       # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
       paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.a","~#!", join_char: "")
+    end
+  end
+end
+
+do list(path: "MBD  ", "var": "$i")
+  unless any_match("$i.M","49HBZ_NETWORK")
+    unless in("$i.M", "@HOL-M_POR-M") # Checks if there is no corresponding HOL or POR-Field
+      add_field( "hasItem[].$append.test","")
+      add_field("hasItem[].$last.label", "lobid Bestandsressource")
+      set_array("hasItem[].$last.type[]", "Item","NurTitel")
+      copy_field("$i.i", "hasItem[].$last.heldBy.id")
+      replace_all("hasItem[].$last.heldBy.id",".*(\\d{4})$","$1")
+      lookup("hasItem[].$last.heldBy.id", "alma-institution-code-to-isil")
+      copy_field("hasItem[].$last.heldBy.id","hasItem[].$last.heldBy.isil")
+      prepend("hasItem[].$last.heldBy.id", "http://lobid.org/organisations/")
+      append("hasItem[].$last.heldBy.id","#!")
+      copy_field("hasItem[].$last.heldBy.id", "hasItem[].$last.heldBy.label")
+      # item id is constructed "http://lobid.org/items/[almaMmsId of the record]:[isil of the Owner]:[almaMmsId of the holding]#!"
+      paste("hasItem[].$last.id", "~http://lobid.org/items/","almaMmsId", "~:", "hasItem[].$last.heldBy.isil","~:", "$i.i", "~#!", join_char: "")
     end
   end
 end

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -262,33 +262,6 @@
     },
     "id" : "http://lobid.org/items/990197293880206441:DE-38:22153644180007147#!"
   }, {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "NurTitel" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-832#!",
-      "isil" : "DE-832",
-      "label" : "Technische Hochschule Köln, Hochschulbibliothek"
-    },
-    "id" : "http://lobid.org/items/990197293880206441:DE-832:9933949907504#!"
-  }, {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "NurTitel" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-1042#!",
-      "isil" : "DE-1042",
-      "label" : "Hochschule Trier, Umwelt-Campus Birkenfeld, Bibliothek"
-    },
-    "id" : "http://lobid.org/items/990197293880206441:DE-1042:9914702207821#!"
-  }, {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "NurTitel" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-361#!",
-      "isil" : "DE-361",
-      "label" : "Universitätsbibliothek Bielefeld"
-    },
-    "id" : "http://lobid.org/items/990197293880206441:DE-361:991009118459706442#!"
-  }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
     "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FDO/openurl?u.ignore_date_coverage=true&portfolio_pid=53717454420006441&Force_direct=true",
@@ -497,6 +470,33 @@
       "label" : "Universitätsbibliothek der RWTH Aachen"
     },
     "id" : "http://lobid.org/items/990197293880206441:DE-82:53717454420006441#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-832#!",
+      "isil" : "DE-832",
+      "label" : "Technische Hochschule Köln, Hochschulbibliothek"
+    },
+    "id" : "http://lobid.org/items/990197293880206441:DE-832:9933949907504#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-1042#!",
+      "isil" : "DE-1042",
+      "label" : "Hochschule Trier, Umwelt-Campus Birkenfeld, Bibliothek"
+    },
+    "id" : "http://lobid.org/items/990197293880206441:DE-1042:9914702207821#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "isil" : "DE-361",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "id" : "http://lobid.org/items/990197293880206441:DE-361:991009118459706442#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -129,6 +129,17 @@
   } ],
   "subjectslabels" : [ "Sonderpädagogik", "Zeitschrift" ],
   "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53155629910006447&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990013137900206447",
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "isil" : "DE-468",
+      "label" : "Universitätsbibliothek Wuppertal"
+    },
+    "id" : "http://lobid.org/items/990199611280206441:DE-468:53155629910006447#!"
+  }, {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
     "heldBy" : {
@@ -146,17 +157,6 @@
       "label" : "Universitätsbibliothek Siegen"
     },
     "id" : "http://lobid.org/items/990199611280206441:DE-467:990195668690106462#!"
-  }, {
-    "type" : [ "Item", "DigitalDocument" ],
-    "label" : "Electronic Portfolio",
-    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53155629910006447&Force_direct=true",
-    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990013137900206447",
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-468#!",
-      "isil" : "DE-468",
-      "label" : "Universitätsbibliothek Wuppertal"
-    },
-    "id" : "http://lobid.org/items/990199611280206441:DE-468:53155629910006447#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -155,15 +155,6 @@
     },
     "id" : "http://lobid.org/items/99371314897806441:DE-Kn41:2225159930007146#!"
   }, {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "NurTitel" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-832#!",
-      "isil" : "DE-832",
-      "label" : "Technische Hochschule Köln, Hochschulbibliothek"
-    },
-    "id" : "http://lobid.org/items/99371314897806441:DE-832:9975224207504#!"
-  }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
     "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HBI/openurl?u.ignore_date_coverage=true&portfolio_pid=53769526120006441&Force_direct=true",
@@ -383,6 +374,15 @@
       "label" : "Universitätsbibliothek der Fernuniversität"
     },
     "id" : "http://lobid.org/items/99371314897806441:DE-708:53133004370006464#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-832#!",
+      "isil" : "DE-832",
+      "label" : "Technische Hochschule Köln, Hochschulbibliothek"
+    },
+    "id" : "http://lobid.org/items/99371314897806441:DE-832:9975224207504#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",

--- a/src/test/resources/alma-fix/99371791018506441.json
+++ b/src/test/resources/alma-fix/99371791018506441.json
@@ -147,15 +147,6 @@
     },
     "id" : "http://lobid.org/items/99371791018506441:DE-Kn41:2222985600007146#!"
   }, {
-    "label" : "lobid Bestandsressource",
-    "type" : [ "Item", "NurTitel" ],
-    "heldBy" : {
-      "id" : "http://lobid.org/organisations/DE-832#!",
-      "isil" : "DE-832",
-      "label" : "Technische Hochschule Köln, Hochschulbibliothek"
-    },
-    "id" : "http://lobid.org/items/99371791018506441:DE-832:9967971407504#!"
-  }, {
     "type" : [ "Item", "DigitalDocument" ],
     "label" : "Electronic Portfolio",
     "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53800421430006441&Force_direct=true",
@@ -320,6 +311,15 @@
       "label" : "FH Münster, Hochschulbibliothek"
     },
     "id" : "http://lobid.org/items/99371791018506441:DE-836:53800421430006441#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "heldBy" : {
+      "id" : "http://lobid.org/organisations/DE-832#!",
+      "isil" : "DE-832",
+      "label" : "Technische Hochschule Köln, Hochschulbibliothek"
+    },
+    "id" : "http://lobid.org/items/99371791018506441:DE-832:9967971407504#!"
   } ],
   "medium" : [ {
     "label" : "Datenträger",


### PR DESCRIPTION
Before item.fix checked every ITM Field before creating a HOL-Holding ("PhysikalischerTitel") and checked every POR and HOL before creating a MBD-Holding ("NurTitel").

Now it is using helper elements `"@ITM-H"` and `"@HOL-M_POR-M"`. It makes the transformation ~~a lot~~ faster by reducing the in-conditionals with wildcards.