### PR TITLE
Improve some subject mappings

### DIFF
--- a/src/main/resources/alma/fix/subjects.fix
+++ b/src/main/resources/alma/fix/subjects.fix
@@ -267,7 +267,7 @@ do list(path:"084??", "var":"$i")
   end
   unless any_contain("$i.0", "https://nwbib.de/") # filter out any nwbib concepts
     unless any_match("$i.a", "^rpbr.*") # filter out any RPB Spatial
-      unless any_match("$i.2", "ssgn|fid") # filter out any Sondersammelgebiete and Fachinformationsdienste
+      unless any_match("$i.2", "ssgn|fid|z") # filter out any Sondersammelgebiete and Fachinformationsdienste
         do list(path:"$i.a", "var":"$j")
           copy_field("$j", "subject[].$append.notation")
           set_array("subject[].$last.type[]","Concept")

--- a/src/main/resources/alma/fix/subjects.fix
+++ b/src/main/resources/alma/fix/subjects.fix
@@ -267,7 +267,7 @@ do list(path:"084??", "var":"$i")
   end
   unless any_contain("$i.0", "https://nwbib.de/") # filter out any nwbib concepts
     unless any_match("$i.a", "^rpbr.*") # filter out any RPB Spatial
-      unless any_match("$i.2", "ssgn|fid|z") # filter out any Sondersammelgebiete and Fachinformationsdienste
+      unless any_match("$i.2", "z") # filter out any z Other - Classification
         do list(path:"$i.a", "var":"$j")
           copy_field("$j", "subject[].$append.notation")
           set_array("subject[].$last.type[]","Concept")

--- a/src/main/resources/alma/maps/classification.tsv
+++ b/src/main/resources/alma/maps/classification.tsv
@@ -1,6 +1,5 @@
 udc	UDC (Universal Decimal Classification)	https://d-nb.info/gnd/4114037-0
 sdnb	Sachgruppen der DNB	https://bartoc.org/en/node/20049
-methepp	Methode Eppelsheimer
 bkl	BK (Basisklassifikation)	http://bartoc.org/en/node/18785
 rvk	RVK (Regensburger Verbundklassifikation)	https://d-nb.info/gnd/4449787-8
 ghbs	Gesamthochschulbibliothekssystematik (GHBS)	https://www.ub.uni-siegen.de/ghbs/index.php
@@ -8,13 +7,12 @@ njb	NDC (Nippon Decimal Classification)	http://bartoc.org/en/node/18624
 kktb	NDLC (National Diet Library Classification)	http://bartoc.org/en/node/876
 rpb	RPB (Rheinland-Pfälzische Bibliographie)	http://bartoc.org/en/node/1990
 msc	MSC (Mathematics Subject Classification)	http://bartoc.org/en/node/20396
-asb	ASB (Allgemeine Systematik für Bibliotheken)
+asb	ASB (Allgemeine Systematik für Bibliotheken)	https://asb-kab-online.de/
 ssd	SSD (Systematik der Stadtbibliothek Duisburg)	http://bartoc.org/en/node/1051
 sfb	SfB (Systematik für Bibliotheken)	http://bartoc.org/en/node/335
 kab	KAB (Klassifikation für Allgemeinbibliotheken)	https://d-nb.info/gnd/4164032-9
-ekz	Systematiken der ekz
 stub	Systematik der TUB München	http://bartoc.org/en/node/495
-dopaed	DOPAED der UB Erlangen
+dopaed	DOPAED der UB Erlangen	https://bartoc.org/en/node/1653
 ifzs	IFZ-Systematik	http://bartoc.org/en/node/1245
 sbb	Systematik der Bayerischen Bibliographie	http://bartoc.org/en/node/1983
 zdbs	DDC-Sachgruppen der ZDB	https://zeitschriftendatenbank.de/fileadmin/user_upload/ZDB/pdf/zdbformat/5080.pdf

--- a/src/main/resources/alma/maps/classification.tsv
+++ b/src/main/resources/alma/maps/classification.tsv
@@ -18,3 +18,4 @@ dopaed	DOPAED der UB Erlangen
 ifzs	IFZ-Systematik	http://bartoc.org/en/node/1245
 sbb	Systematik der Bayerischen Bibliographie	http://bartoc.org/en/node/1983
 zdbs	DDC-Sachgruppen der ZDB	https://zeitschriftendatenbank.de/fileadmin/user_upload/ZDB/pdf/zdbformat/5080.pdf
+sswd	GND-Systematik	http://d-nb.info/standards/vocab/gnd/gnd-sc

--- a/src/main/resources/alma/maps/classification.tsv
+++ b/src/main/resources/alma/maps/classification.tsv
@@ -19,3 +19,5 @@ ifzs	IFZ-Systematik	http://bartoc.org/en/node/1245
 sbb	Systematik der Bayerischen Bibliographie	http://bartoc.org/en/node/1983
 zdbs	DDC-Sachgruppen der ZDB	https://zeitschriftendatenbank.de/fileadmin/user_upload/ZDB/pdf/zdbformat/5080.pdf
 sswd	GND-Systematik	http://d-nb.info/standards/vocab/gnd/gnd-sc
