### PR TITLE
Support auto-complete suggestions created from multiple fields

### DIFF
--- a/web/app/views/api.scala.html
+++ b/web/app/views/api.scala.html
@@ -91,10 +91,11 @@ $('input.search-resources').autocomplete({
 	<p>Siehe auch diesen Abschnitt zu <a href="https://blog.lobid.org/2018/07/02/lobid-update.html#bulk-downloads">Bulk-Downloads in unserem Blog</a>.</p>
 
 	<h2 id="auto-complete">Autovervollständigung <small><a href='#auto-complete'><span class='glyphicon glyphicon-link'></span></a></small></h2>
-	<p>Die API unterstützt ein spezielles Antwortformat mit Vorschlägen zur Vervollständigung aus einem angegebenen Feld:</p>
-	@desc("Titel vorschlagen: \"format=json:title\"", resources.routes.Application.query("title:Werth", format="json:title"))
-	@desc("Mitwirkende vorschlagen: \"format=json:agent\"", resources.routes.Application.query("contribution.agent.label:Hein", format="json:agent"))
-	@desc("Schlagwort vorschlagen: \"format=json:subject\"", resources.routes.Application.query("subject.componentList.label:Pferd", format="json:subject"))
+	<p>Die API unterstützt ein spezielles Antwortformat mit Vorschlägen zur Vervollständigung.</p>
+	@desc("Standardformat für Vorschläge verwenden: \"format=json:suggest\"", resources.routes.Application.query("Twain", format="json:suggest"))
+	@desc("Bestimmtes Feld für Vorschläge verwenden: \"format=json:title\"", resources.routes.Application.query("Twain", format="json:title"))
+	@desc("Vorschläge aus mehreren Feldern zusammenbauen: \"format=json:title,contribution\"", resources.routes.Application.query("Twain", format="json:title,contribution"))
+	@desc("Feld-Templates zur Anpassung und Gruppierung: \"format=json:title,Erschienen_startDate bei_publishedBy\"", resources.routes.Application.query("Twain", format="json:title,Erschienen_startDate bei_publishedBy"))
 	<p>Damit kann z.B. eine Autovervollständigung umgesetzt werden, bei der zur Suche an Stelle des gewählten Labels die entsprechende ID verwendet werden kann:</p>
 	<p><form method="GET" class="form-inline" action="/resources/search"> <!-- use full URL in your code, i.e. https://lobid.org/resources/search -->
 		<input type="text" class="search-resources" id="label" style="width:350px" placeholder="Suchbegriff für Vorschläge eingeben"/>

--- a/web/test/tests/SuggestionsTest.java
+++ b/web/test/tests/SuggestionsTest.java
@@ -1,0 +1,126 @@
+package tests;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static play.test.Helpers.GET;
+import static play.test.Helpers.contentAsString;
+import static play.test.Helpers.fakeApplication;
+import static play.test.Helpers.fakeRequest;
+import static play.test.Helpers.route;
+import static play.test.Helpers.running;
+
+import org.junit.Test;
+
+import play.Application;
+import play.libs.Json;
+import play.mvc.Result;
+
+/**
+ * Test suggestion responses (see {@link controllers.resources.Application})
+ */
+@SuppressWarnings("javadoc")
+public class SuggestionsTest extends LocalIndexSetup {
+
+	@Test
+	public void suggestionsWithoutCallback() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			Result result = route(application, fakeRequest(GET,
+					"/resources/search?q=*&filter=type:Book&format=json:title,contribution"));
+			assertNotNull("We have a result", result);
+			assertThat(result.contentType(), equalTo("application/json"));
+			String content = contentAsString(result);
+			assertNotNull("We can parse the result as JSON", Json.parse(content));
+			assertThat(content,
+					allOf(//
+							containsString("label"), //
+							containsString("id"), //
+							containsString("category")));
+			assertTrue("We used both given fields for any of the labels",
+					Json.parse(content).findValues("label").stream()
+							.anyMatch(label -> label.asText().contains(" | ")));
+		});
+
+	}
+
+	@Test
+	public void suggestionsWithCallback() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			Result result = route(application, fakeRequest(GET,
+					"/resources/search?q=*&filter=type:Book&format=json:title&callback=test"));
+			assertNotNull("We have a result", result);
+			assertThat(result.contentType(), equalTo("application/javascript"));
+			assertThat(contentAsString(result),
+					allOf(containsString("test("), // callback
+							containsString("label"), containsString("id"),
+							containsString("category")));
+		});
+	}
+
+	@Test
+	public void suggestionsCorsHeader() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			Result result = route(application,
+					fakeRequest(GET, "/resources/search?q=*&format=json:title"));
+			assertNotNull("We have a result", result);
+			assertThat(result.header("Access-Control-Allow-Origin"), equalTo("*"));
+		});
+
+	}
+
+	@Test
+	public void suggestionsTemplate() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			String format = "json:title,ab_startDate+als_edition";
+			Result result = route(application, fakeRequest(GET,
+					"/resources/search?q=*&filter=type:Book&format=" + format));
+			assertNotNull("We have a result", result);
+			assertThat(result.contentType(), equalTo("application/json"));
+			String content = contentAsString(result);
+			assertNotNull("We can parse the result as JSON", Json.parse(content));
+			assertTrue(
+					"We replaced the field names in the template with their values",
+					Json.parse(content).findValues("label").stream()
+							.anyMatch(label -> label.asText().contains("als ")));
+		});
+	}
+
+	@Test
+	public void suggestionsTemplateMultiValues() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			String format = "json:title,contribution,about_subject";
+			Result result = route(application,
+					fakeRequest(GET,
+							"/resources/search?q=Volksschulwesens&filter=type:Book&format="
+									+ format));
+			assertNotNull("We have a result", result);
+			assertThat(result.contentType(), equalTo("application/json"));
+			String content = contentAsString(result);
+			assertNotNull("We can parse the result as JSON", Json.parse(content));
+			assertThat("Multi-values use consistent delimiter", content, allOf(
+					containsString("Handwörterbuch des Volksschulwesens"),
+					containsString("about Erziehung, Bildung, Unterricht; Volksschule")));
+		});
+	}
+
+	@Test
+	public void suggestionsArePrettyPrinted() {
+		Application application = fakeApplication();
+		running(application, () -> {
+			Result result = route(application,
+					fakeRequest(GET, "/resources/search?q=*&format=json:suggest"));
+			assertNotNull(result);
+			assertThat(result.contentType(), equalTo("application/json"));
+			assertThat(contentAsString(result), containsString("}, {\n"));
+		});
+	}
+
+}


### PR DESCRIPTION
Like in lobid-gnd: configure fields to use in the `format` param (e.g. `json:title,contribution`), or use `format=json:suggest` for default fields.

See https://jira.hbz-nrw.de/browse/RPB-141

Deployed to test: https://test.lobid.org/resources/api#auto-complete