### PR TITLE
Add inCollection for Digibib hbz VK #2021

### DIFF
--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -392,6 +392,21 @@ if exists("@inNZ")
   add_field("inCollection[].$last.label", "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone")
 end
 
+# digiBib hbz Vk
+
+if any_equal("MBD  .M", "49HBZ_NETWORK")
+  if any_match("POR  .A", ".*")
+    add_field("@inDigibibVK", "true")
+  else
+    add_field("@inDigibibVK", "true")
+  end
+end
+
+if exists("@inDigibibVK")
+  add_field("inCollection[].$append.id", "https://nrw.digibib.net/search/hbzvk/")
+  add_field("inCollection[].$last.label", "Digibib hbz Verbundkatalog")
+end
+
 # zdb
 
 if exists("zdbId")

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -376,8 +376,11 @@ replace_all("related[].*.label","<<|>>","")
 set_array("inCollection[]")
 
 # hbz NZ
+# digiBib hbz Vk
 
 if any_equal("MBD  .M", "49HBZ_NETWORK")
+  add_field("inCollection[].$append.id", "https://nrw.digibib.net/search/hbzvk/")
+  add_field("inCollection[].$last.label", "DigiBib hbz Verbundkatalog")
   if any_match("POR  .A", ".*")
     add_field("@inNZ", "true")
   else
@@ -390,21 +393,6 @@ end
 if exists("@inNZ")
   add_field("inCollection[].$append.id", "http://lobid.org/organisations/DE-655#!")
   add_field("inCollection[].$last.label", "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone")
