### PR TITLE
1761 gnd missing subfield t with persons/events

### DIFF
--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -14,6 +14,9 @@ do put_macro("gndEventCombinedLabel")
   unless is_empty("$[field].@combinedDetailsForEvents.")
     paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~ (", "$[field].@combinedDetailsForEvents", "~)", join_char:"")
   end
+  if exists("$[field].t")
+    paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~: ","$[field].t", join_char:"")
+  end
 end
 
 # Macro for combinedLabel Person
@@ -31,6 +34,9 @@ do put_macro("gndPersonCombinedLabel")
     end
     if exists("$[field].x")
       paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~/","$[field].x")
+    end
+    if exists("$[field].t")
+      paste("$[field].@combinedLabel", "$[field].@combinedLabel", "~: ","$[field].t", join_char:"")
     end
 end
 

--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -103,8 +103,12 @@ do put_macro("schlagwortfolge")
     set_array("subject[].$last.componentList[]")
     do list(path:"$[field]", "var":"$i")
       set_array("subject[].$last.componentList[].$append.type[]")
-      do list(path: "$i.D", "var": "$k")
-        copy_field("$k","subject[].$last.componentList[].$last.type[].$append")
+      if exists("$i.t") # Marker for Werktitel/Work even when the GND-enrichment is falsly labeld as Peron or differently
+        add_field("subject[].$last.componentList[].$last.type[].$append","work")
+      else
+        do list(path: "$i.D", "var": "$k")
+          copy_field("$k","subject[].$last.componentList[].$last.type[].$append")
+        end
       end
       if any_equal("subject[].$last.componentList[].$last.type[]","p")
         call_macro("gndPersonCombinedLabel",field:"$i")

--- a/src/main/resources/alma/fix/subjects.fix
+++ b/src/main/resources/alma/fix/subjects.fix
@@ -403,6 +403,7 @@ do list (path: "subject[]", "var": "$i")
     unless any_match("$j.dateOfBirthAndDeath","^ca\\..*|.*Jh\\.")
       remove_field("$j.dateOfBirthAndDeath")
     end
+    replace_all("$j.label","<<|>>","")
     # compare GND identifier (idn) with ALMA GND enrichment elements:
     set_array("$j.altLabel[]")
     do list(path:"GPN??", "var": "$z")
@@ -429,6 +430,8 @@ do list(path:"subject[]", "var": "$i")
   end
 end
 
+# clean up subjects
+replace_all("subject[].*.label","<<|>>","")
 uniq("subject[]")
 
 # nwbib

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -149,10 +149,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Beethoven, Ludwig <<van>>",
+    "label" : "Beethoven, Ludwig van",
     "componentList" : [ {
       "type" : [ "Person" ],
-      "label" : "Beethoven, Ludwig <<van>>",
+      "label" : "Beethoven, Ludwig van",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",
         "id" : "https://d-nb.info/gnd/7749153-1"
@@ -196,7 +196,7 @@
       }
     }
   } ],
-  "subjectslabels" : [ "Beethoven, Ludwig <<van>>", "Beethoven-Haus Bonn" ],
+  "subjectslabels" : [ "Beethoven, Ludwig van", "Beethoven-Haus Bonn" ],
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],

--- a/src/test/resources/alma-fix/990366338340206441.json
+++ b/src/test/resources/alma-fix/990366338340206441.json
@@ -105,7 +105,7 @@
     "type" : [ "ComplexSubject" ],
     "label" : "Pseudo-Veghe: Wyngaerden der sele | Schriftsprache | Sprachvariante",
     "componentList" : [ {
-      "type" : [ "Person" ],
+      "type" : [ "work" ],
       "label" : "Pseudo-Veghe: Wyngaerden der sele",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",

--- a/src/test/resources/alma-fix/990366338340206441.json
+++ b/src/test/resources/alma-fix/990366338340206441.json
@@ -103,10 +103,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Pseudo-Veghe | Schriftsprache | Sprachvariante",
+    "label" : "Pseudo-Veghe: Wyngaerden der sele | Schriftsprache | Sprachvariante",
     "componentList" : [ {
       "type" : [ "Person" ],
-      "label" : "Pseudo-Veghe",
+      "label" : "Pseudo-Veghe: Wyngaerden der sele",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",
         "id" : "https://d-nb.info/gnd/7749153-1"
@@ -114,7 +114,7 @@
       "id" : "https://d-nb.info/gnd/1209494418",
       "gndIdentifier" : "1209494418",
       "dateOfBirthAndDeath" : "ca. 15. Jh.",
-      "altLabel" : [ "Pseudo-Veghe" ]
+      "altLabel" : [ "Pseudo-Veghe: De Wyngaerde der sele" ]
     }, {
       "type" : [ "SubjectHeading" ],
       "label" : "Schriftsprache",
@@ -199,7 +199,7 @@
       }
     }
   } ],
