### PR TITLE
Schema: Adjust hasItem: loose constant value for type property #1340

### DIFF
--- a/src/test/resources/schemas/hasItem.json
+++ b/src/test/resources/schemas/hasItem.json
@@ -15,7 +15,7 @@
             "type": {
                 "title": "Type",
                 "type": "array",
-                "items": {
+                "contains": {
                     "const": "Item"
                 }
             },


### PR DESCRIPTION
Schema only accepted `Item` as `type` in `hasItem` but we also have additional type classes:
`PhysicalObject`, `DigitalDocument`, `NurTitel`, `PhysikalischerTitel`

Since #1699 is not solved yet @maipet suggested to loosen up the type specification. (Written by @TobiasNx )