### PR TITLE
Do not add zdbId if only DE-599 has ZDB info #2112

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -137,8 +137,6 @@ do list(path:"035  ", "var":"$i")
   unless exists("zdbId")
     if all_match("$i.a", "\\(DE-600\\)(.*)")
       copy_field("$i.a", "zdbId")
-    elsif all_match("$i.a", "\\(DE-599\\)(ZDB.*)")
-      copy_field("$i.a", "zdbId")
     end
   end
 end

--- a/src/test/resources/alma-fix/990217879290206441.json
+++ b/src/test/resources/alma-fix/990217879290206441.json
@@ -12,7 +12,6 @@
   "deprecatedUri" : "http://lobid.org/resources/HT019286510#!",
   "issn" : [ "24054488" ],
   "oclcNumber" : [ "909716357" ],
-  "zdbId" : "2819760-4",
   "publication" : [ {
     "startDate" : "2015",
     "type" : [ "PublicationEvent" ],
@@ -67,9 +66,6 @@
   }, {
     "id" : "http://worldcat.org/oclc/909716357",
     "label" : "OCLC Ressource"
-  }, {
-    "id" : "http://ld.zdb-services.de/resource/2819760-4",
-    "label" : "ZDB-Ressource"
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",
@@ -78,10 +74,6 @@
   }, {
     "id" : "http://lobid.org/organisations/DE-655#!",
     "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
-    "type" : [ "Collection" ]
-  }, {
-    "id" : "http://lobid.org/resources/HT014846970#!",
-    "label" : "Zeitschriftendatenbank (ZDB)",
     "type" : [ "Collection" ]
   } ],
   "language" : [ {
@@ -95,7 +87,7 @@
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "NurTitel" ],
-    "seeAlso" : [ "https://katalog.dombibliothek-koeln.de/F/?local_base=edk01&find_code=ISN&request=24054488&func=find-b" ],
+    "seeAlso" : [ "https://katalog.dombibliothek-koeln.de/F/?local_base=edk01&find_code=IDN&request=HT019286510&func=find-b" ],
     "heldBy" : {
       "isil" : "DE-Kn28",
       "id" : "http://lobid.org/organisations/DE-Kn28#!",


### PR DESCRIPTION
See #2112.

zdbId links should not be added if DE-599 states zdbInfo. following the info of Verbundgruppe. See #2112