-end
-
-# digiBib hbz Vk
-
-if any_equal("MBD  .M", "49HBZ_NETWORK")
-  if any_match("POR  .A", ".*")
-    add_field("@inDigibibVK", "true")
-  else
-    add_field("@inDigibibVK", "true")
-  end
-end
-
-if exists("@inDigibibVK")
-  add_field("inCollection[].$append.id", "https://nrw.digibib.net/search/hbzvk/")
-  add_field("inCollection[].$last.label", "Digibib hbz Verbundkatalog")
 end
 
 # zdb

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -74,12 +74,12 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2019/04/06/file_4/8295425.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -77,6 +77,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -73,6 +73,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "extent" : "XV, 607 S.",
   "natureOfContent" : [ {

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -70,12 +70,12 @@
     } ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "extent" : "XV, 607 S.",

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -67,6 +67,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -64,12 +64,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -73,12 +73,12 @@
     "label" : "Tägliche Einspiel-Übungen"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "extent" : "80 S. + lose Beil.",

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -76,6 +76,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "extent" : "80 S. + lose Beil.",
   "subject" : [ {

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -69,12 +69,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -72,6 +72,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -74,6 +74,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Sovetskoe administrativnoe pravo dt.",

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -71,12 +71,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990026405480206441.json
+++ b/src/test/resources/alma-fix/990026405480206441.json
@@ -69,12 +69,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990026405480206441.json
+++ b/src/test/resources/alma-fix/990026405480206441.json
@@ -72,6 +72,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -65,6 +65,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Carmina",

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -62,12 +62,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -67,6 +67,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/chi",

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -64,12 +64,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -73,6 +73,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "subject" : [ {
     "notation" : "200",

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -70,12 +70,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "subject" : [ {

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -67,6 +67,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "extent" : "104 Spielkt. : Ill. ; Begleith",
   "hasItem" : [ {

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -64,12 +64,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "extent" : "104 Spielkt. : Ill. ; Begleith",

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -75,12 +75,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -78,6 +78,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -81,6 +81,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/fre",

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -78,12 +78,12 @@
     } ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -62,12 +62,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "hasItem" : [ {

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -65,6 +65,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -80,6 +80,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -76,12 +76,12 @@
     "label" : "NWBib-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -99,6 +99,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -95,12 +95,12 @@
     "id" : "http://lobid.org/resources/ZDB-1429221-X#!"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990054089950206441.json
+++ b/src/test/resources/alma-fix/990054089950206441.json
@@ -225,6 +225,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990054089950206441.json
+++ b/src/test/resources/alma-fix/990054089950206441.json
@@ -221,12 +221,12 @@
     "label" : "Der Spiegel <Marburg>"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -87,6 +87,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -83,12 +83,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -87,6 +87,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -83,12 +83,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -88,12 +88,12 @@
     "label" : "NWBib-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -92,6 +92,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -97,6 +97,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -93,12 +93,12 @@
     "label" : "NWBib-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -87,12 +87,12 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2021/05/31/file_1/9034428.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -90,6 +90,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Hú̀rdú̀s ham-meleḵ dt.",

--- a/src/test/resources/alma-fix/990058567920206441.json
+++ b/src/test/resources/alma-fix/990058567920206441.json
@@ -86,6 +86,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990058567920206441.json
+++ b/src/test/resources/alma-fix/990058567920206441.json
@@ -83,12 +83,12 @@
     "numbering" : "239"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -83,12 +83,12 @@
     "numbering" : "29"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -86,6 +86,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -83,6 +83,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -80,12 +80,12 @@
     "numbering" : "509"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -82,6 +82,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -79,12 +79,12 @@
     "numbering" : "42,2,3"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -77,6 +77,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -74,12 +74,12 @@
     "numbering" : "1934,4"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -71,12 +71,12 @@
     "numbering" : "1,2"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "extent" : "XI, 131 S. : zahlr. Ill., graph. Darst.",

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -74,6 +74,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "extent" : "XI, 131 S. : zahlr. Ill., graph. Darst.",
   "subject" : [ {

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -87,6 +87,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -83,12 +83,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -84,6 +84,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -80,12 +80,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -93,6 +93,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -89,12 +89,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -94,12 +94,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -98,6 +98,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -98,6 +98,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -94,12 +94,12 @@
     "issn" : [ "09558810" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -93,12 +93,12 @@
     "label" : "Yearbook of anthropology"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -97,6 +97,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -103,6 +103,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -99,12 +99,12 @@
     } ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -84,6 +84,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -80,12 +80,12 @@
     "numbering" : "2"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -71,12 +71,12 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -75,6 +75,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -71,12 +71,12 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -75,6 +75,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -80,6 +80,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -76,12 +76,12 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -86,6 +86,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -82,12 +82,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -74,12 +74,12 @@
     } ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -77,6 +77,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -81,12 +81,12 @@
     "label" : "Reproduktion"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -84,6 +84,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -89,12 +89,12 @@
     "note" : [ "Reproduktion von" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -92,6 +92,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990119186660206441.json
+++ b/src/test/resources/alma-fix/990119186660206441.json
@@ -89,12 +89,12 @@
     "issn" : [ "01634844" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990119186660206441.json
+++ b/src/test/resources/alma-fix/990119186660206441.json
@@ -93,6 +93,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -73,6 +73,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Folk song arrangements",

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -70,12 +70,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -81,6 +81,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "extent" : "1 Kompaktkassette",
   "bibliographicLevel" : {

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -78,12 +78,12 @@
     "numbering" : "Tonkassette"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "extent" : "1 Kompaktkassette",

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -80,6 +80,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -77,12 +77,12 @@
     "numbering" : "5"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -75,12 +75,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -78,6 +78,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -94,6 +94,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -90,12 +90,12 @@
     "id" : "https://nwbib.de/"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -92,12 +92,12 @@
     "id" : "http://lobid.org/resources/ZDB-2254689-3#!"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -96,6 +96,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -63,12 +63,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -66,6 +66,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Kantaten / Ausw.",

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -81,12 +81,12 @@
     "numbering" : "F,2001,1"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -84,6 +84,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "De arte venandi cum avibus",

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -84,6 +84,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -81,12 +81,12 @@
     } ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -78,6 +78,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -75,12 +75,12 @@
     "numbering" : "1"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -71,12 +71,12 @@
     "label" : "Strukturelle und biochemische Einblicke in Mechanismen des Nukleotidaustauschs von Rab-Proteinen"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -74,6 +74,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990156060190206441.json
+++ b/src/test/resources/alma-fix/990156060190206441.json
@@ -87,12 +87,12 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage/2007/06/08/file_68/1996377.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990156060190206441.json
+++ b/src/test/resources/alma-fix/990156060190206441.json
@@ -90,6 +90,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990166236770206441.json
+++ b/src/test/resources/alma-fix/990166236770206441.json
@@ -86,12 +86,12 @@
     "label" : "Abhandlungen der Akademie der Wissenschaften zu Göttingen"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "predecessor" : [ {

--- a/src/test/resources/alma-fix/990166236770206441.json
+++ b/src/test/resources/alma-fix/990166236770206441.json
@@ -89,6 +89,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "predecessor" : [ {
     "label" : "Akademie der Wissenschaften <Göttingen> / Philologisch-Historische Klasse: Abhandlungen der Akademie der Wissenschaften zu Göttingen, Philologisch-Historische Klasse",

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -66,12 +66,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "extent" : "53 BL. MIT ZAHLR. ABB. U. TAF., TEILS FARB.",

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -69,6 +69,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "extent" : "53 BL. MIT ZAHLR. ABB. U. TAF., TEILS FARB.",
   "note" : [ "NE: SOHLE 1 <GALERIE, BERGKAMEN>. - AUSSTELLUNGSKAT." ],

--- a/src/test/resources/alma-fix/990170546170206441.json
+++ b/src/test/resources/alma-fix/990170546170206441.json
@@ -87,12 +87,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990170546170206441.json
+++ b/src/test/resources/alma-fix/990170546170206441.json
@@ -91,6 +91,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -79,6 +79,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -76,12 +76,12 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage/2011/07/09/file_16/4219074.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990172512030206441.json
+++ b/src/test/resources/alma-fix/990172512030206441.json
@@ -64,12 +64,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990172512030206441.json
+++ b/src/test/resources/alma-fix/990172512030206441.json
@@ -67,6 +67,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -77,12 +77,12 @@
     "numbering" : "Vontei"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -80,6 +80,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -76,6 +76,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -73,12 +73,12 @@
     "numbering" : "1"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990182814750206441.json
+++ b/src/test/resources/alma-fix/990182814750206441.json
@@ -123,6 +123,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/jpn",

--- a/src/test/resources/alma-fix/990182814750206441.json
+++ b/src/test/resources/alma-fix/990182814750206441.json
@@ -120,12 +120,12 @@
     "numbering" : "2"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -94,12 +94,12 @@
     "label" : "Bericht der Beschwerdekommission  / PsychiatrieVerbund Westfalen, Beschwerdekommission"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -98,6 +98,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -75,6 +75,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Pierrot",

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -72,12 +72,12 @@
     "label" : "Mélodies / Claude Debussy"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990183958380206441.json
+++ b/src/test/resources/alma-fix/990183958380206441.json
@@ -82,12 +82,12 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2019/08/02/file_154/8623447.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990183958380206441.json
+++ b/src/test/resources/alma-fix/990183958380206441.json
@@ -86,6 +86,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -102,6 +102,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -98,12 +98,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -70,12 +70,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -73,6 +73,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -78,12 +78,12 @@
     "label" : "OCLC Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -81,6 +81,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Faust",

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -84,12 +84,12 @@
     "isbn" : [ "9783840334900", "384033490X" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -87,6 +87,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -75,6 +75,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -71,12 +71,12 @@
     "label" : "Westfalen"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -75,6 +75,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -72,12 +72,12 @@
     "id" : "http://digitale-objekte.hbz-nrw.de/storage2/2019/08/04/file_26/8646388.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -117,6 +117,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -113,12 +113,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -70,12 +70,12 @@
     "label" : "Reproduktion"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -73,6 +73,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/lat",

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -82,6 +82,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -79,12 +79,12 @@
     "label" : "Reproduktion"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -68,12 +68,12 @@
     } ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -71,6 +71,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -94,12 +94,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -98,6 +98,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -100,12 +100,12 @@
     "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?2719150"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -104,6 +104,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -81,12 +81,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "https://lobid.org/collections#ldd",

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -85,6 +85,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "https://lobid.org/collections#ldd",
     "type" : [ "Collection" ],
     "label" : "collections#ldd"

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -101,6 +101,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-2-STI#!",
     "label" : "Springer ebook collection / Technik und Informatik",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -97,12 +97,12 @@
     "isbn" : [ "9783642320781", "3642320783" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-2-STI#!",

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -75,6 +75,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -72,12 +72,12 @@
     "id" : "http://deposit.dnb.de/cgi-bin/dokserv?id=2649059&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -87,6 +87,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -84,12 +84,12 @@
     "label" : "Advances in special education"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990202474680206441.json
+++ b/src/test/resources/alma-fix/990202474680206441.json
@@ -102,12 +102,12 @@
     "numbering" : "3"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990202474680206441.json
+++ b/src/test/resources/alma-fix/990202474680206441.json
@@ -105,6 +105,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/jpn",

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -84,6 +84,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -80,12 +80,12 @@
     "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4685554&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990204253490206441.json
+++ b/src/test/resources/alma-fix/990204253490206441.json
@@ -83,12 +83,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT016925914#!",

--- a/src/test/resources/alma-fix/990204253490206441.json
+++ b/src/test/resources/alma-fix/990204253490206441.json
@@ -87,6 +87,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -93,6 +93,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -89,12 +89,12 @@
     "isbn" : [ "9783412221607", "3412221600" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -74,12 +74,12 @@
     "numbering" : "3"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -77,6 +77,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -85,12 +85,12 @@
     "note" : [ "Enthalten in" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -88,6 +88,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -67,12 +67,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -70,6 +70,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Momento capriccioso",

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -79,12 +79,12 @@
     "id" : "http://deposit.d-nb.de/cgi-bin/dokserv?id=4521553&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -83,6 +83,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -88,12 +88,12 @@
     "label" : "Classics in linguistics"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -92,6 +92,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -72,12 +72,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -75,6 +75,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "Lieder aus letzter Zeit",

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -75,6 +75,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "containsExampleOfWork" : [ {
     "label" : "La forza del destino. Ouvertüre",

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -72,12 +72,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "containsExampleOfWork" : [ {

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -75,12 +75,12 @@
     "label" : "Zeitschrift des Geschichtsvereins Mülheim a. d. Ruhr"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -79,6 +79,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -96,6 +96,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -92,12 +92,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT016925914#!",

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -100,6 +100,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://repository.publisso.de",
     "label" : "Fachrepositorium Lebenswissenschaften",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -96,12 +96,12 @@
     "label" : "DOI-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://repository.publisso.de",

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -80,6 +80,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -76,12 +76,12 @@
     "label" : "NWBib-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -75,6 +75,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "https://lobid.org/collections#cuvillier",
     "type" : [ "Collection" ],
     "label" : "Cuvillier-E-Books"

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -71,12 +71,12 @@
     "isbn" : [ "9783736992580", "3736992580" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "https://lobid.org/collections#cuvillier",

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -87,12 +87,12 @@
     "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -91,6 +91,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -92,12 +92,12 @@
     "isbn" : [ "9783839436547", "3839436540" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -95,6 +95,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -84,12 +84,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT016925914#!",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -88,6 +88,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990218189790206441.json
+++ b/src/test/resources/alma-fix/990218189790206441.json
@@ -100,6 +100,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/jpn",

--- a/src/test/resources/alma-fix/990218189790206441.json
+++ b/src/test/resources/alma-fix/990218189790206441.json
@@ -97,12 +97,12 @@
     "numbering" : "1"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -69,12 +69,12 @@
     "id" : "http://hss-opus.ub.ruhr-uni-bochum.de/scans/NowackNikola/Zusammenfassung.pdf"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -72,6 +72,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990220027540206441.json
+++ b/src/test/resources/alma-fix/990220027540206441.json
@@ -72,6 +72,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/hin",

--- a/src/test/resources/alma-fix/990220027540206441.json
+++ b/src/test/resources/alma-fix/990220027540206441.json
@@ -69,12 +69,12 @@
     "numbering" : "1"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -88,12 +88,12 @@
     "id" : "http://deposit.dnb.de/cgi-bin/dokserv?id=c575d80bb6cd4fbbbe8bf63f61eceae9&prov=M&dok_var=1&dok_ext=htm"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -91,6 +91,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -76,12 +76,12 @@
     "numbering" : "3"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -79,6 +79,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -94,6 +94,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://repository.publisso.de",
     "label" : "Fachrepositorium Lebenswissenschaften",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -90,12 +90,12 @@
     "label" : "DOI-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://repository.publisso.de",

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -76,6 +76,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -72,12 +72,12 @@
     "label" : "Der Rhein / herausgegeben von/édité par Hélène Miard-Delacroix, Guido Thiemeyer"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -95,6 +95,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-197-MSE#!",
     "label" : "Mohr Siebeck eBooks",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -91,12 +91,12 @@
     "isbn" : [ "9783161546105", "3161546105" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-197-MSE#!",

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -88,12 +88,12 @@
     "label" : "Why does the Sustainable Development Goal on Education (SDG 4) matter for OECD countries?"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-13-SOC#!",

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -92,6 +92,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-13-SOC#!",
     "label" : "OECD iLibrary",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990366338340206441.json
+++ b/src/test/resources/alma-fix/990366338340206441.json
@@ -75,12 +75,12 @@
     "label" : "Mittelniederdeutsche Studien II / Robert Peters; herausgegeben von Christina Eichhorn-Hartmeyer, Verena Kleymann, Norbert Nagel, Meike Tiedemann"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990366338340206441.json
+++ b/src/test/resources/alma-fix/990366338340206441.json
@@ -79,6 +79,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -57,12 +57,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -60,6 +60,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/nds",

--- a/src/test/resources/alma-fix/990366624790206441.json
+++ b/src/test/resources/alma-fix/990366624790206441.json
@@ -78,12 +78,12 @@
     "isbn" : [ "9783531171333", "353117133X" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-30-PQE#!",

--- a/src/test/resources/alma-fix/990366624790206441.json
+++ b/src/test/resources/alma-fix/990366624790206441.json
@@ -82,6 +82,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-30-PQE#!",
     "label" : "ProQuest Ebook Central",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990367593690206441.json
+++ b/src/test/resources/alma-fix/990367593690206441.json
@@ -95,6 +95,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/990367593690206441.json
+++ b/src/test/resources/alma-fix/990367593690206441.json
@@ -92,12 +92,12 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -77,6 +77,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-22-CAN#!",
     "label" : "Ciando",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -73,12 +73,12 @@
     "label" : "lobid Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-22-CAN#!",

--- a/src/test/resources/alma-fix/990367761810206441.json
+++ b/src/test/resources/alma-fix/990367761810206441.json
@@ -103,6 +103,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/jpn",

--- a/src/test/resources/alma-fix/990367761810206441.json
+++ b/src/test/resources/alma-fix/990367761810206441.json
@@ -100,12 +100,12 @@
     "numbering" : "106"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/990368319120206441.json
+++ b/src/test/resources/alma-fix/990368319120206441.json
@@ -76,6 +76,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/990368319120206441.json
+++ b/src/test/resources/alma-fix/990368319120206441.json
@@ -72,12 +72,12 @@
     "label" : "Alternative Kommunal Politik"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -61,6 +61,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/fre",

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -58,12 +58,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -73,6 +73,10 @@
     "issn" : [ "07206763" ]
   } ],
   "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -74,7 +74,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -95,6 +95,10 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -96,7 +96,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/99370690532406441.json
+++ b/src/test/resources/alma-fix/99370690532406441.json
@@ -70,6 +70,11 @@
   "related" : [ {
     "issn" : [ "16105982" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99370690532406441.json
+++ b/src/test/resources/alma-fix/99370690532406441.json
@@ -72,7 +72,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -94,7 +94,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -93,6 +93,10 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -88,6 +88,10 @@
     "issn" : [ "21900574" ]
   } ],
   "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -89,7 +89,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/99370738710506441.json
+++ b/src/test/resources/alma-fix/99370738710506441.json
@@ -80,7 +80,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370738710506441.json
+++ b/src/test/resources/alma-fix/99370738710506441.json
@@ -78,6 +78,11 @@
   "related" : [ {
     "isbn" : [ "9789004297982", "9004297987" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -83,7 +83,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -81,6 +81,11 @@
   "related" : [ {
     "isbn" : [ "9780444533999", "0444533990" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -83,7 +83,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -81,6 +81,11 @@
   "related" : [ {
     "isbn" : [ "9780271084749", "027108474X" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -74,6 +74,11 @@
   }, {
     "isbn" : [ "9789027237019", "9027237018" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -76,7 +76,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370771475306441.json
+++ b/src/test/resources/alma-fix/99370771475306441.json
@@ -84,12 +84,12 @@
     "isbn" : [ "9789783405264", "9783405268" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370771475306441.json
+++ b/src/test/resources/alma-fix/99370771475306441.json
@@ -87,6 +87,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -85,6 +85,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -82,12 +82,12 @@
     "numbering" : "2"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99370970534006441.json
+++ b/src/test/resources/alma-fix/99370970534006441.json
@@ -84,12 +84,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT016925914#!",

--- a/src/test/resources/alma-fix/99370970534006441.json
+++ b/src/test/resources/alma-fix/99370970534006441.json
@@ -88,6 +88,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016925914#!",
     "label" : "Edoweb Rheinland-Pfalz",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99371014448006441.json
+++ b/src/test/resources/alma-fix/99371014448006441.json
@@ -71,12 +71,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371014448006441.json
+++ b/src/test/resources/alma-fix/99371014448006441.json
@@ -74,6 +74,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",

--- a/src/test/resources/alma-fix/99371050452706441.json
+++ b/src/test/resources/alma-fix/99371050452706441.json
@@ -96,6 +96,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99371050452706441.json
+++ b/src/test/resources/alma-fix/99371050452706441.json
@@ -92,12 +92,12 @@
     "id" : "http://www.epubli.de/shop/isbn/9783754906675"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -69,6 +69,11 @@
   "related" : [ {
     "issn" : [ "24715506" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -71,7 +71,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -84,7 +84,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -82,6 +82,11 @@
     "note" : [ "Print version (hardback):" ],
     "isbn" : [ "9783631660126", "363166012X" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"

--- a/src/test/resources/alma-fix/99371147104906441.json
+++ b/src/test/resources/alma-fix/99371147104906441.json
@@ -68,7 +68,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371147104906441.json
+++ b/src/test/resources/alma-fix/99371147104906441.json
@@ -66,6 +66,11 @@
     "id" : "http://worldcat.org/oclc/1294170936",
     "label" : "OCLC Ressource"
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -81,12 +81,12 @@
     "isbn" : [ "9781444335804", "1444335804" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-35-Wiley-EBA#!",

--- a/src/test/resources/alma-fix/99371314897806441.json
+++ b/src/test/resources/alma-fix/99371314897806441.json
@@ -85,6 +85,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-35-Wiley-EBA#!",
     "type" : [ "Collection" ],
     "label" : "lobid Organisation"

--- a/src/test/resources/alma-fix/99371426239306441.json
+++ b/src/test/resources/alma-fix/99371426239306441.json
@@ -83,6 +83,11 @@
     "id" : "https://doi.org/10.1007/978-3-319-59952-6",
     "label" : "DOI-Link"
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99371426239306441.json
+++ b/src/test/resources/alma-fix/99371426239306441.json
@@ -85,7 +85,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -112,6 +112,11 @@
   "related" : [ {
     "isbn" : [ "9780702075599", "0702075590" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -114,7 +114,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -73,6 +73,11 @@
   "related" : [ {
     "isbn" : [ "9781784714864", "1784714860" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -75,7 +75,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371463467006441.json
+++ b/src/test/resources/alma-fix/99371463467006441.json
@@ -70,6 +70,11 @@
       "label" : "PsychBooks Collection"
     } ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99371463467006441.json
+++ b/src/test/resources/alma-fix/99371463467006441.json
@@ -72,7 +72,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371530278506441.json
+++ b/src/test/resources/alma-fix/99371530278506441.json
@@ -103,6 +103,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "label" : "De ente et essentia",

--- a/src/test/resources/alma-fix/99371530278506441.json
+++ b/src/test/resources/alma-fix/99371530278506441.json
@@ -100,12 +100,12 @@
     "numbering" : "44"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/99371791018506441.json
+++ b/src/test/resources/alma-fix/99371791018506441.json
@@ -69,12 +69,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-94-OAB#!",

--- a/src/test/resources/alma-fix/99371791018506441.json
+++ b/src/test/resources/alma-fix/99371791018506441.json
@@ -73,6 +73,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-94-OAB#!",
     "label" : "Directory of Open Access Books",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99371883990606441.json
+++ b/src/test/resources/alma-fix/99371883990606441.json
@@ -85,12 +85,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT016356466#!",

--- a/src/test/resources/alma-fix/99371883990606441.json
+++ b/src/test/resources/alma-fix/99371883990606441.json
@@ -89,6 +89,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT016356466#!",
     "label" : "Elektronische Zeitschriftenbibliothek (EZB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99371964653806441.json
+++ b/src/test/resources/alma-fix/99371964653806441.json
@@ -88,12 +88,12 @@
     "isbn" : [ "9783506770622", "3506770624" ]
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/organisations/ZDB-41-UTB-EBA#!",

--- a/src/test/resources/alma-fix/99371964653806441.json
+++ b/src/test/resources/alma-fix/99371964653806441.json
@@ -92,6 +92,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/organisations/ZDB-41-UTB-EBA#!",
     "type" : [ "Collection" ],
     "label" : "lobid Organisation"

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -88,12 +88,12 @@
     "id" : "http://www.bibliothek.uni-regensburg.de/ezeit/?3154709"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014846970#!",

--- a/src/test/resources/alma-fix/99371981001306441.json
+++ b/src/test/resources/alma-fix/99371981001306441.json
@@ -92,6 +92,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014846970#!",
     "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99372423490706441.json
+++ b/src/test/resources/alma-fix/99372423490706441.json
@@ -68,6 +68,10 @@
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
+  }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {
     "language" : [ {

--- a/src/test/resources/alma-fix/99372423490706441.json
+++ b/src/test/resources/alma-fix/99372423490706441.json
@@ -65,12 +65,12 @@
     "label" : "Culturegraph Ressource"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   } ],
   "exampleOfWork" : {

--- a/src/test/resources/alma-fix/99372483173006441.json
+++ b/src/test/resources/alma-fix/99372483173006441.json
@@ -76,6 +76,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/src/test/resources/alma-fix/99372483173006441.json
+++ b/src/test/resources/alma-fix/99372483173006441.json
@@ -72,12 +72,12 @@
     "label" : "UFOs, Märchen und ein Mythos / herausgegeben im Auftrag der Gesellschaft für Heimatkunde Wanne-Eickel e.V. von Frank Sichau ; Redaktion: Joachim Wittkowski"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/99372680948006441.json
+++ b/src/test/resources/alma-fix/99372680948006441.json
@@ -101,6 +101,11 @@
   }, {
     "isbn" : [ "9780745648446", "0745648444" ]
   } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
   "language" : [ {
     "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
     "label" : "Englisch"

--- a/src/test/resources/alma-fix/99372680948006441.json
+++ b/src/test/resources/alma-fix/99372680948006441.json
@@ -103,7 +103,7 @@
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99373637266706441.json
+++ b/src/test/resources/alma-fix/99373637266706441.json
@@ -93,12 +93,12 @@
     "label" : "URN-Link"
   } ],
   "inCollection" : [ {
-    "id" : "http://lobid.org/organisations/DE-655#!",
-    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
     "type" : [ "Collection" ]
   }, {
-    "id" : "https://nrw.digibib.net/search/hbzvk/",
-    "label" : "Digibib hbz Verbundkatalog",
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
     "id" : "http://lobid.org/resources/HT014176012#!",

--- a/src/test/resources/alma-fix/99373637266706441.json
+++ b/src/test/resources/alma-fix/99373637266706441.json
@@ -97,6 +97,10 @@
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
     "type" : [ "Collection" ]
   }, {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "Digibib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
     "id" : "http://lobid.org/resources/HT014176012#!",
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -67,7 +67,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "publication.location:Berlin AND publication.startDate:[1992 TO 2017]", /*->*/ 5 },
 			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 133 },
-            { "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 150 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 150 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -67,6 +67,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "publication.location:Berlin AND publication.startDate:[1992 TO 2017]", /*->*/ 5 },
 			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 133 },
+            { "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 150 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
See #2021

FEX Daten decided they want all CZ publication be findable in the Digibib hbz
 Verbundkatalog. Since these CZ publications are not part of the genuine NZ we add a new inCollection-statement. It includes NZ+CZ resources.