-  "subjectslabels" : [ "Pseudo-Veghe", "Schriftsprache", "Sprachvariante", "Handschrift (Bayerische Staatsbibliothek), Ms. germ. fol. 549", "Handschrift (Landesarchiv Nordrhein-Westfalen. Abteilung Westfalen), Mscr. 55", "Herkunft" ],
+  "subjectslabels" : [ "Pseudo-Veghe: Wyngaerden der sele", "Schriftsprache", "Sprachvariante", "Handschrift (Bayerische Staatsbibliothek), Ms. germ. fol. 549", "Handschrift (Landesarchiv Nordrhein-Westfalen. Abteilung Westfalen), Mscr. 55", "Herkunft" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/99371050452706441.json
+++ b/src/test/resources/alma-fix/99371050452706441.json
@@ -172,7 +172,7 @@
     "type" : [ "ComplexSubject" ],
     "label" : "Nordrhein-Westfalen: Landesnaturschutzgesetz",
     "componentList" : [ {
-      "type" : [ "CorporateBody" ],
+      "type" : [ "work" ],
       "label" : "Nordrhein-Westfalen: Landesnaturschutzgesetz",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",

--- a/src/test/resources/alma-fix/99371883990606441.json
+++ b/src/test/resources/alma-fix/99371883990606441.json
@@ -115,7 +115,7 @@
     "type" : [ "ComplexSubject" ],
     "label" : "Weerth, Georg: <<Die>> Armen in der Senne | Westfalen (Motiv) | Verelendung (Motiv)",
     "componentList" : [ {
-      "type" : [ "Person" ],
+      "type" : [ "work" ],
       "label" : "Weerth, Georg: <<Die>> Armen in der Senne",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",

--- a/src/test/resources/alma-fix/99371883990606441.json
+++ b/src/test/resources/alma-fix/99371883990606441.json
@@ -113,10 +113,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Weerth, Georg | Westfalen (Motiv) | Verelendung (Motiv)",
+    "label" : "Weerth, Georg: <<Die>> Armen in der Senne | Westfalen (Motiv) | Verelendung (Motiv)",
     "componentList" : [ {
       "type" : [ "Person" ],
-      "label" : "Weerth, Georg",
+      "label" : "Weerth, Georg: <<Die>> Armen in der Senne",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",
         "id" : "https://d-nb.info/gnd/7749153-1"
@@ -220,7 +220,7 @@
       }
     }
   } ],
-  "subjectslabels" : [ "Weerth, Georg", "Westfalen (Motiv)", "Verelendung (Motiv)", "Senne (Landschaft)", "Literarisierung" ],
+  "subjectslabels" : [ "Weerth, Georg: <<Die>> Armen in der Senne", "Westfalen (Motiv)", "Verelendung (Motiv)", "Senne (Landschaft)", "Literarisierung" ],
   "medium" : [ {
     "label" : "Datenträger",
     "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"

--- a/src/test/resources/alma-fix/99371883990606441.json
+++ b/src/test/resources/alma-fix/99371883990606441.json
@@ -113,10 +113,10 @@
     }
   }, {
     "type" : [ "ComplexSubject" ],
-    "label" : "Weerth, Georg: <<Die>> Armen in der Senne | Westfalen (Motiv) | Verelendung (Motiv)",
+    "label" : "Weerth, Georg: Die Armen in der Senne | Westfalen (Motiv) | Verelendung (Motiv)",
     "componentList" : [ {
       "type" : [ "work" ],
-      "label" : "Weerth, Georg: <<Die>> Armen in der Senne",
+      "label" : "Weerth, Georg: Die Armen in der Senne",
       "source" : {
         "label" : "Gemeinsame Normdatei (GND)",
         "id" : "https://d-nb.info/gnd/7749153-1"
@@ -220,7 +220,7 @@
       }
     }
   } ],
-  "subjectslabels" : [ "Weerth, Georg: <<Die>> Armen in der Senne", "Westfalen (Motiv)", "Verelendung (Motiv)", "Senne (Landschaft)", "Literarisierung" ],
+  "subjectslabels" : [ "Weerth, Georg: Die Armen in der Senne", "Westfalen (Motiv)", "Verelendung (Motiv)", "Senne (Landschaft)", "Literarisierung" ],
   "medium" : [ {
     "label" : "Datenträger",
     "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"


### PR DESCRIPTION
This PR does three things:
- Add subfield `$t `if it exists to combined gnd labels of person and events resulting in new  `subject.componentlist.label` and `subject.label`
- Change `type` of `subject.componentlist`-object to Work as in ALEPH Lobid and as the type of the GND-records: https://portal.dnb.de/opac.htm?method=simpleSearch&cqlMode=true&query=nid%3D1209494418
- Clean << and >> from the labels in subjects