### PR TITLE
Update labels for DE-6.

### DIFF
--- a/src/main/resources/alma/maps/lobidOrgLabels.tsv
+++ b/src/main/resources/alma/maps/lobidOrgLabels.tsv
@@ -4278,7 +4278,7 @@ http://lobid.org/organisations/DE-MUS-821114#!	Dommuseum des Domstifts Brandenbu
 http://lobid.org/organisations/DE-1137#!	Mediathek der Stadt Wehr
 http://lobid.org/organisations/DE-26-211#!	Institut für Veterinär-Physiologie, Arbeitsgruppe Biomathematik und Datenverarbeitung , Bibliothek
 http://lobid.org/organisations/DE-82-102#!	Lehrstuhl für Statistik und Institut für Statistik u. Wirtschaftsmathematik, Bibliothek
-http://lobid.org/organisations/DE-6#!	Universitäts- und Landesbibliothek Münster
+http://lobid.org/organisations/DE-6#!	Universitäts- und Landesbibliothek Münster, Zentralbibliothek
 http://lobid.org/organisations/DE-Bs87#!	Landeskirchliche Bibliothek, Bibliothek für Religionspädagogik
 http://lobid.org/organisations/DE-MUS-116125#!	Bundesarchiv - Außenstelle Ludwigsburg
 http://lobid.org/organisations/DE-Ds201#!	Zentralarchiv der Evangelische Kirche in Hessen und Nassau, Bibliothek
@@ -10807,7 +10807,7 @@ http://lobid.org/organisations/DE-Bo404#!	Deutsches Referenzzentrum für Ethik i
 http://lobid.org/organisations/DE-850#!	Stadtbibliothek Straubing
 http://lobid.org/organisations/DE-4029#!	Stadtbibliothek Dessau-Roßlau
 http://lobid.org/organisations/DE-MUS-424317#!	Schulhistorisches Kabinett
-http://lobid.org/organisations/DE-6-210#!	Institut für Vergleichende Städtegeschichte an der Westfälischen Wilhelms-Universität, Bibliothek
+http://lobid.org/organisations/DE-6-210#!	Universität Münster, Institut für Vergleichende Städtegeschichte, Bibliothek
 http://lobid.org/organisations/DE-MUS-907411#!	Bauspar-Museum
 http://lobid.org/organisations/DE-2446#!	Archiv der Stadt Erftstadt
 http://lobid.org/organisations/DE-623#!	Transport- und Umladestation Badische Landesbibliothek Karlsruhe (BLB)

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -224,7 +224,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990001412590206441:DE-6:23507162560006449#!"
   }, {

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -41,7 +41,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",
@@ -482,7 +482,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990050000600206441:DE-6:991037504519706449#!"
   }, {

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -274,7 +274,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990052965140206441:DE-6:991040627879706449#!"
   } ],

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -346,7 +346,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990053976760206441:DE-6:22526741340006449#!"
   }, {

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -247,7 +247,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990055981810206441:DE-6:23651985810006449#!"
   }, {
@@ -259,7 +259,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990055981810206441:DE-6:23650616280006449#!"
   }, {
@@ -271,7 +271,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990055981810206441:DE-6:23650616270006449#!"
   }, {
@@ -326,7 +326,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990055981810206441:DE-6:22547318240006449#!"
   }, {
@@ -337,7 +337,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990055981810206441:DE-6:22547318250006449#!"
   } ],

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -49,7 +49,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         }, {
           "id" : "http://lobid.org/organisations/DE-605#!",
           "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
@@ -336,7 +336,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990058434730206441:DE-6:23602951640006449#!"
   }, {

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -49,7 +49,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },
@@ -201,7 +201,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990063549080206441:DE-6:991027259779706449#!"
   } ],

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -48,7 +48,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },
@@ -91,7 +91,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990065341720206441:DE-6:23553702130006449#!"
   } ],

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -206,7 +206,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990075429930206441:DE-6:23595716630006449#!"
   }, {

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -354,7 +354,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990109712970206441:DE-6:23653461490006449#!"
   }, {
@@ -366,7 +366,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990109712970206441:DE-6:23653461500006449#!"
   }, {

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -40,11 +40,11 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -36,7 +36,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",
@@ -44,7 +44,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -46,7 +46,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -41,7 +41,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-101b#!",

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -37,7 +37,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -223,7 +223,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990126276700206441:DE-6:23535410630006449#!"
   }, {

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -51,7 +51,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },
@@ -242,7 +242,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990133067580206441:DE-6:53804555180006441#!"
   } ],

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -41,7 +41,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",
@@ -49,7 +49,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         }, {
           "id" : "http://lobid.org/organisations/DE-605#!",
           "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
@@ -166,7 +166,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990143325070206441:DE-6:23564603190006449#!"
   }, {

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -172,7 +172,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990173811970206441:DE-6:991037863219706449#!"
   } ],

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -49,7 +49,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-101#!",
@@ -176,7 +176,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990183054020206441:DE-6:22542862200006449#!"
   } ],

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -232,7 +232,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990184127410206441:DE-6:53804344220006441#!"
   } ],

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -248,7 +248,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990189160110206441:DE-6:23527811780006449#!"
   }, {
@@ -260,7 +260,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990189160110206441:DE-6:23527811770006449#!"
   }, {

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -36,7 +36,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",
@@ -44,7 +44,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -57,7 +57,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-101#!",
@@ -292,7 +292,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990193229450206441:DE-6:53807024380006441#!"
   } ],

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -39,11 +39,11 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },
@@ -83,7 +83,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990193806600206441:DE-6:23526297370006449#!"
   } ],

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -42,7 +42,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-929#!",
@@ -181,7 +181,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990204246530206441:DE-6:23593081430006449#!"
   }, {

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -41,7 +41,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-101#!",
@@ -49,7 +49,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },
@@ -160,7 +160,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990209817770206441:DE-6:23490552480006449#!"
   } ],

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -146,7 +146,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990210093550206441:DE-6:53625317550006449#!"
   }, {

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -488,7 +488,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990217478660206441:DE-6:23512237280006449#!"
   }, {

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -42,7 +42,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-466#!",
@@ -463,7 +463,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990223521400206441:DE-6:23506634650006449#!"
   }, {
@@ -475,7 +475,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990223521400206441:DE-6:23506634640006449#!"
   }, {

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -233,7 +233,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990365842280206441:DE-6:53706734800006441#!"
   } ],

