### PR TITLE
Make mapping for 856 less strict #2070

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -19,7 +19,7 @@ end
 # 1. Indicator: 4 = HTTP
 set_array("@urnLinks")
 
-do list(path:"8564?", "var":"$i")
+do list(path:"856??", "var":"$i")
   if all_match("$i.u", "^http.*(urn=|\\.(org|de)/)urn:.+$") # This should ignore repository links like: https://sammlungen.ulb.uni-muenster.de/urn/urn:nbn:de:hbz:6-85659520092
     copy_field("$i.u", "urn[].$append")
     copy_field("$i.u", "@urnLinks.$append")
@@ -100,12 +100,12 @@ end
 # Sometimes dois are not set in 024 then we could pick up the missing from 856.
 # 856 - Electronic Location and Access (R) - Subfield: $u (R) $3 (NR)
 # 1. Indicator: 4 = HTTP
-do list(path:"8564?", "var":"$i")
+do list(path:"856??", "var":"$i")
   if all_match("$i.u", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*") # Volltext
     copy_field("$i.u", "doi[].$append")
-    replace_all("doi[].$last", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*", "$1")
   end
 end
+replace_all("doi[].*", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*", "$1")
 uniq("doi[]")
 
 # 035 - System Control Number (R) - Subfield: $a (NR)

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -35,7 +35,7 @@ do list(path: "rpbId", "var": "$i")
 end
 
 # DBIS
-do list(path: "8564?", "var":"$i")
+do list(path: "856??", "var":"$i")
   if exists("$i.u")
     if all_match("$i.x", ".*DBIS.*")
       copy_field("$i.u", "sameAs[].$append.id")
@@ -254,7 +254,7 @@ replace_all("secondaryForm[].*.id", "^\\(DE-600\\)(.*)$", "http://lobid.org/reso
 
 set_array("tableOfContents[]")
 
-do list(path: "8564?", "var":"$i")
+do list(path: "856??", "var":"$i")
   if all_match("$i.3", "^[Ii][Nn][Hh][aA][lL][tT][sS][vV].*") # Inhaltsverzeichnis
     copy_field("$i.3", "tableOfContents[].$append.label")
     copy_field("$i.u", "tableOfContents[].$last.id")
@@ -263,7 +263,7 @@ end
 
 set_array("description[]")
 
-do list(path: "8564?", "var":"$i")
+do list(path: "856??", "var":"$i")
   if all_match("$i.3", "^[Ii][Nn][Hh][aA][lL][tT][sS][tT].*") # Inhaltstext
     copy_field("$i.3", "description[].$append.label")
     copy_field("$i.u", "description[].$last.id")
@@ -272,7 +272,7 @@ end
 
 set_array("seeAlso[]")
 
-do list(path: "8564?", "var":"$i")
+do list(path: "856??", "var":"$i")
   if all_match("$i.3", "^[zZ][uU][sS].*") # Zusätzliche Angaben
     copy_field("$i.3", "seeAlso[].$append.label")
     copy_field("$i.u", "seeAlso[].$last.id")
@@ -281,7 +281,7 @@ end
 
 set_array("fulltextOnline[]")
 
-do list(path: "8564?", "var":"$i")
+do list(path: "856??", "var":"$i")
   if exists("$i.u")
     unless any_match("$i.u",".*(doi.org|urn=urn:|\\.(org|de)/urn:).*") # This should not skip repository links like: https://sammlungen.ulb.uni-muenster.de/urn/urn:nbn:de:hbz:6-85659520092
       if all_equal("$i.z", "kostenfrei") # kostenfrei, added Digitalisierung not only Verlag or Agentur as filter
@@ -439,7 +439,7 @@ end
 
 # 856 - Electronic Location and Access (R) - Subfield: $x - Nonpublic note (R)
 # TODO: Check if src/test/resources/alma-fix/(CKB)5280000000199164.xml is also an EZB titel even when it has no 865.
-do list(path:"8564?", "var":"$i")
+do list(path:"856??", "var":"$i")
   if any_equal("$i.x","EZB") # can test x and x.*
     add_field("inCollection[].$append.id", "http://lobid.org/resources/HT016356466#!")
     add_field("inCollection[].$last.label", "Elektronische Zeitschriftenbibliothek (EZB)")
@@ -452,7 +452,7 @@ end
 
 # edoweb
 
-do list(path:"8564?", "var":"$i")
+do list(path:"856??", "var":"$i")
   if any_match("$i.u","^.*edoweb.*") # can test x and x.*
     add_field("inCollection[].$append.id", "http://lobid.org/resources/HT016925914#!")
     add_field("inCollection[].$last.label", "Edoweb Rheinland-Pfalz")
@@ -463,7 +463,7 @@ end
 
 
 # TODO: AlephMorph checked for ellinet in "078r1.a" but publisso is also stated in the Link URI is that enough?
-do list(path:"8564?", "var":"$i")
+do list(path:"856??", "var":"$i")
   if any_match("$i.u","^.*publisso.*") # can test x and x.*
     add_field("inCollection[].$append.id", "http://repository.publisso.de")
     add_field("inCollection[].$last.label", "Fachrepositorium Lebenswissenschaften")

--- a/src/test/resources/alma-fix/990177418660206441.json
+++ b/src/test/resources/alma-fix/990177418660206441.json
@@ -80,6 +80,22 @@
     "id" : "http://worldcat.org/oclc/838434577",
     "label" : "OCLC Ressource"
   } ],
+  "fulltextOnline" : [ {
+    "label" : "Volltext",
+    "id" : "http://www.gbv.de/dms/belser/aszese/74817-1.pdf"
+  }, {
+    "label" : "Volltext",
+    "id" : "http://www.gbv.de/dms/belser/aszese/74817-2.pdf"
+  }, {
+    "label" : "Volltext",
+    "id" : "http://www.gbv.de/dms/belser/aszese/74817-3.pdf"
+  }, {
+    "label" : "Volltext",
+    "id" : "http://www.gbv.de/dms/belser/aszese/74817-4.pdf"
+  }, {
+    "label" : "Volltext",
+    "id" : "http://www.gbv.de/dms/belser/aszese/74817-5.pdf"
+  } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
     "label" : "DigiBib hbz Verbundkatalog",

--- a/src/test/resources/alma-fix/990177418660206441.json
+++ b/src/test/resources/alma-fix/990177418660206441.json
@@ -1,0 +1,1146 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990177418660206441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Vollkommene Lebens-Art einer gottliebenden Seel",
+  "almaMmsId" : "990177418660206441",
+  "hbzId" : "TT050372336",
+  "deprecatedUri" : "http://lobid.org/resources/TT050372336#!",
+  "isbn" : [ "3628748178", "9783628748172" ],
+  "oclcNumber" : [ "838434577" ],
+  "otherTitleInformation" : [ "worin sie unter d. Nahmen Hagiophilae angeführet wird, ihr tägl. Leben nach gegründeter Vollkommenheit einzurichten ." ],
+  "edition" : [ "3. Dr., verm. u. außgebessert" ],
+  "publication" : [ {
+    "startDate" : "1757",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Cöllen am Rhein" ],
+    "publishedBy" : [ "Horst" ]
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "location" : [ "Ballinlough, Ireland" ],
+    "publishedBy" : [ "Belser Wiss. Dienst" ],
+    "startDate" : "2004"
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990177418660206441",
+    "label" : "Webseite der hbz-Ressource 990177418660206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990177418660206441",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2024-07-29",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990177418660206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-601#!",
+          "label" : "Verbundzentrale des GBV (VZG)"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-601#!",
+          "label" : "Verbundzentrale des GBV (VZG)"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990177418660206441",
+    "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/838434577",
+    "label" : "OCLC Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/ZDB-1-MYA#!",
+    "label" : "Mystik & Aszese des 16.-19. Jahrhunderts [Nationallizenz]",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "https://lobid.org/collections#NLZ",
+    "type" : [ "Collection" ],
+    "label" : "Nationallizenzen"
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "[10], 388 S.",
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Freie Verschlagwortung",
+      "id" : "https://www.wikidata.org/wiki/Q47524318"
+    },
+    "label" : "Glaubensleben"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Freie Verschlagwortung",
+      "id" : "https://www.wikidata.org/wiki/Q47524318"
+    },
+    "label" : "Spiritualität"
+  } ],
+  "subjectslabels" : [ "Glaubensleben", "Spiritualität" ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLibrary" : "ED001",
+    "currentLocation" : "UNASSIGNED",
+    "heldBy" : {
+      "isil" : "DE-Kn28",
+      "id" : "http://lobid.org/organisations/DE-Kn28#!",
+      "label" : "Erzbischöfliche Diözesan- und Dombibliothek"
+    },
+    "seeAlso" : [ "https://katalog.dombibliothek-koeln.de/F/?local_base=edk01&find_code=IDN&request=TT050372336&func=find-b" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Kn28#!",
+      "label" : "Erzbischöfliche Diözesan- und Dombibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Kn28:22116140460007507#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLibrary" : "T0006",
+    "currentLocation" : "UNASSIGNED",
+    "heldBy" : {
+      "isil" : "DE-Tr2",
+      "id" : "http://lobid.org/organisations/DE-Tr2#!",
+      "label" : "Bibliothek des Bischöflichen Priesterseminars Trier"
+    },
+    "seeAlso" : [ "https://katalog.dombibliothek-koeln.de/F/?local_base=ptr01&find_code=IDN&request=TT050372336&func=find-b" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Tr2#!",
+      "label" : "Bibliothek des Bischöflichen Priesterseminars Trier"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Tr2:2259312620007817#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLibrary" : "R0001",
+    "currentLocation" : "UNASSIGNED",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+    },
+    "seeAlso" : [ "https://lbz-rlp.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-929:22129289960007506#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-wuppertal.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-468",
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-468:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hs-duesseldorf.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-Due62",
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Due62:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-294",
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-294:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr%5Bq,any%5D=990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-466:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=990177418660206441&fdb=uni" ],
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-38:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-385:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-361:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://fub-hagen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-708",
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-708:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990177418660206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-6:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-siegen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-467",
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-467:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-5:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378650006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ulb.hhu.de/Search/Results?lookfor=id_marc_001_txt:990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-61",
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-61:53725378650006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-wuppertal.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-468",
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-468:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hs-duesseldorf.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-Due62",
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Due62:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-294",
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-294:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr%5Bq,any%5D=990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-466:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=990177418660206441&fdb=uni" ],
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-38:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-385:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-361:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://fub-hagen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-708",
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-708:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990177418660206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-6:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-siegen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-467",
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-467:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-5:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378630006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ulb.hhu.de/Search/Results?lookfor=id_marc_001_txt:990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-61",
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-61:53725378630006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-wuppertal.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-468",
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-468:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hs-duesseldorf.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-Due62",
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Due62:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-294",
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-294:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr%5Bq,any%5D=990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-466:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=990177418660206441&fdb=uni" ],
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-38:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-385:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-361:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://fub-hagen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-708",
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-708:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990177418660206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-6:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-siegen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-467",
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-467:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-5:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378670006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ulb.hhu.de/Search/Results?lookfor=id_marc_001_txt:990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-61",
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-61:53725378670006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-wuppertal.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-468",
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-468:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hs-duesseldorf.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-Due62",
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Due62:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-294",
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-294:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr%5Bq,any%5D=990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-466:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=990177418660206441&fdb=uni" ],
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-38:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-385:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-361:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://fub-hagen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-708",
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-708:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990177418660206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-6:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-siegen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-467",
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-467:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-5:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378690006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ulb.hhu.de/Search/Results?lookfor=id_marc_001_txt:990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-61",
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-61:53725378690006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_WUP/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-wuppertal.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-468",
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-468#!",
+      "label" : "Universitätsbibliothek Wuppertal"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-468:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_HSD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hs-duesseldorf.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-Due62",
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Due62#!",
+      "label" : "Hochschulbibliothek der Hochschule Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-Due62:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-294",
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-294:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr%5Bq,any%5D=990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-466:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=990177418660206441&fdb=uni" ],
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-38:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-385:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-361:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://fub-hagen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-708",
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-708:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990177418660206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-6:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_SIE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://ub-siegen.digibib.net/search/katalog/record/(DE-605)TT050372336" ],
+    "heldBy" : {
+      "isil" : "DE-467",
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-467#!",
+      "label" : "Universitätsbibliothek Siegen"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-467:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-5:53725378710006441#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53725378710006441&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=990177418660206441",
+    "seeAlso" : [ "https://katalog.ulb.hhu.de/Search/Results?lookfor=id_marc_001_txt:990177418660206441" ],
+    "heldBy" : {
+      "isil" : "DE-61",
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    } ],
+    "id" : "http://lobid.org/items/990177418660206441:DE-61:53725378710006441#!"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "verf. von Jacobo Nütten" ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Nütten, Jacob",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990177418660206441.xml
+++ b/src/test/resources/alma-fix/990177418660206441.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01935nmm a2200445 c 4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20240729180241.0</controlfield>
+  <controlfield tag="007">cr#|||||||||||</controlfield>
+  <controlfield tag="008">091118|1757    xx      o  |        ger c</controlfield>
+  <controlfield tag="001">990177418660206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">838434577</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">walburg126973105</subfield>
+    <subfield code="2">XX-XxUND</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">3628748178</subfield>
+    <subfield code="9">3-628-74817-8</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)TT050372336</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">GBV</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">GBV</subfield>
+    <subfield code="d">DE-605</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Nütten, Jacob</subfield>
+    <subfield code="4">aut</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Vollkommene Lebens-Art einer gottliebenden Seel</subfield>
+    <subfield code="h">Elektronische Ressource</subfield>
+    <subfield code="b">worin sie unter d. Nahmen Hagiophilae angeführet wird, ihr tägl. Leben nach gegründeter Vollkommenheit einzurichten ..</subfield>
+    <subfield code="c">verf. von Jacobo Nütten</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">3. Dr., verm. u. außgebessert</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Cöllen am Rhein</subfield>
+    <subfield code="b">Horst</subfield>
+    <subfield code="c">1757</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">[10], 388 S.</subfield>
+  </datafield>
+  <datafield tag="340" ind1=" " ind2=" ">
+    <subfield code="a">Online-Ressource</subfield>
+    <subfield code="9">F:652a</subfield>
+  </datafield>
+  <datafield tag="688" ind1=" " ind2=" ">
+    <subfield code="a">Glaubensleben</subfield>
+  </datafield>
+  <datafield tag="688" ind1=" " ind2=" ">
+    <subfield code="a">Spiritualität</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(hbzERes_GBV-NLZ)NLM003558266</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)838434577</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)GBVNLM003558266</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-601)NLM003558266</subfield>
+  </datafield>
+  <datafield tag="962" ind1=" " ind2=" ">
+    <subfield code="e">ZDB-1-MYA</subfield>
+    <subfield code="e">NLZ</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">e|1u|||z|0017</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">||||||||g|||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">m|||||||</subfield>
+  </datafield>
+  <datafield tag="912" ind1=" " ind2=" ">
+    <subfield code="a">ZDB-1-MYA</subfield>
+  </datafield>
+  <datafield tag="856" ind1=" " ind2=" ">
+    <subfield code="u">http://www.gbv.de/dms/belser/aszese/74817-1.pdf</subfield>
+    <subfield code="3">Volltext</subfield>
+  </datafield>
+  <datafield tag="856" ind1=" " ind2=" ">
+    <subfield code="u">http://www.gbv.de/dms/belser/aszese/74817-2.pdf</subfield>
+    <subfield code="3">Volltext</subfield>
+  </datafield>
+  <datafield tag="856" ind1=" " ind2=" ">
+    <subfield code="u">http://www.gbv.de/dms/belser/aszese/74817-3.pdf</subfield>
+    <subfield code="3">Volltext</subfield>
+  </datafield>
+  <datafield tag="856" ind1=" " ind2=" ">
+    <subfield code="u">http://www.gbv.de/dms/belser/aszese/74817-4.pdf</subfield>
+    <subfield code="3">Volltext</subfield>
+  </datafield>
+  <datafield tag="856" ind1=" " ind2=" ">
+    <subfield code="u">http://www.gbv.de/dms/belser/aszese/74817-5.pdf</subfield>
+    <subfield code="3">Volltext</subfield>
+  </datafield>
+  <datafield tag="533" ind1=" " ind2=" ">
+    <subfield code="b">Ballinlough, Ireland</subfield>
+    <subfield code="c">Belser Wiss. Dienst</subfield>
+    <subfield code="d">2004</subfield>
+    <subfield code="f">Mystik &amp; Aszese (Spiritualität) des 16. - 19. Jahrhunderts</subfield>
+    <subfield code="n">IDNR 22803476</subfield>
+  </datafield>
+  <datafield tag="538" ind1=" " ind2=" ">
+    <subfield code="a">Sofern kein Zugang über ein Universitätsnetz zur Verfügung steht, kann eine Registrierung zur kostenlosen Nutzung erfolgen: http://www.nationallizenzen.de</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990177418660206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_EDK</subfield>
+    <subfield code="i">9975390207507</subfield>
+    <subfield code="n">Erzbischöfliche Diözesan- und Dombibliothek</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_PTR</subfield>
+    <subfield code="i">9943685707817</subfield>
+    <subfield code="n">Priesterseminar, Bibliothek, Trier</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_LBZ</subfield>
+    <subfield code="i">99123135207506</subfield>
+    <subfield code="n">Rheinische Landesbibliothek Koblenz</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">SchackmannNZ</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2024-07-29 18:02:41 Europe/Berlin</subfield>
+    <subfield code="g">017741866-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 07:46:43 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">German National Licenses</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53725378650006441</subfield>
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="p">61737818480006441</subfield>
+    <subfield code="q">GBV - Mystik &amp; Aszese des 16. bis 19. Jahrhunderts (ZDB-1-MYA)</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="B">Produktsigel: ZDB-1-MYA
+NZ Phase 1 - Wave 1: NZ-P2E
+E-Book-Verfahren: GBV-NLZ?</subfield>
+    <subfield code="A">49HBZ_WUP</subfield>
+    <subfield code="A">49HBZ_HSD</subfield>
+    <subfield code="A">49HBZ_UBO</subfield>
+    <subfield code="A">49HBZ_PAD</subfield>
+    <subfield code="A">49HBZ_UBK</subfield>
+    <subfield code="A">49HBZ_UBT</subfield>
+    <subfield code="A">49HBZ_BIE</subfield>
+    <subfield code="A">49HBZ_FUH</subfield>
+    <subfield code="A">49HBZ_ULM</subfield>
+    <subfield code="A">49HBZ_SIE</subfield>
+    <subfield code="A">49HBZ_ULB</subfield>
+    <subfield code="A">49HBZ_DUE</subfield>
+    <subfield code="y">2021-04-15 16:45:59 Europe/Berlin</subfield>
+    <subfield code="w">2021-04-06 11:59:13 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53725378650006441&amp;Force_direct=true</subfield>
+    <subfield code="v">P2E_JOB</subfield>
+    <subfield code="z">2021-04-06 09:59:13</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62737818470006441</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=990177418660206441</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">DOCUMENT</subfield>
+    <subfield code="e">http://www.gbv.de/dms/belser/aszese/74817-4.pdf</subfield>
+    <subfield code="8">53725378650006441</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">German National Licenses</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53725378630006441</subfield>
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="p">61737818480006441</subfield>
+    <subfield code="q">GBV - Mystik &amp; Aszese des 16. bis 19. Jahrhunderts (ZDB-1-MYA)</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="B">Produktsigel: ZDB-1-MYA
+NZ Phase 1 - Wave 1: NZ-P2E
+E-Book-Verfahren: GBV-NLZ?</subfield>
+    <subfield code="A">49HBZ_WUP</subfield>
+    <subfield code="A">49HBZ_HSD</subfield>
+    <subfield code="A">49HBZ_UBO</subfield>
+    <subfield code="A">49HBZ_PAD</subfield>
+    <subfield code="A">49HBZ_UBK</subfield>
+    <subfield code="A">49HBZ_UBT</subfield>
+    <subfield code="A">49HBZ_BIE</subfield>
+    <subfield code="A">49HBZ_FUH</subfield>
+    <subfield code="A">49HBZ_ULM</subfield>
+    <subfield code="A">49HBZ_SIE</subfield>
+    <subfield code="A">49HBZ_ULB</subfield>
+    <subfield code="A">49HBZ_DUE</subfield>
+    <subfield code="y">2021-04-15 16:46:02 Europe/Berlin</subfield>
+    <subfield code="w">2021-04-06 11:59:13 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53725378630006441&amp;Force_direct=true</subfield>
+    <subfield code="v">P2E_JOB</subfield>
+    <subfield code="z">2021-04-06 09:59:13</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62737818470006441</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=990177418660206441</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">DOCUMENT</subfield>
+    <subfield code="e">http://www.gbv.de/dms/belser/aszese/74817-5.pdf</subfield>
+    <subfield code="8">53725378630006441</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">German National Licenses</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53725378670006441</subfield>
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="p">61737818480006441</subfield>
+    <subfield code="q">GBV - Mystik &amp; Aszese des 16. bis 19. Jahrhunderts (ZDB-1-MYA)</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="B">Produktsigel: ZDB-1-MYA
+NZ Phase 1 - Wave 1: NZ-P2E
+E-Book-Verfahren: GBV-NLZ?</subfield>
+    <subfield code="A">49HBZ_WUP</subfield>
+    <subfield code="A">49HBZ_HSD</subfield>
+    <subfield code="A">49HBZ_UBO</subfield>
+    <subfield code="A">49HBZ_PAD</subfield>
+    <subfield code="A">49HBZ_UBK</subfield>
+    <subfield code="A">49HBZ_UBT</subfield>
+    <subfield code="A">49HBZ_BIE</subfield>
+    <subfield code="A">49HBZ_FUH</subfield>
+    <subfield code="A">49HBZ_ULM</subfield>
+    <subfield code="A">49HBZ_SIE</subfield>
+    <subfield code="A">49HBZ_ULB</subfield>
+    <subfield code="A">49HBZ_DUE</subfield>
+    <subfield code="y">2021-04-15 16:45:59 Europe/Berlin</subfield>
+    <subfield code="w">2021-04-06 11:59:13 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53725378670006441&amp;Force_direct=true</subfield>
+    <subfield code="v">P2E_JOB</subfield>
+    <subfield code="z">2021-04-06 09:59:13</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62737818470006441</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=990177418660206441</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">DOCUMENT</subfield>
+    <subfield code="e">http://www.gbv.de/dms/belser/aszese/74817-3.pdf</subfield>
+    <subfield code="8">53725378670006441</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">German National Licenses</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53725378690006441</subfield>
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="p">61737818480006441</subfield>
+    <subfield code="q">GBV - Mystik &amp; Aszese des 16. bis 19. Jahrhunderts (ZDB-1-MYA)</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="B">Produktsigel: ZDB-1-MYA
+NZ Phase 1 - Wave 1: NZ-P2E
+E-Book-Verfahren: GBV-NLZ?</subfield>
+    <subfield code="A">49HBZ_WUP</subfield>
+    <subfield code="A">49HBZ_HSD</subfield>
+    <subfield code="A">49HBZ_UBO</subfield>
+    <subfield code="A">49HBZ_PAD</subfield>
+    <subfield code="A">49HBZ_UBK</subfield>
+    <subfield code="A">49HBZ_UBT</subfield>
+    <subfield code="A">49HBZ_BIE</subfield>
+    <subfield code="A">49HBZ_FUH</subfield>
+    <subfield code="A">49HBZ_ULM</subfield>
+    <subfield code="A">49HBZ_SIE</subfield>
+    <subfield code="A">49HBZ_ULB</subfield>
+    <subfield code="A">49HBZ_DUE</subfield>
+    <subfield code="y">2021-04-15 16:46:00 Europe/Berlin</subfield>
+    <subfield code="w">2021-04-06 11:59:13 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53725378690006441&amp;Force_direct=true</subfield>
+    <subfield code="v">P2E_JOB</subfield>
+    <subfield code="z">2021-04-06 09:59:13</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62737818470006441</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=990177418660206441</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">DOCUMENT</subfield>
+    <subfield code="e">http://www.gbv.de/dms/belser/aszese/74817-2.pdf</subfield>
+    <subfield code="8">53725378690006441</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">German National Licenses</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53725378710006441</subfield>
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="p">61737818480006441</subfield>
+    <subfield code="q">GBV - Mystik &amp; Aszese des 16. bis 19. Jahrhunderts (ZDB-1-MYA)</subfield>
+    <subfield code="c">static</subfield>
+    <subfield code="B">Produktsigel: ZDB-1-MYA
+NZ Phase 1 - Wave 1: NZ-P2E
+E-Book-Verfahren: GBV-NLZ?</subfield>
+    <subfield code="A">49HBZ_WUP</subfield>
+    <subfield code="A">49HBZ_HSD</subfield>
+    <subfield code="A">49HBZ_UBO</subfield>
+    <subfield code="A">49HBZ_PAD</subfield>
+    <subfield code="A">49HBZ_UBK</subfield>
+    <subfield code="A">49HBZ_UBT</subfield>
+    <subfield code="A">49HBZ_BIE</subfield>
+    <subfield code="A">49HBZ_FUH</subfield>
+    <subfield code="A">49HBZ_ULM</subfield>
+    <subfield code="A">49HBZ_SIE</subfield>
+    <subfield code="A">49HBZ_ULB</subfield>
+    <subfield code="A">49HBZ_DUE</subfield>
+    <subfield code="y">2021-04-15 16:46:02 Europe/Berlin</subfield>
+    <subfield code="w">2021-04-06 11:59:13 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53725378710006441&amp;Force_direct=true</subfield>
+    <subfield code="v">P2E_JOB</subfield>
+    <subfield code="z">2021-04-06 09:59:13</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62737818470006441</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=990177418660206441</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">DOCUMENT</subfield>
+    <subfield code="e">http://www.gbv.de/dms/belser/aszese/74817-1.pdf</subfield>
+    <subfield code="8">53725378710006441</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">ED001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">22116140460007507</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2024-07-31 04:19:21</subfield>
+    <subfield code="8">22116140460007507</subfield>
+    <subfield code="b">2024-07-31 04:19:21</subfield>
+    <subfield code="M">49HBZ_BRIDGE_EDK</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">T0006</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">2259312620007817</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2024-07-31 04:19:03</subfield>
+    <subfield code="8">2259312620007817</subfield>
+    <subfield code="b">2024-07-31 04:19:03</subfield>
+    <subfield code="M">49HBZ_BRIDGE_PTR</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">R0001</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">22129289960007506</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2024-07-31 04:17:40</subfield>
+    <subfield code="8">22129289960007506</subfield>
+    <subfield code="b">2024-07-31 04:17:40</subfield>
+    <subfield code="M">49HBZ_BRIDGE_LBZ</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/990184766040206441.json
+++ b/src/test/resources/alma-fix/990184766040206441.json
@@ -13,6 +13,7 @@
   "almaMmsId" : "990184766040206441",
   "hbzId" : "HT016770284",
   "deprecatedUri" : "http://lobid.org/resources/HT016770284#!",
