### PR TITLE
Reuse nwbib fix for #1992, #1951 and  #1829

### DIFF
--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -91,8 +91,11 @@
   }}}
 }
 
-@lobidUrl(doc: JsValue) = @{
-  "http://lobid.org/resources/" + (doc\"almaMmsId").asOpt[String].orElse((doc\"hbzId").asOpt[String]).orElse((doc\"rpbId").asOpt[String]).getOrElse("") + "#!"
+@lobidUrlWithHbzId(doc: JsValue) = @{
+    "http://lobid.org/resources/" + ((doc\"hbzId").asOpt[String]).getOrElse("") + "#!"
+}
+@lobidUrlWithZdbId(doc: JsValue) = @{
+    "http://lobid.org/resources/ZDB-" + (doc\"zdbId").asOpt[String].getOrElse("") + "#!"
 }
 
 @lobid2_part_of(field: String, subField: String) = {
@@ -197,9 +200,13 @@
   @result_field("In", "containedIn", doc, TableRow.LINKS)
 
   @lobid2_part_of("isPartOf", "hasSuperordinate")
-  @defining(lobidUrl(doc)){ id =>
-   @subordinated("isPartOf.hasSuperordinate.id", id, "Bände", ("zugehöriger Band", "zugehörige Bände"))
-   @subordinated("containedIn.id", id, "Enthält", ("Beitrag", "Beiträge"))
+  @defining(lobidUrlWithZdbId(doc)){ id =>
+    @subordinated("isPartOf.hasSuperordinate.id", id, "Bände", ("zugehöriger Band", "zugehörige Bände"))
+    @subordinated("containedIn.id", id, "Enthält", ("Beitrag", "Beiträge"))
+  }
+  @defining(lobidUrlWithHbzId(doc)){ id =>
+    @subordinated("isPartOf.hasSuperordinate.id", id, "Bände", ("zugehöriger Band", "zugehörige Bände"))
+    @subordinated("containedIn.id", id, "Enthält", ("Beitrag", "Beiträge"))
   }
 
 

--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -188,8 +188,8 @@
   @for(pub <- sortedPublications((doc\"publication").asOpt[Seq[JsValue]].getOrElse(Seq()))){ @publication(pub) }
 
   @result_field("Auflage", "edition", doc, TableRow.VALUES)
-  @result_field("ISBN", "isbn", doc, TableRow.VALUES)
-  @result_field("ISSN", "issn", doc, TableRow.VALUES)
+  @result_field("ISBN", "isbn", doc, TableRow.VALUES, node = Option(doc))
+  @result_field("ISSN", "issn", doc, TableRow.VALUES, node = Option(doc))
   @withPrefixedLink("DOI", "https://dx.doi.org/", doc \ "doi")
   @withPrefixedLink("URN", "https://nbn-resolving.org/", doc \ "urn")
   @result_field("Umfang", "extent", doc, TableRow.VALUES)

--- a/web/app/views/tags/result_field.scala.html
+++ b/web/app/views/tags/result_field.scala.html
@@ -6,9 +6,10 @@
 @import java.util.Optional
 @import controllers.resources.Lobid
 
-@jsonVal(p: String) = @{ node match {
-  case Some(node) => node
-  case None => if ((doc \\ p).isEmpty) (doc \ p) else (doc \\ p).head
+@jsonVal(p: String) = @{
+	node match {
+		case Some(node) => (node \ p).asOpt[JsValue].getOrElse(node \ p)
+		case None => if ((doc \\ p).isEmpty) (doc \ p) else (doc \\ p).head
 	}
 }
 


### PR DESCRIPTION
Resolves #1951 and  #1829 Wrong ISBN and ISSN

and also fixes #1992 missing linking to Bände and Enthält

https://github.com/hbz/nwbib/issues/636