### PR TITLE
Preserve order of suggestions search results (#2065)

### DIFF
--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -394,7 +394,7 @@ public class Application extends Controller {
 								: typeText));
 			});
 		});
-		return Json.toJson(suggestions.collect(Collectors.toSet()));
+		return Json.toJson(suggestions.collect(Collectors.toList()));
 	}
 
 	private static Stream<JsonNode> fieldValues(String field, JsonNode document) {


### PR DESCRIPTION
Use ordered list (`toList`), not unordered set (`toSet`).

Will resolve #2065.

@dr0i: I wanted to deploy this to test for review, but https://test.lobid.org/resources is down, and there seems to be no monit process for it on our current test server (q3). Is this still missing from the move from q2 to q3? Or did you change something in the setup? This is a very small change, so  maybe the best process in this case would be that you review it and then deploy it straight to production? 