### PR TITLE
2108-noLocalHbzIds

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -168,3 +168,7 @@ unless exists("hbzId")
     copy_field("@hbzId","hbzId")
   end
 end
+
+unless exists("@inNZ")
+  remove_field("hbzId")
+end

--- a/src/test/resources/alma-fix/991000128689108979.json
+++ b/src/test/resources/alma-fix/991000128689108979.json
@@ -1,0 +1,86 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/991000128689108979#!",
+  "type" : [ "BibliographicResource", "Series" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Kreisfreie Städte und Landkreise",
+  "almaMmsId" : "991000128689108979",
+  "hbzId" : "HT006919400",
+  "deprecatedUri" : "http://lobid.org/resources/HT006919400#!",
+  "publication" : [ {
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Bad Ems." ],
+    "publicationHistory" : "1998 -"
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/991000128689108979",
+    "label" : "Webseite der hbz-Ressource 991000128689108979",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/991000128689108979",
+        "dateCreated" : "2024-09-16",
+        "dateModified" : "2024-10-09",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 991000128689108979 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/XX-DE#!",
+          "label" : "lobid Organisation"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "seeAlso" : [ "https://bibserv.fh-trier.de/webOPACClient/start.do?Query=0010=%22HT006919400%22" ],
+    "heldBy" : {
+      "isil" : "DE-Tr5",
+      "id" : "http://lobid.org/organisations/DE-Tr5#!",
+      "label" : "Hochschulbibliothek Trier"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Tr5#!",
+      "label" : "Hochschulbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/991000128689108979:DE-Tr5:991000128689108979#!"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Serial",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Serial"
+  },
+  "responsibilityStatement" : [ "Rheinland-Pfalz, Statistisches Landesamt." ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Rheinland-Pfalz",
+      "type" : [ "CorporateBody" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/991000128689108979.json
+++ b/src/test/resources/alma-fix/991000128689108979.json
@@ -8,7 +8,6 @@
   } ],
   "title" : "Kreisfreie Städte und Landkreise",
   "almaMmsId" : "991000128689108979",
-  "hbzId" : "HT006919400",
   "deprecatedUri" : "http://lobid.org/resources/HT006919400#!",
   "publication" : [ {
     "type" : [ "PublicationEvent" ],
@@ -55,7 +54,6 @@
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
-    "seeAlso" : [ "https://bibserv.fh-trier.de/webOPACClient/start.do?Query=0010=%22HT006919400%22" ],
     "heldBy" : {
       "isil" : "DE-Tr5",
       "id" : "http://lobid.org/organisations/DE-Tr5#!",

--- a/src/test/resources/alma-fix/991000128689108979.xml
+++ b/src/test/resources/alma-fix/991000128689108979.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>00845cas a2200241   4500</leader>
+  <controlfield tag="005">20090427095900.0</controlfield>
+  <controlfield tag="007">zu</controlfield>
+  <controlfield tag="008">                   n mg      0   b      </controlfield>
+  <controlfield tag="001">991000128689108979</controlfield>
+  <datafield tag="016" ind1=" " ind2=" ">
+    <subfield code="2">HBZ</subfield>
+    <subfield code="a">HT006919400</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-1042)UCB_33892-49hbz_hst</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">HT006919400</subfield>
+    <subfield code="9">ExL</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT006919400</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">33892</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DE</subfield>
+    <subfield code="b">                 m  y0gery0103    ba</subfield>
+    <subfield code="e">RAK-WB</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Kreisfreie Städte und Landkreise / </subfield>
+    <subfield code="c">Rheinland-Pfalz, Statistisches Landesamt.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Bad Ems.</subfield>
+  </datafield>
+  <datafield tag="362" ind1="1" ind2=" ">
+    <subfield code="a">1998 -</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">Rheinland-Pfalz.</subfield>
+  </datafield>
+  <datafield tag="910" ind1=" " ind2=" ">
+    <subfield code="a">HT006919400</subfield>
+  </datafield>
+  <datafield tag="911" ind1=" " ind2=" ">
+    <subfield code="a">HT006919400</subfield>
+  </datafield>
+  <datafield tag="913" ind1=" " ind2=" ">
+    <subfield code="a">35524</subfield>
+  </datafield>
+  <datafield tag="989" ind1=" " ind2=" ">
+    <subfield code="a">Beil. zu ---&gt;: Rheinland-Pfalz: Statistische Monatshefte Rheinland-Pfalz</subfield>
+    <subfield code="9">LOCAL</subfield>
+  </datafield>
+  <datafield tag="989" ind1=" " ind2=" ">
+    <subfield code="a">Vorg. ---&gt;: Rheinland-Pfalz: Kreisübersichten</subfield>
+    <subfield code="9">LOCAL</subfield>
+  </datafield>
+  <datafield tag="989" ind1=" " ind2=" ">
+    <subfield code="a">Ersch. bis 1996 jeweils Apr. u. kumulierend im Okt., ab 1997 jeweils Mai u. kumulierend im Nov.</subfield>
+    <subfield code="9">LOCAL</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_HST</subfield>
+    <subfield code="i">991000128689108979</subfield>
+    <subfield code="n">Hochschule Trier - Umwelt-Campus</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">50</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2024-10-09 13:04:02 Europe/Berlin</subfield>
+    <subfield code="g">UCB_33892-49hbz_hst</subfield>
+    <subfield code="j">00</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2024-09-16 14:52:44 Europe/Berlin</subfield>
+  </datafield>
+</record>


### PR DESCRIPTION
Talked to Verbundgruppe N.D. she said conceptually no local records should have hbzIds but local libraries often do not delete them. Therefore I suggest deleting them in lobid.