--- a/src/test/resources/alma-fix/990366338340206441.json
+++ b/src/test/resources/alma-fix/990366338340206441.json
@@ -37,7 +37,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",
@@ -45,7 +45,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         }, {
           "id" : "http://lobid.org/organisations/DE-605#!",
           "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -37,7 +37,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         }
       }
     },
@@ -71,7 +71,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990366394400206441:DE-6:23534915260006449#!"
   } ],

--- a/src/test/resources/alma-fix/990368319120206441.json
+++ b/src/test/resources/alma-fix/990368319120206441.json
@@ -37,7 +37,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -38,7 +38,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         }
       }
     },
@@ -72,7 +72,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/990368743120206441:DE-6:23544500850006449#!"
   } ],

--- a/src/test/resources/alma-fix/991000688209706449.json
+++ b/src/test/resources/alma-fix/991000688209706449.json
@@ -61,7 +61,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/991000688209706449:DE-6:23607591370006449#!"
   } ],

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -473,7 +473,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370678063606441:DE-6:53627078260006449#!"
   }, {
@@ -484,7 +484,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370678063606441:DE-6:53626936090006449#!"
   }, {
@@ -495,7 +495,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370678063606441:DE-6:53627921000006449#!"
   }, {

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -215,7 +215,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370682219806441:DE-6:53629253910006449#!"
   }, {

--- a/src/test/resources/alma-fix/99370690532406441.json
+++ b/src/test/resources/alma-fix/99370690532406441.json
@@ -146,7 +146,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370690532406441:DE-6:53653301110006449#!"
   }, {

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -216,7 +216,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370694196806441:DE-6:53630052410006449#!"
   }, {

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -147,7 +147,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370699582506441:DE-6:53630816910006449#!"
   }, {

--- a/src/test/resources/alma-fix/99370738710506441.json
+++ b/src/test/resources/alma-fix/99370738710506441.json
@@ -182,7 +182,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370738710506441:DE-6:53632399120006449#!"
   } ],

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -123,7 +123,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370763433806441:DE-6:53648029900006449#!"
   }, {
@@ -134,7 +134,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370763433806441:DE-6:53642731060006449#!"
   }, {
@@ -145,7 +145,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370763433806441:DE-6:53634752800006449#!"
   } ],

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -136,7 +136,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370763882706441:DE-6:53639140850006449#!"
   }, {
@@ -147,7 +147,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99370763882706441:DE-6:53643672020006449#!"
   } ],

--- a/src/test/resources/alma-fix/99371050452706441.json
+++ b/src/test/resources/alma-fix/99371050452706441.json
@@ -40,7 +40,7 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-605#!",
@@ -48,7 +48,7 @@
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         }, {
           "id" : "http://lobid.org/organisations/DE-605#!",
           "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
@@ -212,7 +212,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99371050452706441:DE-6:23596739030006449#!"
   } ],

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -138,7 +138,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99371107766906441:DE-6:53627314570006449#!"
   } ],

--- a/src/test/resources/alma-fix/99371147104906441.json
+++ b/src/test/resources/alma-fix/99371147104906441.json
@@ -202,7 +202,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99371147104906441:DE-6:53652173090006449#!"
   } ],

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -272,7 +272,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99371314897806441:DE-6:53769526120006441#!"
   }, {

--- a/src/test/resources/alma-fix/99371791018506441.json
+++ b/src/test/resources/alma-fix/99371791018506441.json
@@ -154,7 +154,7 @@
     "heldBy" : {
       "id" : "http://lobid.org/organisations/DE-6#!",
       "isil" : "DE-6",
-      "label" : "Universitäts- und Landesbibliothek Münster"
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
     },
     "id" : "http://lobid.org/items/99371791018506441:DE-6:53800421430006441#!"
   }, {

--- a/src/test/resources/alma-fix/99371883990606441.json
+++ b/src/test/resources/alma-fix/99371883990606441.json
@@ -41,7 +41,7 @@
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-605#!",

--- a/src/test/resources/alma-fix/99372483173006441.json
+++ b/src/test/resources/alma-fix/99372483173006441.json
@@ -37,15 +37,15 @@
         },
         "sourceOrganization" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "provider" : {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         },
         "modifiedBy" : [ {
           "id" : "http://lobid.org/organisations/DE-6#!",
-          "label" : "Universitäts- und Landesbibliothek Münster"
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
         } ]
       }
     },


### PR DESCRIPTION
Originally reported as DigiBib-Ticket#2023082450341165:

> DE-6: Universitäts- und Landesbibliothek Münster >> NEU: Universitäts- und Landesbibliothek Münster, Zentralbibliothek
> DE-210 [sic!]: Institut für Vergleichende Städtegeschichte an der Westfälischen Wilhelms-Universität, Bibliothek >> NEU: Universität Münster, Institut für Vergleichende Städtegeschichte, Bibliothek

Is there some process to synchronize with lobid-organisations? It's already corrected there.