+fid	FID-Klassifikation	http://bartoc.org/en/node/18929
+ssgn	Sondersammelgebiets-Nummer	https://bartoc.org/en/node/18928

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -178,8 +178,8 @@
     "notation" : "6.4",
     "type" : [ "Concept" ],
     "source" : {
-      "label" : "sswd",
-      "id" : "sswd"
+      "label" : "GND-Systematik",
+      "id" : "http://d-nb.info/standards/vocab/gnd/gnd-sc"
     }
   }, {
     "notation" : "UA 1000",

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -117,6 +117,13 @@
     "id" : "https://d-nb.info/gnd/4067488-5"
   } ],
   "subject" : [ {
+    "notation" : "8,1",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "notation" : "710",
     "type" : [ "Concept" ],
     "id" : "https://w3id.org/lobid/rpb2#n710",

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -113,6 +113,13 @@
     "id" : "https://d-nb.info/gnd/4142300-8"
   } ],
   "subject" : [ {
+    "notation" : "2",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "notation" : "330",
     "type" : [ "Concept" ],
     "source" : {

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -125,6 +125,20 @@
     "id" : "https://d-nb.info/gnd/4067488-5"
   } ],
   "subject" : [ {
+    "notation" : "PHARM",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "FID-Klassifikation",
+      "id" : "http://bartoc.org/en/node/18929"
+    }
+  }, {
+    "notation" : "15,3",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "notation" : "610",
     "type" : [ "Concept" ],
     "source" : {

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -134,6 +134,13 @@
     "id" : "https://d-nb.info/gnd/4067488-5"
   } ],
   "subject" : [ {
+    "notation" : "9,2",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "id" : "https://nwbib.de/subjects#N824040",
     "label" : "Komponisten",
     "notation" : "824040",

--- a/src/test/resources/alma-fix/990156060190206441.json
+++ b/src/test/resources/alma-fix/990156060190206441.json
@@ -114,13 +114,6 @@
       "label" : "LBZ-Notationen"
     }
   }, {
-    "notation" : "020",
-    "type" : [ "Concept" ],
-    "source" : {
-      "label" : "z",
-      "id" : "z"
-    }
-  }, {
     "notation" : "AN 76400",
     "type" : [ "Concept" ],
     "source" : {

--- a/src/test/resources/alma-fix/990166236770206441.json
+++ b/src/test/resources/alma-fix/990166236770206441.json
@@ -105,20 +105,6 @@
   } ],
   "note" : [ "Hauptsacht. N.F. 1.2008 - 2.2008: Neue Abhandlungen der Akademie der Wissenschaften zu Göttingen, Philologisch-Historische Klasse. Hauptsacht. N.F. 7.2009: Abhandlungen der Akademie der Wissenschaften zu Göttingen, Philologisch-Historische Klasse", "Urheber N.F. 1.2008 - 2.2008: Akademie der Wissenschaften zu Göttingen, Philologisch-Historische Klasse" ],
   "subject" : [ {
-    "notation" : "900",
-    "type" : [ "Concept" ],
-    "source" : {
-      "label" : "z",
-      "id" : "z"
-    }
-  }, {
-    "notation" : "800",
-    "type" : [ "Concept" ],
-    "source" : {
-      "label" : "z",
-      "id" : "z"
-    }
-  }, {
     "notation" : "125",
     "type" : [ "Concept" ],
     "source" : {

--- a/src/test/resources/alma-fix/990170546170206441.json
+++ b/src/test/resources/alma-fix/990170546170206441.json
@@ -109,6 +109,13 @@
     "id" : "https://d-nb.info/gnd/4067488-5"
   } ],
   "subject" : [ {
+    "notation" : "9,10",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "notation" : "510",
     "type" : [ "Concept" ],
     "id" : "https://w3id.org/lobid/rpb2#n510",

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -118,6 +118,13 @@
     "id" : "https://d-nb.info/gnd/4067510-5"
   } ],
   "subject" : [ {
+    "notation" : "7,261",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "notation" : "070",
     "type" : [ "Concept" ],
     "source" : {

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -126,6 +126,14 @@
     "label" : "Zeitung",
     "id" : "https://d-nb.info/gnd/4067510-5"
   } ],
+  "subject" : [ {
+    "notation" : "26",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  } ],
   "bibliographicLevel" : {
     "label" : "Serial",
     "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Serial"

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -209,6 +209,20 @@
     "notation" : "330",
     "version" : "sdnb"
   }, {
+    "notation" : "3,2",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
+    "notation" : "5,3",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Sondersammelgebiets-Nummer",
+      "id" : "https://bartoc.org/en/node/18928"
+    }
+  }, {
     "notation" : "280",
     "type" : [ "Concept" ],
     "source" : {


### PR DESCRIPTION
See #2045 and #2047

We have some notation/concept systems that were not mapped properly.
If they are `z` they are not defined but sorted under "Other",
`sswd`  on the other hand is the GND Systematik as SKOS System.

Not sure if we should also use the Labels for the GND Systematik.

This will also fix some validation errors from #1340 