### PR TITLE
Add non-electronics maps to the medium "print"

### DIFF
--- a/src/main/resources/alma/fix/mediumAndType.fix
+++ b/src/main/resources/alma/fix/mediumAndType.fix
@@ -179,6 +179,10 @@ elsif any_match("@leaderTyp+008", "(Book|Music|Continuing Resources|Mixed materi
   add_field("medium[].$append.label","Print")
 elsif any_match("@leaderTyp+008", "(Map|Visual materials)(.{29})[dr].*")  # Pos29
   add_field("medium[].$append.label","Print")
+elsif any_match("@leaderTyp+008", "Map.*")
+unless any_match("337.b","c")  # add medium "print" if map is non-electronic (337b code b computermedia)
+  add_field("medium[].$append.label","Print")
+end  
 # elsif any_match("@leaderTyp+008", "(Visual materials)(.{33})b.*")  # Pos33  I excluded Kit
 #  add_field("medium[].$append.label","Print")
 elsif any_match("006", "[acdpst]](.{5})[dr].*") # Pos00+06 Added Print for pos 006.

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -90,8 +90,8 @@
     "id" : "http://lobid.org/items/990193806600206441:DE-6:23526297370006449#!"
   } ],
   "medium" : [ {
-    "label" : "Sonstige",
-    "id" : "http://purl.org/lobid/lv#Miscellaneous"
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
   } ],
   "bibliographicLevel" : {
     "label" : "Monograph/Item",


### PR DESCRIPTION
Resolves #1970 

Maps have not yet been included in the "print" medium, so the "Miscellaneous" label was set by default.