### PR TITLE
Create DOIs only from true DOI resolver links #1925

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -98,9 +98,9 @@ end
 # 856 - Electronic Location and Access (R) - Subfield: $u (R) $3 (NR)
 # 1. Indicator: 4 = HTTP
 do list(path:"8564?", "var":"$i")
-  if all_match("$i.u", ".*(10\\.(\\d)+/(\\S)+).*") # Volltext
+  if all_match("$i.u", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*") # Volltext
     copy_field("$i.u", "doi[].$append")
-    replace_all("doi[].$last", ".*(10\\.(\\d)+/(\\S)+).*", "$1")
+    replace_all("doi[].$last", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*", "$1")
   end
 end
 uniq("doi[]")

--- a/src/test/resources/alma-fix/991002103529706485.json
+++ b/src/test/resources/alma-fix/991002103529706485.json
@@ -2,7 +2,6 @@
   "@context" : "http://lobid.org/resources/context.jsonld",
   "almaMmsId" : "991002103529706485",
   "isbn" : [ "9783838557823", "3838557824" ],
-  "doi" : [ "10.36198/9783838557823" ],
   "oclcNumber" : [ "1277506540" ],
   "title" : "Grundkurs Kinder- und Jugendhilferecht für die Soziale Arbeit",
   "otherTitleInformation" : [ "mit 62 Übersichten, 3 Tabellen, 14 Fallbeispielen und Musterlösungen" ],
@@ -60,9 +59,6 @@
   "sameAs" : [ {
     "id" : "http://worldcat.org/oclc/1277506540",
     "label" : "OCLC Ressource"
-  }, {
-    "id" : "https://doi.org/10.36198/9783838557823",
-    "label" : "9783838557823"
   } ],
   "isPartOf" : [ {
     "type" : [ "IsPartOfRelation" ],
@@ -70,10 +66,6 @@
       "label" : "UTB ;"
     } ],
     "numbering" : "2878 ;Soziale Arbeit"
-  } ],
-  "fulltextOnline" : [ {
-    "id" : "https://doi.org/10.36198/9783838557823",
-    "label" : "DOI-Link"
   } ],
   "related" : [ {
     "note" : [ "Erscheint auch als: Druck-Ausgabe" ],


### PR DESCRIPTION
Resolves #1925

Creating links that contain DOIs but are not DOI resolver links are  not reliable to identify DOIs.