### PR TITLE
Fix fallback for publication dates #2089

### DIFF
--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -258,14 +258,14 @@ if exists("publication[].$first")
       end
     end
   end
-  unless exists("publication[].$first.startDate[]")
+  unless exists("publication[].$first.startDate")
     if any_match("008","^.{6}[brestikm](\\d{4}).*$")
       copy_field("008","@008startDate")
       replace_all("@008startDate","^.{7}(\\d{4}).*$","$1")
       copy_field("@008startDate","publication[].$first.startDate")
     end
   end
-  unless exists("publication[].$first.endDate[]")
+  unless exists("publication[].$first.endDate")
     if any_match("008","^.{6}[km]\\d{4}(\\d{4}).*$")
       copy_field("008","@008endDate")
       replace_all("@008endDate","^.{11}(\\d{4}).*$","$1")

--- a/src/test/resources/alma-fix/99374153235806441.json
+++ b/src/test/resources/alma-fix/99374153235806441.json
@@ -16,7 +16,7 @@
   "otherTitleInformation" : [ "Thüringen" ],
   "edition" : [ "1. Auflage" ],
   "publication" : [ {
-    "startDate" : "2088",
+    "startDate" : "2008",
     "type" : [ "PublicationEvent" ],
     "location" : [ "München" ],
     "publishedBy" : [ "Stark" ]


### PR DESCRIPTION
Related to #2089

Deletes the not needed brackets that lead to overwriting the publication dates from `"264` by `008`