### PR TITLE
Allow to identify failing `IndexIntegrationTest` queries.

### DIFF
--- a/web/app/controllers/resources/Queries.java
+++ b/web/app/controllers/resources/Queries.java
@@ -32,13 +32,13 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * Queries on the lobid-resources index.
- * 
+ *
  * @author Fabian Steeg (fsteeg)
  */
 public class Queries {
 	/**
 	 * Parameters for API requests.
-	 * 
+	 *
 	 * @author Fabian Steeg (fsteeg)
 	 */
 	static enum Parameter {
@@ -163,6 +163,11 @@ public class Queries {
 		public QueryBuilder build() { return new Queries(this).query(); }
 		//@formatter:on
 
+		@Override
+		public String toString() {
+			return q;
+		}
+
 	}
 
 	private QueryBuilder query() {
@@ -194,7 +199,7 @@ public class Queries {
 
 	/**
 	 * Superclass for queries on different indexes.
-	 * 
+	 *
 	 * @author Fabian Steeg (fsteeg)
 	 */
 	static abstract class AbstractIndexQuery {

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -29,7 +29,7 @@ import play.Logger;
 public class IndexIntegrationTest extends LocalIndexSetup {
 
 	// test data parameters, formatted as "input /*->*/ expected output"
-	@Parameters(name = "{0}")
+	@Parameters(name = "({index}) {0}")
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {


### PR DESCRIPTION
Resolves #1839.

Implementing `Queries.Builder.toString()` as `q` is the absolute minimum viable solution targeting this specific use case. A more encompassing representation would include all members, formatted appropriately.