### PR TITLE
Cache table "isil2opac_hbzid"

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -105,6 +105,7 @@ This should result in *BUILD SUCCESS*. Push your changes. You're done :)
 h2. Tables as gitsubmodules
 Some lookup tables are provided through gitsubmodules. To make a @git pull@ also
 update these tables you can e.g. do @git config --local submodule.recurse true@ once.
+If you update an already cloned repo you need to do @git submodule update --init --recursive@ first.
 
 h2. Propagate the context.json to lobid-resources-web
 

--- a/web/app/Global.java
+++ b/web/app/Global.java
@@ -1,9 +1,14 @@
 /* Copyright 2017, hbz. Licensed under the EPL 2.0 */
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import controllers.resources.Lobid;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
@@ -18,6 +23,7 @@ import org.lobid.resources.run.AlmaMarcXmlFix2lobidJsonEs;
 import play.Application;
 import play.GlobalSettings;
 import play.Logger;
+import play.libs.Json;
 
 /**
  * Application global settings.
@@ -48,6 +54,8 @@ public class Global extends GlobalSettings {
     private LocalIndex localIndex = null;
     private Client client = null;
 
+    private static final String ISIL2OPAC ="../link-templates/isil2opac_hbzid.json";
+
     @Override
     public void onStart(Application app) {
         super.onStart(app);
@@ -71,6 +79,7 @@ public class Global extends GlobalSettings {
         if (client != null) {
             Search.elasticsearchClient = client;
         }
+        Lobid.isil2opac = loadIsil2Opac();
     }
 
     @Override
@@ -95,5 +104,17 @@ public class Global extends GlobalSettings {
                     e.getMessage());
             }
         }
+    }
+
+    private static JsonNode loadIsil2Opac() {
+        JsonNode node = null;
+        try (InputStream stream =
+                 new FileInputStream(ISIL2OPAC)) {
+            node = Json.parse(stream);
+        }
+        catch (IOException e) {
+            Logger.error("Could not create OPAC URL", e);
+        }
+        return node;
     }
 }

--- a/web/app/controllers/resources/Lobid.java
+++ b/web/app/controllers/resources/Lobid.java
@@ -2,9 +2,6 @@
 
 package controllers.resources;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,6 +48,7 @@ public class Lobid {
 	static final String ORGS_ROOT = Application.CONFIG.getString("orgs.api");
 	/** Timeout for API calls in milliseconds. */
 	public static final int API_TIMEOUT = 50000;
+	public static JsonNode isil2opac = null;
 
 	/**
 	 * @param url The URL to call
@@ -391,21 +389,16 @@ public class Lobid {
 	 * @return The OPAC URL for the given item, or null
 	 */
 	public static String opacUrl(String itemUri) {
-		try (InputStream stream =
-				new URL(Application.CONFIG.getString("isil2opac_hbzid")).openStream()) {
-			JsonNode json = Json.parse(stream);
+
 			String[] hbzId_isil_sig =
 					itemUri.substring(itemUri.indexOf("items/") + 6).split(":");
 			String hbzId = hbzId_isil_sig[0];
 			String isil = hbzId_isil_sig[1];
 			Logger.debug("From item URI {}, got ISIL {} and HBZ-ID {}", itemUri, isil,
 					hbzId);
-			JsonNode urlTemplate = json.get(isil);
+			JsonNode urlTemplate = isil2opac.get(isil);
 			if (urlTemplate != null)
 				return urlTemplate.asText().replace("{hbzid}", hbzId);
-		} catch (IOException e) {
-			Logger.error("Could not create OPAC URL", e);
-		}
 		return null;
 	}
 

--- a/web/conf/resources.conf_template
+++ b/web/conf/resources.conf_template
@@ -3,8 +3,6 @@ hbz01.api="http://lobid.org/hbz01"
 mrcx.api="https://lobid.org/marcxml/"
 orgs.api="http://lobid.org/organisations/"
 
-isil2opac_hbzid = "https://raw.githubusercontent.com/hbz/link-templates/master/isil2opac_hbzid.json"
-
 webhook = {
 	alma = {
 		update = {


### PR DESCRIPTION
Don't make a URL lookup to get the concordance every time an item is shown. Load thie concordance from a gitsubmodule table and cache it as HashMap.

Follows #1893.