### PR TITLE
1830-publicationImprovement

### DIFF
--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -329,7 +329,6 @@ end
 do put_macro("publication")
   do list(path:"$[field]", "var":"$i")
     add_field("publication[].$append.test","")
-    copy_field("362??.a","publication[].$last.publicationHistory")
     do list(path: "$i.c", "var":"$j")
       replace_all("$j", "\\[|\\]|ca. |c ", "")
       unless exists("publication[].$last.startDate")
@@ -343,30 +342,11 @@ do put_macro("publication")
         end
       end
     end
-    # TODO is there a way to distinguish PublicationEvent and SecondaryPublicationEvent?
     set_array("publication[].$last.type[]","PublicationEvent")
     set_array("publication[].$last.location[]")
     copy_field("$i.a", "publication[].$last.location[].$append")
     set_array("publication[].$last.publishedBy[]")
     copy_field("$i.b", "publication[].$last.publishedBy[].$append")
-    set_array("publication[].$last.frequency[]")
-    if any_match("leader","^.{6}(a[bis]|m[bis]).*$") # checks if continous ressource
-      unless any_match("008","^.{18}[#\\| u].*$") # filters out not matching values and also the value unknown
-        copy_field("008","publication[].$last.frequency[].$append.id")
-        replace_all("publication[].$last.frequency[].$last.id", "^.{18}(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
-      end
-    elsif any_match("006","^s.*$")
-      do list(path: "006", "var":"$z")
-        if any_match("$z","^s.*$")
-          unless any_match("$z","^.[#\\| u].*$")
-            copy_field("$z","publication[].$last.frequency[].$append.id")
-            replace_all("publication[].$last.frequency[].$last.id", "^.(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
-          end
-        end
-      end
-    end
-    set_array("publication[].$last.note[]")
-    copy_field("515??.a","publication[].$last.note[].$append")
     if exists("$i.6")
       copy_field("$i.6","$i.linkageTest")
       do list(path:"880??","var":"$880")

--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -325,3 +325,77 @@ do put_macro("subjectLabel")
   copy_field("$i.v","subject[].$last.label.$append")
   join_field("subject[].$last.label"," / ")
 end
+
+do put_macro("publication")
+  do list(path:"$[field]", "var":"$i")
+    add_field("publication[].$append.test","")
+    copy_field("362??.a","publication[].$last.publicationHistory")
+    do list(path: "$i.c", "var":"$j")
+      replace_all("$j", "\\[|\\]|ca. |c ", "")
+      unless exists("publication[].$last.startDate")
+        if any_match("$j",".*?([01]\\d{3}|20\\d{2}).*")
+          paste("publication[].$last.startDate", "$j")
+        end
+      end
+      unless exists("publication[].$last.endDate")
+        if any_match("$j",".*-[ ]?([01]\\d{3}|20\\d{2})$")
+          paste("publication[].$last.endDate", "$j")
+        end
+      end
+    end
+    # TODO is there a way to distinguish PublicationEvent and SecondaryPublicationEvent?
+    set_array("publication[].$last.type[]","PublicationEvent")
+    set_array("publication[].$last.location[]")
+    copy_field("$i.a", "publication[].$last.location[].$append")
+    set_array("publication[].$last.publishedBy[]")
+    copy_field("$i.b", "publication[].$last.publishedBy[].$append")
+    set_array("publication[].$last.frequency[]")
+    if any_match("leader","^.{6}(a[bis]|m[bis]).*$") # checks if continous ressource
+      unless any_match("008","^.{18}[#\\| u].*$") # filters out not matching values and also the value unknown
+        copy_field("008","publication[].$last.frequency[].$append.id")
+        replace_all("publication[].$last.frequency[].$last.id", "^.{18}(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
+      end
+    elsif any_match("006","^s.*$")
+      do list(path: "006", "var":"$z")
+        if any_match("$z","^s.*$")
+          unless any_match("$z","^.[#\\| u].*$")
+            copy_field("$z","publication[].$last.frequency[].$append.id")
+            replace_all("publication[].$last.frequency[].$last.id", "^.(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
+          end
+        end
+      end
+    end
+    set_array("publication[].$last.note[]")
+    copy_field("515??.a","publication[].$last.note[].$append")
+    if exists("$i.6")
+      copy_field("$i.6","$i.linkageTest")
+      do list(path:"880??","var":"$880")
+        if in ("$i.linkageTest","$880.linkageTest")
+          if in ("$880.@script.id","alternateGraphicRepresentation[].*.script.id")   
+            do list(path:"alternateGraphicRepresentation[]","var":"$AGR")
+              if in ("$880.@script.id","$AGR.script.id")
+                unless exists("$AGR.record.publication[]")
+                  set_array("$AGR.record.publication[]")
+                end                
+                add_field ("$AGR.record.publication[].$append.dummi","")       
+                set_array("$AGR.record.publication[].$last.location[]")        
+                copy_field("$880.a", "$AGR.record.publication[].$last.location[].$append")
+                set_array("$AGR.record.publication[].$last.publishedBy[]")
+                copy_field("$880.b", "$AGR.record.publication[].$last.publishedBy[].$append")
+              end
+            end
+          else    
+            copy_field("$880.@script.id","alternateGraphicRepresentation[].$append.script.id")
+            copy_field("$880.@script.label","alternateGraphicRepresentation[].$last.script.label")
+            set_array("alternateGraphicRepresentation[].$last.publication[]")
+            add_field ("alternateGraphicRepresentation[].$last.publication[].$append.dummi","")       
+            set_array("alternateGraphicRepresentation[].$last.publication[].$last.location[]")        
+            copy_field("$880.a", "alternateGraphicRepresentation[].$last.publication[].$last.location[].$append")
+            set_array("alternateGraphicRepresentation[].$last.publication[].$last.publishedBy[]")
+            copy_field("$880.b", "alternateGraphicRepresentation[].$last.publication[].$last.publishedBy[].$append")
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -285,6 +285,22 @@ if exists("publication[].$first")
       end
     end
   end
+  unless exists("publication[].$first.startDate[]")
+    if any_match("008","^.{6}[brestikm](\\d{4}).*$")
+      copy_field("008","@008startDate")
+      replace_all("@008startDate","^.{7}(\\d{4}).*$","$1")
+      copy_field("@008startDate","publication[].$first.startDate")
+    end
+  end
+  unless exists("publication[].$first.endDate[]")
+    if any_match("008","^.{6}[km]\\d{4}(\\d{4}).*$")
+      copy_field("008","@008endDate")
+      replace_all("@008endDate","^.{11}(\\d{4}).*$","$1")
+      unless any_equal("@008endDate","9999")
+        copy_field("@008endDate","publication[].$first.endDate")
+      end
+    end
+  end
 end
 
 

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -224,16 +224,41 @@ end
 
 set_array("publication[]")
 if exists("264[ 23][ 1]")
-  call_macro("publication",field:"264[ 23][ 1]")
+  call_macro("publication",field:"2643[ 1]") # 3 - Current/Latest
+  call_macro("publication",field:"2642[ 1]") # 2 - Intervening
+  call_macro("publication",field:"264 [ 1]") # # - Not applicable/No information provided/Earliest
 else
-  call_macro("publication",field:"260[ 23] ")
+  call_macro("publication",field:"2603[ 1]") # 3 - Current/Latest
+  call_macro("publication",field:"2602[ 1]") # 2 - Intervening
+  call_macro("publication",field:"260 [ 1]") # # - Not applicable/No information provided/Earliest
 end
 
-do list(path:"500  ", "var":"$i")
-  if any_match("$i.a", "^.*saṃ. \\d{4}=(\\d{4}).*Chr.*")
-    remove_field("publication[].$last.startDate")
-    copy_field("$i.a","publication[].$last.startDate")
-    replace_all("publication[].$last.startDate","^.*saṃ. \\d{4}=(\\d{4}).*Chr.*","$1")
+if exists("publication[].$first")
+  copy_field("362??.a","publication[].$first.publicationHistory")
+    set_array("publication[].$first.frequency[]")
+    if any_match("leader","^.{6}(a[bis]|m[bis]).*$") # checks if continous ressource
+      unless any_match("008","^.{18}[#\\| u].*$") # filters out not matching values and also the value unknown
+        copy_field("008","publication[].$first.frequency[].$append.id")
+        replace_all("publication[].$first.frequency[].$last.id", "^.{18}(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
+      end
+    elsif any_match("006","^s.*$")
+      do list(path: "006", "var":"$z")
+        if any_match("$z","^s.*$")
+          unless any_match("$z","^.[#\\| u].*$")
+            copy_field("$z","publication[].$first.frequency[].$append.id")
+            replace_all("publication[].$first.frequency[].$last.id", "^.(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
+          end
+        end
+      end
+    end
+    set_array("publication[].$first.note[]")
+    copy_field("515??.a","publication[].$first.note[].$append")
+  do list(path:"500  ", "var":"$i")
+    if any_match("$i.a", "^.*saṃ. \\d{4}=(\\d{4}).*Chr.*")
+      remove_field("publication[].$first.startDate")
+      copy_field("$i.a","publication[].$first.startDate")
+      replace_all("publication[].$first.startDate","^.*saṃ. \\d{4}=(\\d{4}).*Chr.*","$1")
+    end
   end
 end
 

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -221,6 +221,7 @@ end
 # 264 - Production, Publication, Distribution, Manufacture, and Copyright Notice (R) -  Subfield: $a (R), $b (R), $c  (R)
 # 008,18 for frequency
 # 515 - Numbering Peculiarities Note (R)
+# Prefer 264 over 260 since it can create duplicate info and 260 is discontinued in RDA.
 
 set_array("publication[]")
 if exists("264[ 23][ 1]")
@@ -232,6 +233,8 @@ else
   call_macro("publication",field:"2602[ 1]") # 2 - Intervening
   call_macro("publication",field:"260 [ 1]") # # - Not applicable/No information provided/Earliest
 end
+
+# Only add additional publication info to the first publication-object since it is the latest.
 
 if exists("publication[].$first")
   copy_field("362??.a","publication[].$first.publicationHistory")

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -263,6 +263,28 @@ if exists("publication[].$first")
       replace_all("publication[].$first.startDate","^.*saṃ. \\d{4}=(\\d{4}).*Chr.*","$1")
     end
   end
+  # Add fallbacks for missing publication dates and other publication info.
+  do list(path:"260[ 3][ 1]", "var":"$i")
+    do list(path: "$i.c", "var":"$j")
+      replace_all("$j", "\\[|\\]|ca. |c ", "")
+      unless exists("publication[].$first.startDate")
+        if any_match("$j",".*?([01]\\d{3}|20\\d{2}).*")
+          paste("publication[].$first.startDate", "$j")
+        end
+      end
+      unless exists("publication[].$first.endDate")
+        if any_match("$j",".*-[ ]?([01]\\d{3}|20\\d{2})$")
+          paste("publication[].$last.endDate", "$j")
+        end
+      end
+      unless exists("publication[].$first.location[].1")
+        copy_field("$i.a", "publication[].$first.location[].$append")
+      end
+      unless exists("publication[].$first.publishedBy[].1")
+        copy_field("$i.b", "publication[].$first.publishedBy[].$append")
+      end
+    end
+  end
 end
 
 

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -223,78 +223,7 @@ end
 # 515 - Numbering Peculiarities Note (R)
 
 set_array("publication[]")
-do list(path:"260[ 23] |264[ 23][ 1]", "var":"$i")
-  add_field("publication[].$append.test","")
-  copy_field("362??.a","publication[].$last.publicationHistory")
-  do list(path: "$i.c", "var":"$j")
-    replace_all("$j", "\\[|\\]|ca. |c ", "")
-    unless exists("publication[].$last.startDate")
-      if any_match("$j",".*?([01]\\d{3}|20\\d{2}).*")
-        paste("publication[].$last.startDate", "$j")
-      end
-    end
-    unless exists("publication[].$last.endDate")
-      if any_match("$j",".*-[ ]?([01]\\d{3}|20\\d{2})$")
-        paste("publication[].$last.endDate", "$j")
-      end
-    end
-  end
-  # TODO is there a way to distinguish PublicationEvent and SecondaryPublicationEvent?
-  set_array("publication[].$last.type[]","PublicationEvent")
-  set_array("publication[].$last.location[]")
-  copy_field("$i.a", "publication[].$last.location[].$append")
-  set_array("publication[].$last.publishedBy[]")
-  copy_field("$i.b", "publication[].$last.publishedBy[].$append")
-  set_array("publication[].$last.frequency[]")
-  if any_match("leader","^.{6}(a[bis]|m[bis]).*$") # checks if continous ressource
-    unless any_match("008","^.{18}[#\\| u].*$") # filters out not matching values and also the value unknown
-      copy_field("008","publication[].$last.frequency[].$append.id")
-      replace_all("publication[].$last.frequency[].$last.id", "^.{18}(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
-    end
-  elsif any_match("006","^s.*$")
-    do list(path: "006", "var":"$z")
-      if any_match("$z","^s.*$")
-        unless any_match("$z","^.[#\\| u].*$")
-          copy_field("$z","publication[].$last.frequency[].$append.id")
-          replace_all("publication[].$last.frequency[].$last.id", "^.(.).*$", "http://marc21rdf.info/terms/continuingfre#$1")
-        end
-      end
-    end
-  end
-  set_array("publication[].$last.note[]")
-  copy_field("515??.a","publication[].$last.note[].$append")
-  if exists("$i.6")
-    copy_field("$i.6","$i.linkageTest")
-    do list(path:"880??","var":"$880")
-      if in ("$i.linkageTest","$880.linkageTest")
-        if in ("$880.@script.id","alternateGraphicRepresentation[].*.script.id")   
-          do list(path:"alternateGraphicRepresentation[]","var":"$AGR")
-            if in ("$880.@script.id","$AGR.script.id")
-              unless exists("$AGR.record.publication[]")
-                set_array("$AGR.record.publication[]")
-              end                
-              add_field ("$AGR.record.publication[].$append.dummi","")       
-              set_array("$AGR.record.publication[].$last.location[]")        
-              copy_field("$880.a", "$AGR.record.publication[].$last.location[].$append")
-              set_array("$AGR.record.publication[].$last.publishedBy[]")
-              copy_field("$880.b", "$AGR.record.publication[].$last.publishedBy[].$append")
-            end
-          end
-        else    
-          copy_field("$880.@script.id","alternateGraphicRepresentation[].$append.script.id")
-          copy_field("$880.@script.label","alternateGraphicRepresentation[].$last.script.label")
-          set_array("alternateGraphicRepresentation[].$last.publication[]")
-          add_field ("alternateGraphicRepresentation[].$last.publication[].$append.dummi","")       
-          set_array("alternateGraphicRepresentation[].$last.publication[].$last.location[]")        
-          copy_field("$880.a", "alternateGraphicRepresentation[].$last.publication[].$last.location[].$append")
-          set_array("alternateGraphicRepresentation[].$last.publication[].$last.publishedBy[]")
-          copy_field("$880.b", "alternateGraphicRepresentation[].$last.publication[].$last.publishedBy[].$append")
-        end
-      end
-    end
-  end
-end
-
+call_macro("publication",field:"260[ 23] |264[ 23][ 1]")
 
 do list(path:"500  ", "var":"$i")
   if any_match("$i.a", "^.*saṃ. \\d{4}=(\\d{4}).*Chr.*")

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -223,7 +223,11 @@ end
 # 515 - Numbering Peculiarities Note (R)
 
 set_array("publication[]")
-call_macro("publication",field:"260[ 23] |264[ 23][ 1]")
+if exists("264[ 23][ 1]")
+  call_macro("publication",field:"264[ 23][ 1]")
+else
+  call_macro("publication",field:"260[ 23] ")
+end
 
 do list(path:"500  ", "var":"$i")
   if any_match("$i.a", "^.*saṃ. \\d{4}=(\\d{4}).*Chr.*")

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -6,10 +6,10 @@
   "oclcNumber" : [ "183288969" ],
   "title" : "Zweckverband Naturpark Kottenforst-Ville",
   "publication" : [ {
-    "publicationHistory" : "1.1985 - 4.2001; damit Ersch. eingest.",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Köln [i.e.] Pulheim" ],
-    "publishedBy" : [ "Rheinland-Verl." ]
+    "publishedBy" : [ "Rheinland-Verl." ],
+    "publicationHistory" : "1.1985 - 4.2001; damit Ersch. eingest."
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990052965140206441",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -9,25 +9,20 @@
   "hbzId" : "HT000312236",
   "title" : "Physik in der Schule",
   "publication" : [ {
-    "publicationHistory" : "2.1964,7 - 38.2000",
     "startDate" : "1964",
     "endDate" : "2000",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin" ],
     "publishedBy" : [ "Pädagogischer Zeitschriftenverl." ],
+    "publicationHistory" : "2.1964,7 - 38.2000",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#m",
       "label" : "monatlich"
     } ]
   }, {
-    "publicationHistory" : "2.1964,7 - 38.2000",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin" ],
-    "publishedBy" : [ "Verl. Volk & Wissen" ],
-    "frequency" : [ {
-      "id" : "http://marc21rdf.info/terms/continuingfre#m",
-      "label" : "monatlich"
-    } ]
+    "publishedBy" : [ "Verl. Volk & Wissen" ]
   } ],
   "shortTitle" : [ "Phys. Sch." ],
   "describedBy" : {

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -11,12 +11,12 @@
   "alternativeTitle" : [ "Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord", "Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki", "Annual bulletin of transport statistics for Europe ( Hauptsacht. bis 44.1994 )", "Bulletin annuel de statistiques de transports européens ( Parallelsacht. bis 44.1994 )", "Ežegodnyj bjulleten' evropejskoj statistiki transporta ( Parallelsacht. bis 44.1994 )" ],
   "otherTitleInformation" : [ "= Bulletin annuel de statistiques des transports pour l'Europe et l'Amérique du Nord = Ežegodnyj bjulleten' statistiki transporta dlja Evropy i Severnoj Ameriki" ],
   "publication" : [ {
-    "publicationHistory" : "6.1954(1955) - 52.2004",
     "startDate" : "1955",
     "endDate" : "2004",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Genève [u.a.]" ],
-    "publishedBy" : [ "UN" ]
+    "publishedBy" : [ "UN" ],
+    "publicationHistory" : "6.1954(1955) - 52.2004"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990054215550206441",

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -11,12 +11,12 @@
   "alternativeTitle" : [ "Reisen in Deutschland / 2", "Bayern ( Sachl. Benennung bis 25.1975 )" ],
   "otherTitleInformation" : [ "deutsches Handbuch für Fremdenverkehr" ],
   "publication" : [ {
-    "publicationHistory" : "19.[1966] - 34.1984",
     "startDate" : "1966",
     "endDate" : "1984",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Darmstadt" ],
-    "publishedBy" : [ "Jaeger" ]
+    "publishedBy" : [ "Jaeger" ],
+    "publicationHistory" : "19.[1966] - 34.1984"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990054301770206441",

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -10,11 +10,11 @@
   "title" : "Eilendorfer Heimatblätter",
   "otherTitleInformation" : [ "Jahresschrift des Heimatvereins Eilendorf 1983 e.V" ],
   "publication" : [ {
-    "publicationHistory" : "1.1983(1984) -",
     "startDate" : "1984",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Aachen-Eilendorf" ],
     "publishedBy" : [ "Heimatverein" ],
+    "publicationHistory" : "1.1983(1984) -",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#z",
       "label" : "unregelmäßig oder sonstige Erscheinungsfrequenz"

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -10,25 +10,20 @@
   "title" : "Bochumer Zeitpunkte",
   "otherTitleInformation" : [ "Beiträge zur Stadtgeschichte, Heimatkunde und Denkmalpflege" ],
   "publication" : [ {
-    "publicationHistory" : "1.1991 -",
     "startDate" : "1991",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Bochum" ],
     "publishedBy" : [ "Kortum-Gesellschaft Bochum" ],
+    "publicationHistory" : "1.1991 -",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#z",
       "label" : "unregelmäßig oder sonstige Erscheinungsfrequenz"
     } ]
   }, {
-    "publicationHistory" : "1.1991 -",
     "startDate" : "1991",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Bochum" ],
-    "publishedBy" : [ "Kracht" ],
-    "frequency" : [ {
-      "id" : "http://marc21rdf.info/terms/continuingfre#z",
-      "label" : "unregelmäßig oder sonstige Erscheinungsfrequenz"
-    } ]
+    "publishedBy" : [ "Kracht" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990055981810206441",

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -8,11 +8,11 @@
   "hbzId" : "HT012224491",
   "title" : "Wettersbacher Anzeiger",
   "publication" : [ {
-    "publicationHistory" : "Nachgewiesen 1979 -",
     "startDate" : "1972",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Weil der Stadt" ],
     "publishedBy" : [ "Nussbaum" ],
+    "publicationHistory" : "Nachgewiesen 1979 -",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#w",
       "label" : "wöchentlich"

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -8,12 +8,12 @@
   "hbzId" : "HT012237361",
   "title" : "Statistische Berichte des Statistischen Landesamtes Rheinland-Pfalz, L. IV. 6: Finanzen und Steuern. Einheitswerte des Grundvermögens nach der Hauptfeststellung : Gemeindeergebnisse",
   "publication" : [ {
-    "publicationHistory" : "1964(1975); damit Ersch. eingest.",
     "startDate" : "1975",
     "endDate" : "1975",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Bad Ems" ],
-    "publishedBy" : [ "Statist. Landesamt" ]
+    "publishedBy" : [ "Statist. Landesamt" ],
+    "publicationHistory" : "1964(1975); damit Ersch. eingest."
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990103899140206441",

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -10,11 +10,11 @@
   "alternativeTitle" : [ "Appropriation acts ( Nebent. d. Mikrofiche-Ausg. )" ],
   "otherTitleInformation" : [ "passed at the session of ..." ],
   "publication" : [ {
-    "publicationHistory" : "Nachgewiesen 1911 -",
     "startDate" : "1911",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Harrisburg, Pa." ],
-    "publishedBy" : [ "[Verlag nicht ermittelbar]" ]
+    "publishedBy" : [ "[Verlag nicht ermittelbar]" ],
+    "publicationHistory" : "Nachgewiesen 1911 -"
   }, {
     "type" : [ "SecondaryPublicationEvent" ],
     "location" : [ "Buffalo, NY" ],

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -9,37 +9,25 @@
   "title" : "Tauben- und Hühnerzeitung",
   "otherTitleInformation" : [ "Organ der gesammten Haus-Federviehzucht, mit Inbegriff der Sangvögel" ],
   "publication" : [ {
-    "publicationHistory" : "2.1857,28(11.Juli) - 7.1862 nachgewiesen",
     "startDate" : "1861",
     "endDate" : "1862",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin" ],
     "publishedBy" : [ "Schotte" ],
+    "publicationHistory" : "2.1857,28(11.Juli) - 7.1862 nachgewiesen",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#w",
       "label" : "wöchentlich"
     } ],
     "note" : [ "Periodizität: wöchentl." ]
   }, {
-    "publicationHistory" : "2.1857,28(11.Juli) - 7.1862 nachgewiesen",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin" ],
-    "publishedBy" : [ "Janke" ],
-    "frequency" : [ {
-      "id" : "http://marc21rdf.info/terms/continuingfre#w",
-      "label" : "wöchentlich"
-    } ],
-    "note" : [ "Periodizität: wöchentl." ]
+    "publishedBy" : [ "Janke" ]
   }, {
-    "publicationHistory" : "2.1857,28(11.Juli) - 7.1862 nachgewiesen",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin" ],
-    "publishedBy" : [ "Voss" ],
-    "frequency" : [ {
-      "id" : "http://marc21rdf.info/terms/continuingfre#w",
-      "label" : "wöchentlich"
-    } ],
-    "note" : [ "Periodizität: wöchentl." ]
+    "publishedBy" : [ "Voss" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990108740950206441",

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -9,11 +9,11 @@
   "hbzId" : "HT012734833",
   "title" : "Behavioural pharmacology",
   "publication" : [ {
-    "publicationHistory" : "1.1989 -",
     "startDate" : "1989",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Philadelphia, Pa." ],
-    "publishedBy" : [ "Lippincott Williams & Wilkins" ]
+    "publishedBy" : [ "Lippincott Williams & Wilkins" ],
+    "publicationHistory" : "1.1989 -"
   } ],
   "shortTitle" : [ "Behav Pharmacol" ],
   "describedBy" : {

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -8,12 +8,12 @@
   "hbzId" : "HT012734884",
   "title" : "Yearbook of anthropology",
   "publication" : [ {
-    "publicationHistory" : "1.1955",
     "startDate" : "1955",
     "endDate" : "1955",
     "type" : [ "PublicationEvent" ],
     "location" : [ "New York, NY" ],
-    "publishedBy" : [ "Found." ]
+    "publishedBy" : [ "Found." ],
+    "publicationHistory" : "1.1955"
   } ],
   "shortTitle" : [ "Yearb Anthropol" ],
   "describedBy" : {

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -9,27 +9,21 @@
   "title" : "Bonner Beethoven-Studien",
   "otherTitleInformation" : [ "Mitteilungen aus dem Beethoven-Haus und Beethoven-Archiv Bonn" ],
   "publication" : [ {
-    "publicationHistory" : "1.1999 - 2.2001; 3.2003; 4.2005 - 8.2009; 9.2011 -",
     "startDate" : "1999",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Bonn", "Leinfelden-Echterdingen" ],
     "publishedBy" : [ "Verl. Beethoven-Haus", "Carus" ],
+    "publicationHistory" : "1.1999 - 2.2001; 3.2003; 4.2005 - 8.2009; 9.2011 -",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#a",
       "label" : "jährlich"
     } ],
     "note" : [ "Ersch. jährl.; 2000 u. 2002 u. 2004 u. 2010 nicht ersch." ]
   }, {
-    "publicationHistory" : "1.1999 - 2.2001; 3.2003; 4.2005 - 8.2009; 9.2011 -",
     "startDate" : "2006",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Bonn" ],
-    "publishedBy" : [ "Verl. Beethoven-Haus" ],
-    "frequency" : [ {
-      "id" : "http://marc21rdf.info/terms/continuingfre#a",
-      "label" : "jährlich"
-    } ],
-    "note" : [ "Ersch. jährl.; 2000 u. 2002 u. 2004 u. 2010 nicht ersch." ]
+    "publishedBy" : [ "Verl. Beethoven-Haus" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990109712970206441",

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -10,12 +10,12 @@
   "title" : "Mainz",
   "otherTitleInformation" : [ "Programm" ],
   "publication" : [ {
-    "publicationHistory" : "1999 - 2004; damit Ersch. eingest.",
     "startDate" : "1999",
     "endDate" : "2004",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Mainz" ],
-    "publishedBy" : [ "[Verlag nicht ermittelbar]" ]
+    "publishedBy" : [ "[Verlag nicht ermittelbar]" ],
+    "publicationHistory" : "1999 - 2004; damit Ersch. eingest."
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990113537330206441",

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -9,11 +9,11 @@
   "title" : "Nordrhein-Westfälische Bibliographie",
   "otherTitleInformation" : [ "Regionale Literaturdokumentation ab Berichtsjahr  ..." ],
   "publication" : [ {
-    "publicationHistory" : "1983 -",
     "startDate" : "1983",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Köln" ],
-    "publishedBy" : [ "HBZ" ]
+    "publishedBy" : [ "HBZ" ],
+    "publicationHistory" : "1983 -"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990133067580206441",

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -10,12 +10,12 @@
   "alternativeTitle" : [ "Die Heimatzeitung", "Heimatzeitung für die Verbandsgemeinde Vallendar" ],
   "otherTitleInformation" : [ "die Heimatzeitung" ],
   "publication" : [ {
-    "publicationHistory" : "2005,1/20 - 2007,13",
     "startDate" : "2005",
     "endDate" : "2007",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Sinzig" ],
     "publishedBy" : [ "Krupp" ],
+    "publicationHistory" : "2005,1/20 - 2007,13",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#w",
       "label" : "wöchentlich"

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -10,11 +10,11 @@
   "alternativeTitle" : [ "LWL - für die Menschen. Für Westfalen-Lippe" ],
   "otherTitleInformation" : [ "für das Jahr ..." ],
   "publication" : [ {
-    "publicationHistory" : "2004(2005) -",
     "startDate" : "2005",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Münster" ],
     "publishedBy" : [ "Landschaftsverb. Westfalen-Lippe" ],
+    "publicationHistory" : "2004(2005) -",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#a",
       "label" : "jährlich"

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -10,12 +10,12 @@
   "title" : "Wohnungsmarktbericht",
   "otherTitleInformation" : [ "Fortschreibung mit Stand ..." ],
   "publication" : [ {
-    "publicationHistory" : "2002=2001(2002) - 2004=2003(2004)",
     "startDate" : "2002",
     "endDate" : "2004",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Düsseldorf" ],
-    "publishedBy" : [ "Amt für Wohnungswesen" ]
+    "publishedBy" : [ "Amt für Wohnungswesen" ],
+    "publicationHistory" : "2002=2001(2002) - 2004=2003(2004)"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990184127410206441",

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -10,21 +10,19 @@
   "title" : "Westfälische Bibliographie zur Geschichte, Landeskunde und Volkskunde",
   "alternativeTitle" : [ "Veröffentlichungen der Historischen Kommission für Westfalen / Westfälische Bibliographie zur Geschichte, Landeskunde und Volkskunde" ],
   "publication" : [ {
-    "publicationHistory" : "1.1951/55; 2.1961/90; 3.1977; 4.2004=Register; damit Ersch. eingest.",
     "startDate" : "1951",
     "endDate" : "2004",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Münster" ],
     "publishedBy" : [ "Regensberg", "Historische Kommission, Landschaftsverband Westfalen-Lippe" ],
+    "publicationHistory" : "1.1951/55; 2.1961/90; 3.1977; 4.2004=Register; damit Ersch. eingest.",
     "note" : [ "Ersch. in Lfg; springende Ersch.-Jahre" ]
   }, {
-    "publicationHistory" : "1.1951/55; 2.1961/90; 3.1977; 4.2004=Register; damit Ersch. eingest.",
     "startDate" : "1951",
     "endDate" : "1977",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Münster" ],
-    "publishedBy" : [ "Regensberg" ],
-    "note" : [ "Ersch. in Lfg; springende Ersch.-Jahre" ]
+    "publishedBy" : [ "Regensberg" ]
   }, {
     "type" : [ "SecondaryPublicationEvent" ],
     "description" : [ "Digitalisierte Ausg." ]

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -9,12 +9,12 @@
   "title" : "The Geneva gazette",
   "alternativeTitle" : [ "Early American newspapers / The Geneva gazette" ],
   "publication" : [ {
-    "publicationHistory" : "1809,21.Juni - 1810,26.Dez.[?]",
     "startDate" : "1809",
     "endDate" : "1810",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Geneva, NY" ],
     "publishedBy" : [ "[Verlag nicht ermittelbar]" ],
+    "publicationHistory" : "1809,21.Juni - 1810,26.Dez.[?]",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#w",
       "label" : "wöchentlich"

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -8,12 +8,12 @@
   "hbzId" : "HT017664407",
   "title" : "Aegyptische Nachrichten",
   "publication" : [ {
-    "publicationHistory" : "1912,Jan.-Dez.; mehr nicht digitalisiert",
     "startDate" : "1912",
     "endDate" : "1912",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Kairo" ],
-    "publishedBy" : [ "[Verlag nicht ermittelbar]" ]
+    "publishedBy" : [ "[Verlag nicht ermittelbar]" ],
+    "publicationHistory" : "1912,Jan.-Dez.; mehr nicht digitalisiert"
   }, {
     "type" : [ "SecondaryPublicationEvent" ],
     "location" : [ "Berlin" ],

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -8,11 +8,11 @@
   "title" : "Advances in special education",
   "otherTitleInformation" : [ "a research annual" ],
   "publication" : [ {
-    "publicationHistory" : "1.1980 - 3.1981; 4.1984 -",
     "startDate" : "1980",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Greenwich, Conn." ],
-    "publishedBy" : [ "JAI Pr." ]
+    "publishedBy" : [ "JAI Pr." ],
+    "publicationHistory" : "1.1980 - 3.1981; 4.1984 -"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990199611280206441",

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -9,11 +9,11 @@
   "hbzId" : "HT018839495",
   "title" : "Classics in linguistics",
   "publication" : [ {
-    "publicationHistory" : "1-",
     "startDate" : "2015",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin" ],
-    "publishedBy" : [ "Language Science Press" ]
+    "publishedBy" : [ "Language Science Press" ],
+    "publicationHistory" : "1-"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990210093550206441",

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -8,12 +8,12 @@
   "hbzId" : "HT019128882",
   "title" : "Das Lied von Eis und Feuer",
   "publication" : [ {
-    "publicationHistory" : "Band 1, Heft 1 (2016)-Band 10, Heft 19 (2019) = Ausgabe 1-Ausgabe 46 ; damit Erscheinen eingestellt",
     "startDate" : "2016",
     "endDate" : "2019",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Leipzig" ],
     "publishedBy" : [ "[Deutsche Zentralbücherei für Blinde (DZB)]" ],
+    "publicationHistory" : "Band 1, Heft 1 (2016)-Band 10, Heft 19 (2019) = Ausgabe 1-Ausgabe 46 ; damit Erscheinen eingestellt",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#w",
       "label" : "wöchentlich"

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -10,12 +10,12 @@
   "title" : "Wirtschaft & Erziehung",
   "alternativeTitle" : [ "Wirtschaft und Erziehung", "Organ für kaufmännisches Bildungswesen", "Monatsschrift des Bundesverbandes der Lehrerinnen und Lehrer an Wirtschaftsschulen (VLW) e.V.", "Wirtschaft und Erziehung ( Hauptsacht. bis 64.2012,6 )" ],
   "publication" : [ {
-    "publicationHistory" : "1.1949-70. Jahrgang, Ausgabe 2 (2018)",
     "startDate" : "1949",
     "endDate" : "2018",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Wolfenbüttel" ],
     "publishedBy" : [ "Heckner" ],
+    "publicationHistory" : "1.1949-70. Jahrgang, Ausgabe 2 (2018)",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#m",
       "label" : "monatlich"

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -9,10 +9,10 @@
   "title" : "ABI-Technik",
   "alternativeTitle" : [ "A.B.I.-Technik" ],
   "publication" : [ {
-    "publicationHistory" : "Began in 1981.",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Berlin, Germany :" ],
     "publishedBy" : [ "De Gruyter" ],
+    "publicationHistory" : "Began in 1981.",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#q",
       "label" : "vierteljährlich"

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -11,11 +11,11 @@
   "alternativeTitle" : [ "Kirche weltweit", "Mitteilungsblatt des Leipziger Missionswerkes der Evangelisch-Lutherischen Landeskirchen Mecklenburgs, Sachsens, Thüringens" ],
   "otherTitleInformation" : [ "Mitteilungsblatt des Leipziger Missionswerkes der Evangelisch-Lutherischen Landeskirche Sachsens und der Evangelischen Kirche in Mitteldeutschland" ],
   "publication" : [ {
-    "publicationHistory" : "Nachgewiesen 2006 -",
     "startDate" : "2006",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Leipzig", "Dresden" ],
     "publishedBy" : [ "Evangelisch-Lutherisches Missionswerk Leipzig e.V. (LMW)", "SLUB" ],
+    "publicationHistory" : "Nachgewiesen 2006 -",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#q",
       "label" : "vierteljährlich"

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -11,11 +11,11 @@
   "alternativeTitle" : [ "Informationen für die rheinischen Museen" ],
   "otherTitleInformation" : [ "Informationen für die rheinischen Museen" ],
   "publication" : [ {
-    "publicationHistory" : "1.2012 -",
     "startDate" : "2012",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Köln-Deutz" ],
-    "publishedBy" : [ "LVR-Dezernat Kultur und Umwelt" ]
+    "publishedBy" : [ "LVR-Dezernat Kultur und Umwelt" ],
+    "publicationHistory" : "1.2012 -"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/99370694196806441",

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -10,11 +10,11 @@
   "alternativeTitle" : [ "BUW-Output", "BUW-Output", "Output" ],
   "otherTitleInformation" : [ "Forschungsmagazin = Research bulletin / Universität Wuppertal ; hrsg. im Auftrag des Rektorates" ],
   "publication" : [ {
-    "publicationHistory" : "2009 -",
     "startDate" : "2009",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Wuppertal" ],
-    "publishedBy" : [ "BUW" ]
+    "publishedBy" : [ "BUW" ],
+    "publicationHistory" : "2009 -"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/99370699582506441",

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -6,7 +6,9 @@
   "title" : "Lexicology, Semantics and Lexicography : Selected Papers from the Fourth G.L. Brook Symposium, Manchester, August 1998",
   "publication" : [ {
     "type" : [ "PublicationEvent" ],
-    "publishedBy" : [ "John Benjamins Publishing Company" ]
+    "location" : [ "Philadelphia, PA, USA" ],
+    "publishedBy" : [ "John Benjamins Publishing Company" ],
+    "startDate" : "2000"
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/99370763882706441",

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -5,11 +5,6 @@
   "oclcNumber" : [ "70765802" ],
   "title" : "Lexicology, Semantics and Lexicography : Selected Papers from the Fourth G.L. Brook Symposium, Manchester, August 1998",
   "publication" : [ {
-    "startDate" : "2000",
-    "type" : [ "PublicationEvent" ],
-    "location" : [ "Philadelphia, PA, USA" ],
-    "publishedBy" : [ "John Benjamins Publishing Company" ]
-  }, {
     "type" : [ "PublicationEvent" ],
     "publishedBy" : [ "John Benjamins Publishing Company" ]
   } ],

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -4,23 +4,18 @@
   "oclcNumber" : [ "945571548" ],
   "title" : "The natural family",
   "publication" : [ {
-    "publicationHistory" : "Began with volume 30, number 3 (2016).",
     "type" : [ "PublicationEvent" ],
-    "location" : [ "Rockford, IL :" ],
-    "publishedBy" : [ "Howard Center for Family, Religion & Society" ],
+    "location" : [ "Rockford, Illinois :" ],
+    "publishedBy" : [ "The International Organization for the Family" ],
+    "publicationHistory" : "Began with volume 30, number 3 (2016).",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#a",
       "label" : "jährlich"
     } ]
   }, {
-    "publicationHistory" : "Began with volume 30, number 3 (2016).",
     "type" : [ "PublicationEvent" ],
-    "location" : [ "Rockford, Illinois :" ],
-    "publishedBy" : [ "The International Organization for the Family" ],
-    "frequency" : [ {
-      "id" : "http://marc21rdf.info/terms/continuingfre#a",
-      "label" : "jährlich"
-    } ]
+    "location" : [ "Rockford, IL :" ],
+    "publishedBy" : [ "Howard Center for Family, Religion & Society" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/99371107766906441",

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -7,11 +7,6 @@
   "publication" : [ {
     "startDate" : "2015",
     "type" : [ "PublicationEvent" ],
-    "location" : [ "Bern" ],
-    "publishedBy" : [ "Peter Lang International Academic Publishing Group" ]
-  }, {
-    "startDate" : "2015",
-    "type" : [ "PublicationEvent" ],
     "location" : [ "Frankfurt am Main, [Germany] :" ],
     "publishedBy" : [ "Peter Lang Edition" ]
   } ],

--- a/src/test/resources/alma-fix/99371147104906441.json
+++ b/src/test/resources/alma-fix/99371147104906441.json
@@ -6,11 +6,11 @@
   "title" : "Information & media",
   "alternativeTitle" : [ "Information and media" ],
   "publication" : [ {
-    "publicationHistory" : "Began with: Vol. 91 (2021).",
     "startDate" : "2021",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Vilnius :" ],
     "publishedBy" : [ "Vilnius University Press" ],
+    "publicationHistory" : "Began with: Vol. 91 (2021).",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#f",
       "label" : "halbjährlich"

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -9,11 +9,11 @@
   "title" : "Smart grids and sustainable energy",
   "alternativeTitle" : [ "Technology and economics of smart grids and sustainable energy ( Abweichender Titel in Volume 8, issue 1 (March 2023) teils )" ],
   "publication" : [ {
-    "publicationHistory" : "Volume 8, issue 1 (March 2023)-",
     "startDate" : "2023",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Singapore" ],
     "publishedBy" : [ "Springer Nature Singapore" ],
+    "publicationHistory" : "Volume 8, issue 1 (March 2023)-",
     "frequency" : [ {
       "id" : "http://marc21rdf.info/terms/continuingfre#z",
       "label" : "unregelmäßig oder sonstige Erscheinungsfrequenz"


### PR DESCRIPTION
Solves an issue from #1830 and solves #1886 

In Aleph it seems, that there is only one object for PrimaryPublicationEvent. Because of the different sources of the publicationInfo we now have multiple and all have the info outside `260` and `264`.

I suggest to keep the multiple `publication`-objects, but prefer `264` over `260`.
And only add the info for `frequency`,`publicationHistory`,`note` and the mapping of indian pub dates, to the first `object` of the `publication`-Array.
The first ideally is the current (indicator1: 3) publication info, if not the intermediate  (indicator1: 2) and if not the first/undefined (indicator1: #).

This PR does:
- introduce a macro for publication
- prefer 264 over 260 publication info
- only add publicationHistory and frequency to the first/current publication info
- add some fallbacks for publication date and location
