### PR TITLE
Adjust license mapping to map 540 Open Access infos  #2103

### DIFF
--- a/src/main/resources/alma/fix/otherFields.fix
+++ b/src/main/resources/alma/fix/otherFields.fix
@@ -174,14 +174,19 @@ replace_all("bibliographicCitation.*","^In: ","")
 
 join_field("bibliographicCitation", "; ")
 
+# 540 - Terms Governing Use and Reproduction Note (R)
+
 # 542 - Information Relating to Copyright Status (R) - $n - Note (R)  $u - Uniform Resource Identifier (R)
 
 set_array("license[]")
-do list(path: "542??", "var": "$i")
+do list(path: "540??|542??", "var": "$i")
   copy_field("$i.u", "license[].$append.id")
+  replace_all("license[].$last.id", "^(http://|https://)(.*)$","https://$2")
   copy_field("$i.u", "license[].$last.label")
   replace_all("license[].$last.label", "^(http://|https://)(.*)$","$2")
 end
+
+uniq("license[]")
 
 set_array("langNote[]")
 do list(path: "546??", "var": "$i")

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -93,6 +93,10 @@
   } ],
   "extent" : "1 online resource (194 pages) : digital file(s).",
   "abstract" : [ "2012 wurde das Netzwerk-Projekt Landeskunde Nord ins Leben gerufen, dessen Ziel es ist, Forschung und Lehre zur Landeskunde des Deutschen als Fremdsprache, insbesondere in den nordischen Ländern, voranzutreiben. Das vorliegende Buch, Perspektive Nord, knüpft an den 2013 erschienenen Band Landeskunde Nord an und bietet Reflexionen wissenschaftstheoretischer, fachdidaktischer und inhaltlicher Aspekte, die für die Gestaltung der Landeskundelehre bzw. des Landeskundeunterrichts relevant sind. In ihrer Vielfalt sind die hier vorgelegten Konzepte und Ideen vor allem modernen kulturwissenschaftlichen Ansätzen verpflichtet, knüpfen an international geführte Diskussionen an und haben auch deshalb über die nordischen Länder hinaus Bedeutung. Dabei setzen die Autorinnen und Autoren auf autonomes und lebenslanges Lernen." ],
+  "license" : [ {
+    "id" : "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode",
+    "label" : "creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+  } ],
   "langNote" : [ "German" ],
   "subject" : [ {
     "type" : [ "Concept" ],


### PR DESCRIPTION
Improved the mapping. To fetch 540 and not only 542 for licensing info.

We could discuss, if we also intend to catch licensing info from 856 but I am not sure yet. And I have no example.