+  "doi" : [ "10.48644/mpirg_sisis_125001" ],
   "oclcNumber" : [ "179716832" ],
   "publication" : [ {
     "startDate" : "1883",
@@ -73,11 +74,18 @@
   }, {
     "id" : "http://worldcat.org/oclc/179716832",
     "label" : "OCLC Ressource"
+  }, {
+    "id" : "https://doi.org/10.48644/mpirg_sisis_125001",
+    "label" : "mpirg_sisis_125001"
   } ],
   "primaryForm" : [ {
     "id" : "http://lobid.org/resources/HT000522767#!",
     "label" : "Elektronische Reproduktion von HT000522767",
     "note" : [ "Elektronische Reproduktion von" ]
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.48644/mpirg_sisis_125001",
+    "label" : "DOI-Link"
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",

--- a/src/test/resources/alma-fix/990184766040206441.json
+++ b/src/test/resources/alma-fix/990184766040206441.json
@@ -1,0 +1,117 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990184766040206441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Das Rheinische Civilrecht in seiner heutigen Geltung",
+  "almaMmsId" : "990184766040206441",
+  "hbzId" : "HT016770284",
+  "deprecatedUri" : "http://lobid.org/resources/HT016770284#!",
+  "oclcNumber" : [ "179716832" ],
+  "publication" : [ {
+    "startDate" : "1883",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Düsseldorf" ],
+    "publishedBy" : [ "Bagel" ]
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "location" : [ "Frankfurt am Main" ],
+    "description" : [ "Online-Ausgabe" ],
+    "publishedBy" : [ "Max-Planck-Institut für europäische Rechtsgeschichte" ],
+    "startDate" : "2002"
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990184766040206441",
+    "label" : "Webseite der hbz-Ressource 990184766040206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990184766040206441",
+        "dateCreated" : "2021-04-05",
+        "dateModified" : "2024-09-06",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990184766040206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-929#!",
+          "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990184766040206441",
+    "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/179716832",
+    "label" : "OCLC Ressource"
+  } ],
+  "primaryForm" : [ {
+    "id" : "http://lobid.org/resources/HT000522767#!",
+    "label" : "Elektronische Reproduktion von HT000522767",
+    "note" : [ "Elektronische Reproduktion von" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "VI, 808 S.",
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Dargestellt u. erl. von Cretschmar" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "11672613X",
+      "id" : "https://d-nb.info/gnd/11672613X",
+      "label" : "Cretschmar, Cornelius",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1856",
+      "dateOfDeath" : "1926",
+      "altLabel" : [ "Cretschmar, C.", "Cretschmar, Corn.", "Cretschmar, Leopold Cornelius", "Kretschmar, Cornelius", "Cretschmar" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990184766040206441.xml
+++ b/src/test/resources/alma-fix/990184766040206441.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01195nmm a2200289 c 4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20240906125011.0</controlfield>
+  <controlfield tag="007">cr#|||||||||||</controlfield>
+  <controlfield tag="008">110406|1883    gw      o  |        ger c</controlfield>
+  <controlfield tag="001">990184766040206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">179716832</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT016770284</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">929</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="d">DE-605</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DXDE</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Cretschmar, Cornelius</subfield>
+    <subfield code="d">1856-1926</subfield>
+    <subfield code="0">(DE-588)11672613X</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/11672613X</subfield>
+    <subfield code="0">http://viaf.org/viaf/49984186</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">&lt;&lt;Das&gt;&gt; Rheinische Civilrecht in seiner heutigen Geltung</subfield>
+    <subfield code="h">[Elektronische Ressource]</subfield>
+    <subfield code="c">Dargestellt u. erl. von Cretschmar</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Düsseldorf</subfield>
+    <subfield code="b">Bagel</subfield>
+    <subfield code="c">1883</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">VI, 808 S.</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)179716832</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT016770284</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||17</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">||||||||g|||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">m|||||||</subfield>
+  </datafield>
+  <datafield tag="856" ind1=" " ind2=" ">
+    <subfield code="u">https://doi.org/10.48644/mpirg_sisis_125001</subfield>
+    <subfield code="x">Digitalisierung</subfield>
+    <subfield code="z">kostenfrei</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="i">Elektronische Reproduktion von</subfield>
+    <subfield code="a">Cretschmar, Cornelius, 1856-1926</subfield>
+    <subfield code="t">&lt;&lt;Das&gt;&gt; rheinische Civilrecht in seiner heutigen Geltung</subfield>
+    <subfield code="w">(DE-605)HT000522767</subfield>
+  </datafield>
+  <datafield tag="533" ind1=" " ind2=" ">
+    <subfield code="a">Online-Ausgabe</subfield>
+    <subfield code="b">Frankfurt am Main</subfield>
+    <subfield code="c">Max-Planck-Institut für europäische Rechtsgeschichte</subfield>
+    <subfield code="d">2002</subfield>
+    <subfield code="e">Online-Ressource</subfield>
+    <subfield code="n">[Online-Ausg.]</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990184766040206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">SchackmannNZ</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2024-09-06 12:50:11 Europe/Berlin</subfield>
+    <subfield code="g">018476604-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 15:04:51 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Cretschmar, C.</subfield>
+    <subfield code="d">1856-1926</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Cretschmar, Corn.</subfield>
+    <subfield code="d">1856-1926</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Cretschmar, Leopold Cornelius</subfield>
+    <subfield code="d">1856-1926</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Cretschmar</subfield>
+    <subfield code="d">1856-1926</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Kretschmar, Cornelius</subfield>
+    <subfield code="d">1856-1926</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">11672613X</subfield>
+    <subfield code="0">http://d-nb.info/gnd/11672613X</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11672613X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -66,8 +66,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.startDate:1993", /*->*/ 3 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "publication.location:Berlin AND publication.startDate:[1992 TO 2017]", /*->*/ 5 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 135 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 152 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 137 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 154 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },
@@ -142,7 +142,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "contribution.agent.altLabel.digibib_unstemmed:Nemačke", /*->*/ 1 },
 			{ "contribution.agent.altLabel.digibib_unstemmed:Nemack", /*->*/ 0 },
 			{ "exampleOfWork.language.id:\"http\\://id.loc.gov/vocabulary/iso639-2/eng\"", /*->*/ 1 },
-			{ "hasItem.inCollection.id:\"http://lobid.org/organisations/DE-468#!\"", /*->*/ 23 }
+			{ "hasItem.inCollection.id:\"http://lobid.org/organisations/DE-468#!\"", /*->*/ 24 }
 		});
 	} // @formatter:on
 


### PR DESCRIPTION
This PR resolves #2070

It makes all the mappings for 856 less strict concerning the indices it enables the transformation to get more fullTextOnline info aswell as other relevant information as DOI. 