### PR TITLE
Use initial cataloguing date instead of alma indexing date #2114

### DIFF
--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -31,9 +31,19 @@ add_field("describedBy.resultOf.instrument.label","Software lobid-resources")
 copy_field("almaMmsId","describedBy.resultOf.object.id")
 prepend("describedBy.resultOf.object.id","https://lobid.org/marcxml/")
 
-# MNG is a ALMA-specific element
+# MNG is a ALMA-specific element (MNG  .b only states the indexing date into ALMA, while 008 is the initial cataloguing date.)
 
-copy_field("MNG  .b","describedBy.resultOf.object.dateCreated")
+copy_field("008","@initialCataloguingDate")
+substring("@initialCataloguingDate","0","6")
+if any_match("@initialCataloguingDate","^[0-4].*")
+  prepend("@initialCataloguingDate","20")
+elsif any_match("@initialCataloguingDate","\\d*")
+  prepend("@initialCataloguingDate","19")
+else
+  copy_field("MNG  .b","@initialCataloguingDate")
+end
+copy_field("@initialCataloguingDate","describedBy.resultOf.object.dateCreated")
+
 copy_field("MNG  .d","describedBy.resultOf.object.dateModified")
 replace_all("describedBy.resultOf.object.dateCreated","-","")
 replace_all("describedBy.resultOf.object.dateCreated"," .*","")
@@ -41,12 +51,12 @@ replace_all("describedBy.resultOf.object.dateCreated","c|©|\\s?|,|.|:|;|/|=",""
 replace_all("describedBy.resultOf.object.dateModified","-","")
 replace_all("describedBy.resultOf.object.dateModified"," .*","")
 replace_all("describedBy.resultOf.object.dateModified","c|©|\\s?|,|.|:|;|/|=","")
-unless any_match("describedBy.resultOf.object.dateCreated","\\d{8}|\\d{4}")
-	remove_field("describedBy.resultOf.object.dateCreated")
-end
-unless any_match("describedBy.resultOf.object.dateModified","\\d{8}|\\d{4}")
-	remove_field("describedBy.resultOf.object.dateModified")
-end
+#unless any_match("describedBy.resultOf.object.dateCreated","\\d{8}|\\d{4}")
+#	remove_field("describedBy.resultOf.object.dateCreated")
+#end
+#unless any_match("describedBy.resultOf.object.dateModified","\\d{8}|\\d{4}")
+#	remove_field("describedBy.resultOf.object.dateModified")
+#end
 replace_all("describedBy.resultOf.object.dateCreated","^(\\d{4})(\\d{2})(\\d{2})$","$1-$2-$3")
 replace_all("describedBy.resultOf.object.dateModified","^(\\d{4})(\\d{2})(\\d{2})$","$1-$2-$3")
 replace_all("describedBy.resultOf.object.dateCreated","^(\\d{4})$","$1-01-01")

--- a/src/test/resources/alma-fix/990001412590206441.json
+++ b/src/test/resources/alma-fix/990001412590206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990001412590206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2000-01-11",
         "dateModified" : "2023-02-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990001412590206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990011470300206441.json
+++ b/src/test/resources/alma-fix/990011470300206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990011470300206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1988-06-22",
         "dateModified" : "2023-08-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990011470300206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990014830510206441.json
+++ b/src/test/resources/alma-fix/990014830510206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990014830510206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-05-10",
         "dateModified" : "2023-08-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990014830510206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990016782920206441.json
+++ b/src/test/resources/alma-fix/990016782920206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990016782920206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1992-08-28",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990016782920206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990021367710206441.json
+++ b/src/test/resources/alma-fix/990021367710206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990021367710206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1999-07-12",
         "dateModified" : "2023-04-02",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990021367710206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990021974470206441.json
+++ b/src/test/resources/alma-fix/990021974470206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990021974470206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1996-06-04",
         "dateModified" : "2023-04-02",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990021974470206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990026405480206441.json
+++ b/src/test/resources/alma-fix/990026405480206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990026405480206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1995-12-08",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990026405480206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990030574430206441.json
+++ b/src/test/resources/alma-fix/990030574430206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990030574430206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1998-01-05",
         "dateModified" : "2023-02-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990030574430206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990033263300206441.json
+++ b/src/test/resources/alma-fix/990033263300206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990033263300206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1998-04-29",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990033263300206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990035016180206441.json
+++ b/src/test/resources/alma-fix/990035016180206441.json
@@ -43,7 +43,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990035016180206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1998-07-16",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990035016180206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990041403870206441.json
+++ b/src/test/resources/alma-fix/990041403870206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990041403870206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-03-02",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990041403870206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990050000600206441.json
+++ b/src/test/resources/alma-fix/990050000600206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990050000600206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1998-11-16",
         "dateModified" : "2023-05-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990050000600206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990051552280206441.json
+++ b/src/test/resources/alma-fix/990051552280206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990051552280206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-02-22",
         "dateModified" : "2022-02-15",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990051552280206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990051708340206441.json
+++ b/src/test/resources/alma-fix/990051708340206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990051708340206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-03-11",
         "dateModified" : "2021-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990051708340206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990052965140206441.json
+++ b/src/test/resources/alma-fix/990052965140206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990052965140206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2000-01-17",
         "dateModified" : "2022-11-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990052965140206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990053976760206441.json
+++ b/src/test/resources/alma-fix/990053976760206441.json
@@ -49,7 +49,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990053976760206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-18",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990053976760206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990054089950206441.json
+++ b/src/test/resources/alma-fix/990054089950206441.json
@@ -62,7 +62,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990054089950206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-19",
         "dateModified" : "2024-04-28",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054089950206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990054215550206441.json
+++ b/src/test/resources/alma-fix/990054215550206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990054215550206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1999-11-18",
         "dateModified" : "2023-08-01",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054215550206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990054301770206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-18",
         "dateModified" : "2023-08-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054301770206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990054345550206441.json
+++ b/src/test/resources/alma-fix/990054345550206441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990054345550206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-20",
         "dateModified" : "2023-05-15",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990054345550206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990055981810206441.json
+++ b/src/test/resources/alma-fix/990055981810206441.json
@@ -49,7 +49,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990055981810206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1999-11-21",
         "dateModified" : "2023-05-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990055981810206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990058434730206441.json
+++ b/src/test/resources/alma-fix/990058434730206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990058434730206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-02-28",
         "dateModified" : "2022-09-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990058434730206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990058567920206441.json
+++ b/src/test/resources/alma-fix/990058567920206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990058567920206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1993-12-25",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990058567920206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990059571560206441.json
+++ b/src/test/resources/alma-fix/990059571560206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990059571560206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1998-06-15",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990059571560206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990063549080206441.json
+++ b/src/test/resources/alma-fix/990063549080206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990063549080206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1997-09-12",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990063549080206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990065341720206441.json
+++ b/src/test/resources/alma-fix/990065341720206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990065341720206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1993-09-30",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990065341720206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990075429930206441.json
+++ b/src/test/resources/alma-fix/990075429930206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990075429930206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1998-10-24",
         "dateModified" : "2022-03-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990075429930206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990075538650206441.json
+++ b/src/test/resources/alma-fix/990075538650206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990075538650206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1988-10-06",
         "dateModified" : "2023-04-02",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990075538650206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990103770440206441.json
+++ b/src/test/resources/alma-fix/990103770440206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990103770440206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-19",
         "dateModified" : "2023-08-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990103770440206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990103899140206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1999-11-20",
         "dateModified" : "2023-04-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990103899140206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990104908070206441.json
+++ b/src/test/resources/alma-fix/990104908070206441.json
@@ -48,7 +48,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990104908070206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-20",
         "dateModified" : "2023-05-15",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990104908070206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990108740950206441.json
+++ b/src/test/resources/alma-fix/990108740950206441.json
@@ -53,7 +53,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990108740950206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-22",
         "dateModified" : "2023-04-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108740950206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990108873860206441.json
+++ b/src/test/resources/alma-fix/990108873860206441.json
@@ -43,7 +43,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990108873860206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-16",
         "dateModified" : "2023-04-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108873860206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990108874370206441.json
+++ b/src/test/resources/alma-fix/990108874370206441.json
@@ -43,7 +43,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990108874370206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-11-16",
         "dateModified" : "2023-04-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990108874370206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990109712970206441.json
+++ b/src/test/resources/alma-fix/990109712970206441.json
@@ -49,7 +49,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990109712970206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2000-01-03",
         "dateModified" : "2023-05-31",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990109712970206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990110509950206441.json
+++ b/src/test/resources/alma-fix/990110509950206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990110509950206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1994-08-29",
         "dateModified" : "2023-03-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110509950206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -32,7 +32,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990110714900206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "1995-09-29",
         "dateModified" : "2023-08-20",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110714900206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -32,7 +32,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990110881770206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1996-08-14",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990110881770206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -34,7 +34,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990112067120206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-12-01",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990112067120206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990113537330206441.json
+++ b/src/test/resources/alma-fix/990113537330206441.json
@@ -41,7 +41,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990113537330206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2000-12-15",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990113537330206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990114098170206441.json
+++ b/src/test/resources/alma-fix/990114098170206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990114098170206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2001-07-12",
         "dateModified" : "2023-08-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990114098170206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990114617880206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2001-09-14",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990114617880206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990118562160206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2002-12-17",
         "dateModified" : "2023-05-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990118562160206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990119186660206441.json
+++ b/src/test/resources/alma-fix/990119186660206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990119186660206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2003-02-18",
         "dateModified" : "2023-05-25",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990119186660206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990122511970206441.json
+++ b/src/test/resources/alma-fix/990122511970206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990122511970206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1999-08-16",
         "dateModified" : "2023-03-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990122511970206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990123613330206441.json
+++ b/src/test/resources/alma-fix/990123613330206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990123613330206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "1998-08-07",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990123613330206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990124590390206441.json
+++ b/src/test/resources/alma-fix/990124590390206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990124590390206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2004-02-02",
         "dateModified" : "2023-01-19",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990124590390206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990126276700206441.json
+++ b/src/test/resources/alma-fix/990126276700206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990126276700206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2004-05-11",
         "dateModified" : "2023-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990126276700206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990126426530206441.json
+++ b/src/test/resources/alma-fix/990126426530206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990126426530206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2002-05-07",
         "dateModified" : "2024-08-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990126426530206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990133067580206441.json
+++ b/src/test/resources/alma-fix/990133067580206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990133067580206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2004-10-06",
         "dateModified" : "2023-05-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990133067580206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990136041660206441.json
+++ b/src/test/resources/alma-fix/990136041660206441.json
@@ -46,7 +46,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990136041660206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2005-05-27",
         "dateModified" : "2023-05-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990136041660206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990139686910206441.json
+++ b/src/test/resources/alma-fix/990139686910206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990139686910206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2005-10-20",
         "dateModified" : "2023-05-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990139686910206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990141342350206441.json
+++ b/src/test/resources/alma-fix/990141342350206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990141342350206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2005-11-10",
         "dateModified" : "2023-05-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990141342350206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990143325070206441.json
+++ b/src/test/resources/alma-fix/990143325070206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990143325070206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2006-01-09",
         "dateModified" : "2021-11-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990143325070206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990150856900206441.json
+++ b/src/test/resources/alma-fix/990150856900206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990150856900206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2006-05-12",
         "dateModified" : "2023-06-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990150856900206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990156027740206441.json
+++ b/src/test/resources/alma-fix/990156027740206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990156027740206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2007-03-07",
         "dateModified" : "2021-10-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990156027740206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990156060190206441.json
+++ b/src/test/resources/alma-fix/990156060190206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990156060190206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2007-03-09",
         "dateModified" : "2023-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990156060190206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990166236770206441.json
+++ b/src/test/resources/alma-fix/990166236770206441.json
@@ -43,7 +43,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990166236770206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2008-04-28",
         "dateModified" : "2023-05-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990166236770206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990167595410206441.json
+++ b/src/test/resources/alma-fix/990167595410206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990167595410206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2008-07-18",
         "dateModified" : "2021-09-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990167595410206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990170546170206441.json
+++ b/src/test/resources/alma-fix/990170546170206441.json
@@ -46,7 +46,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990170546170206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2008-07-17",
         "dateModified" : "2023-04-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990170546170206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990171142550206441.json
+++ b/src/test/resources/alma-fix/990171142550206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990171142550206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2008-09-18",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990171142550206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990172512030206441.json
+++ b/src/test/resources/alma-fix/990172512030206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990172512030206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2008-12-12",
         "dateModified" : "2023-05-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990172512030206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990173607780206441.json
+++ b/src/test/resources/alma-fix/990173607780206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990173607780206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2009-02-25",
         "dateModified" : "2024-08-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990173607780206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990173811970206441.json
+++ b/src/test/resources/alma-fix/990173811970206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990173811970206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2009-03-17",
         "dateModified" : "2023-06-16",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990173811970206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990177418660206441.json
+++ b/src/test/resources/alma-fix/990177418660206441.json
@@ -46,7 +46,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990177418660206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2009-11-18",
         "dateModified" : "2024-07-29",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990177418660206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990181275760206441.json
+++ b/src/test/resources/alma-fix/990181275760206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990181275760206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2010-07-12",
         "dateModified" : "2021-07-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990181275760206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990182814750206441.json
+++ b/src/test/resources/alma-fix/990182814750206441.json
@@ -70,7 +70,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990182814750206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2010-11-10",
         "dateModified" : "2023-09-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990182814750206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990183054020206441.json
+++ b/src/test/resources/alma-fix/990183054020206441.json
@@ -45,7 +45,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990183054020206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2010-11-16",
         "dateModified" : "2023-08-01",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183054020206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990183092590206441.json
+++ b/src/test/resources/alma-fix/990183092590206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990183092590206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2010-11-30",
         "dateModified" : "2022-11-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183092590206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990183958380206441.json
+++ b/src/test/resources/alma-fix/990183958380206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990183958380206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2011-02-07",
         "dateModified" : "2023-05-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990183958380206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990184127410206441.json
+++ b/src/test/resources/alma-fix/990184127410206441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990184127410206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2011-02-10",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990184127410206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990184766040206441.json
+++ b/src/test/resources/alma-fix/990184766040206441.json
@@ -45,7 +45,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990184766040206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2011-04-06",
         "dateModified" : "2024-09-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990184766040206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990185607520206441.json
+++ b/src/test/resources/alma-fix/990185607520206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990185607520206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2011-04-11",
         "dateModified" : "2023-02-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990185607520206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990185619180206441.json
+++ b/src/test/resources/alma-fix/990185619180206441.json
@@ -47,7 +47,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990185619180206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2011-04-11",
         "dateModified" : "2023-02-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990185619180206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990189160110206441.json
+++ b/src/test/resources/alma-fix/990189160110206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990189160110206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2011-10-31",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990189160110206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990190567380206441.json
+++ b/src/test/resources/alma-fix/990190567380206441.json
@@ -32,7 +32,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990190567380206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2012-02-28",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990190567380206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990193094010206441.json
+++ b/src/test/resources/alma-fix/990193094010206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990193094010206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2012-09-25",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193094010206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990193229450206441.json
+++ b/src/test/resources/alma-fix/990193229450206441.json
@@ -54,7 +54,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990193229450206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2012-10-08",
         "dateModified" : "2023-08-01",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193229450206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990193806600206441.json
+++ b/src/test/resources/alma-fix/990193806600206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990193806600206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2012-11-26",
         "dateModified" : "2023-07-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990193806600206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990194668760206441.json
+++ b/src/test/resources/alma-fix/990194668760206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990194668760206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2013-02-20",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990194668760206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990194744870206441.json
+++ b/src/test/resources/alma-fix/990194744870206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990194744870206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-02-27",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990194744870206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990196925330206441.json
+++ b/src/test/resources/alma-fix/990196925330206441.json
@@ -53,7 +53,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990196925330206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-05-28",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990196925330206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990197023370206441.json
+++ b/src/test/resources/alma-fix/990197023370206441.json
@@ -47,7 +47,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990197023370206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-06-06",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197023370206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990197067610206441.json
+++ b/src/test/resources/alma-fix/990197067610206441.json
@@ -45,7 +45,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990197067610206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-06-11",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197067610206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990197293880206441.json
+++ b/src/test/resources/alma-fix/990197293880206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990197293880206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-07-01",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990197293880206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990198125850206441.json
+++ b/src/test/resources/alma-fix/990198125850206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990198125850206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-08-26",
         "dateModified" : "2022-06-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990198125850206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990198383780206441.json
+++ b/src/test/resources/alma-fix/990198383780206441.json
@@ -41,7 +41,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990198383780206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2013-09-19",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990198383780206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990199611280206441.json
+++ b/src/test/resources/alma-fix/990199611280206441.json
@@ -41,7 +41,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990199611280206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2013-11-19",
         "dateModified" : "2023-05-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990199611280206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990202474680206441.json
+++ b/src/test/resources/alma-fix/990202474680206441.json
@@ -63,7 +63,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990202474680206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2014-01-14",
         "dateModified" : "2023-08-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990202474680206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990204246530206441.json
+++ b/src/test/resources/alma-fix/990204246530206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990204246530206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2014-06-16",
         "dateModified" : "2023-03-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990204246530206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990204253490206441.json
+++ b/src/test/resources/alma-fix/990204253490206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990204253490206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2014-06-17",
         "dateModified" : "2023-09-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990204253490206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990206060640206441.json
+++ b/src/test/resources/alma-fix/990206060640206441.json
@@ -40,7 +40,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990206060640206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2014-11-25",
         "dateModified" : "2023-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990206060640206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990207668220206441.json
+++ b/src/test/resources/alma-fix/990207668220206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990207668220206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2015-04-17",
         "dateModified" : "2023-02-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990207668220206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -35,7 +35,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990207856340206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2015-04-30",
         "dateModified" : "2023-06-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990207856340206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990209515320206441.json
+++ b/src/test/resources/alma-fix/990209515320206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990209515320206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2015-10-16",
         "dateModified" : "2023-05-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990209515320206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990209817770206441.json
+++ b/src/test/resources/alma-fix/990209817770206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990209817770206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2015-11-20",
         "dateModified" : "2023-03-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990209817770206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210093550206441.json
+++ b/src/test/resources/alma-fix/990210093550206441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210093550206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2015-12-16",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210093550206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210237770206441.json
+++ b/src/test/resources/alma-fix/990210237770206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210237770206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-01-11",
         "dateModified" : "2023-08-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210237770206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210285400206441.json
+++ b/src/test/resources/alma-fix/990210285400206441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210285400206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2016-01-14",
         "dateModified" : "2022-08-21",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210285400206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210312460206441.json
+++ b/src/test/resources/alma-fix/990210312460206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210312460206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-01-19",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210312460206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210667610206441.json
+++ b/src/test/resources/alma-fix/990210667610206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210667610206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-02-25",
         "dateModified" : "2023-09-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210667610206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210781980206441.json
+++ b/src/test/resources/alma-fix/990210781980206441.json
@@ -43,7 +43,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210781980206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-03-07",
         "dateModified" : "2023-09-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210781980206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990210950050206441.json
+++ b/src/test/resources/alma-fix/990210950050206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990210950050206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-03-23",
         "dateModified" : "2023-04-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990210950050206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990213367870206441.json
+++ b/src/test/resources/alma-fix/990213367870206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990213367870206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-08-29",
         "dateModified" : "2021-06-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990213367870206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990213906490206441.json
+++ b/src/test/resources/alma-fix/990213906490206441.json
@@ -46,7 +46,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990213906490206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2016-10-21",
         "dateModified" : "2023-04-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990213906490206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990217478660206441.json
+++ b/src/test/resources/alma-fix/990217478660206441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990217478660206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2017-02-21",
         "dateModified" : "2023-04-28",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217478660206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990217495840206441.json
+++ b/src/test/resources/alma-fix/990217495840206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990217495840206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2017-02-22",
         "dateModified" : "2023-09-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217495840206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990217879290206441.json
+++ b/src/test/resources/alma-fix/990217879290206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990217879290206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2017-03-31",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990217879290206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990218189790206441.json
+++ b/src/test/resources/alma-fix/990218189790206441.json
@@ -65,7 +65,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990218189790206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2017-05-04",
         "dateModified" : "2023-09-04",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990218189790206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990219911120206441.json
+++ b/src/test/resources/alma-fix/990219911120206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990219911120206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2017-10-24",
         "dateModified" : "2023-03-26",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990219911120206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990220027540206441.json
+++ b/src/test/resources/alma-fix/990220027540206441.json
@@ -34,7 +34,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990220027540206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2017-11-07",
         "dateModified" : "2023-02-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990220027540206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990223521400206441.json
+++ b/src/test/resources/alma-fix/990223521400206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990223521400206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2018-03-22",
         "dateModified" : "2023-04-02",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990223521400206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990225056670206441.json
+++ b/src/test/resources/alma-fix/990225056670206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990225056670206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2018-05-30",
         "dateModified" : "2023-02-10",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990225056670206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990226465800206441.json
+++ b/src/test/resources/alma-fix/990226465800206441.json
@@ -40,7 +40,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990226465800206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2018-10-16",
         "dateModified" : "2023-09-05",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990226465800206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990226763120206441.json
+++ b/src/test/resources/alma-fix/990226763120206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990226763120206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2018-11-13",
         "dateModified" : "2023-04-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990226763120206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990363946050206441.json
+++ b/src/test/resources/alma-fix/990363946050206441.json
@@ -40,7 +40,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990363946050206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2019-09-18",
         "dateModified" : "2023-04-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990363946050206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990365842280206441.json
+++ b/src/test/resources/alma-fix/990365842280206441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990365842280206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2020-03-09",
         "dateModified" : "2023-02-17",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990365842280206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990366338340206441.json
+++ b/src/test/resources/alma-fix/990366338340206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990366338340206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2020-04-29",
         "dateModified" : "2023-08-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990366338340206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990366394400206441.json
+++ b/src/test/resources/alma-fix/990366394400206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990366394400206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2020-05-06",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990366394400206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990366624790206441.json
+++ b/src/test/resources/alma-fix/990366624790206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990366624790206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2020-06-03",
         "dateModified" : "2022-11-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990366624790206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990367593690206441.json
+++ b/src/test/resources/alma-fix/990367593690206441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990367593690206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2020-08-31",
         "dateModified" : "2023-11-27",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990367593690206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990367731740206441.json
+++ b/src/test/resources/alma-fix/990367731740206441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990367731740206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2020-09-16",
         "dateModified" : "2023-08-23",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990367731740206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990367761810206441.json
+++ b/src/test/resources/alma-fix/990367761810206441.json
@@ -64,7 +64,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990367761810206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2020-09-18",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990367761810206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990368319120206441.json
+++ b/src/test/resources/alma-fix/990368319120206441.json
@@ -33,7 +33,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990368319120206441",
-        "dateCreated" : "2021-04-06",
+        "dateCreated" : "2020-11-09",
         "dateModified" : "2023-04-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990368319120206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990368743120206441.json
+++ b/src/test/resources/alma-fix/990368743120206441.json
@@ -34,7 +34,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990368743120206441",
-        "dateCreated" : "2021-04-05",
+        "dateCreated" : "2020-12-21",
         "dateModified" : "2021-04-09",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990368743120206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/991002103529706485.json
+++ b/src/test/resources/alma-fix/991002103529706485.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/991002103529706485",
-        "dateCreated" : "2022-07-06",
+        "dateCreated" : "2021-10-20",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991002103529706485 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/991005935279706485.json
+++ b/src/test/resources/alma-fix/991005935279706485.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/991005935279706485",
-        "dateCreated" : "2022-07-06",
+        "dateCreated" : "1999-11-19",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 991005935279706485 im Exportformat MARC21 XML",
         "inDataset" : {

--- a/src/test/resources/alma-fix/99370673692206441.json
+++ b/src/test/resources/alma-fix/99370673692206441.json
@@ -56,7 +56,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370673692206441",
-        "dateCreated" : "2021-04-15",
+        "dateCreated" : "2002-05-02",
         "dateModified" : "2024-09-21",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370673692206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370678063606441.json
+++ b/src/test/resources/alma-fix/99370678063606441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370678063606441",
-        "dateCreated" : "2021-04-15",
+        "dateCreated" : "2005-06-14",
         "dateModified" : "2023-04-15",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370678063606441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370682219806441.json
+++ b/src/test/resources/alma-fix/99370682219806441.json
@@ -47,7 +47,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370682219806441",
-        "dateCreated" : "2021-04-19",
+        "dateCreated" : "2013-12-10",
         "dateModified" : "2022-12-16",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370682219806441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370690532406441.json
+++ b/src/test/resources/alma-fix/99370690532406441.json
@@ -40,7 +40,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370690532406441",
-        "dateCreated" : "2021-04-19",
+        "dateCreated" : "2023-02-07",
         "dateModified" : "2023-03-07",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370690532406441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370694196806441.json
+++ b/src/test/resources/alma-fix/99370694196806441.json
@@ -42,7 +42,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370694196806441",
-        "dateCreated" : "2021-04-19",
+        "dateCreated" : "2012-07-03",
         "dateModified" : "2023-05-14",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370694196806441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370699582506441.json
+++ b/src/test/resources/alma-fix/99370699582506441.json
@@ -41,7 +41,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370699582506441",
-        "dateCreated" : "2021-04-19",
+        "dateCreated" : "2009-08-06",
         "dateModified" : "2023-02-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370699582506441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370738710506441.json
+++ b/src/test/resources/alma-fix/99370738710506441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370738710506441",
-        "dateCreated" : "2021-04-29",
+        "dateCreated" : "2015-06-08",
         "dateModified" : "2022-12-11",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370738710506441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370746459806441.json
+++ b/src/test/resources/alma-fix/99370746459806441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370746459806441",
-        "dateCreated" : "2021-04-29",
+        "dateCreated" : "2014-01-13",
         "dateModified" : "2023-07-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370746459806441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370763433806441.json
+++ b/src/test/resources/alma-fix/99370763433806441.json
@@ -38,7 +38,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370763433806441",
-        "dateCreated" : "2021-05-04",
+        "dateCreated" : "2020-09-30",
         "dateModified" : "2023-07-13",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370763433806441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99370763882706441.json
+++ b/src/test/resources/alma-fix/99370763882706441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99370763882706441",
-        "dateCreated" : "2021-05-04",
+        "dateCreated" : "2015-04-24",
         "dateModified" : "2022-08-20",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99370763882706441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371107766906441.json
+++ b/src/test/resources/alma-fix/99371107766906441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371107766906441",
-        "dateCreated" : "2021-12-20",
+        "dateCreated" : "2016-03-25",
         "dateModified" : "2023-06-03",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371107766906441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371123630706441.json
+++ b/src/test/resources/alma-fix/99371123630706441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371123630706441",
-        "dateCreated" : "2022-01-11",
+        "dateCreated" : "2015-05-06",
         "dateModified" : "2023-07-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371123630706441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371147104906441.json
+++ b/src/test/resources/alma-fix/99371147104906441.json
@@ -44,7 +44,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371147104906441",
-        "dateCreated" : "2022-01-24",
+        "dateCreated" : "2022-01-18",
         "dateModified" : "2023-05-27",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371147104906441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371426239306441.json
+++ b/src/test/resources/alma-fix/99371426239306441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371426239306441",
-        "dateCreated" : "2022-07-06",
+        "dateCreated" : "2017-11-03",
         "dateModified" : "2023-10-24",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371426239306441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371447897606441.json
+++ b/src/test/resources/alma-fix/99371447897606441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371447897606441",
-        "dateCreated" : "2022-07-18",
+        "dateCreated" : "2018-08-28",
         "dateModified" : "2023-08-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371447897606441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371449208306441.json
+++ b/src/test/resources/alma-fix/99371449208306441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371449208306441",
-        "dateCreated" : "2022-07-18",
+        "dateCreated" : "2019-01-19",
         "dateModified" : "2023-07-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371449208306441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371463467006441.json
+++ b/src/test/resources/alma-fix/99371463467006441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371463467006441",
-        "dateCreated" : "2022-07-29",
+        "dateCreated" : "2023-06-05",
         "dateModified" : "2023-12-22",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371463467006441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371791018506441.json
+++ b/src/test/resources/alma-fix/99371791018506441.json
@@ -37,7 +37,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371791018506441",
-        "dateCreated" : "2022-11-30",
+        "dateCreated" : "2022-08-03",
         "dateModified" : "2022-12-06",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371791018506441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99371964653806441.json
+++ b/src/test/resources/alma-fix/99371964653806441.json
@@ -39,7 +39,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99371964653806441",
-        "dateCreated" : "2023-03-10",
+        "dateCreated" : "2024-01-12",
         "dateModified" : "2024-01-12",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99371964653806441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99372680948006441.json
+++ b/src/test/resources/alma-fix/99372680948006441.json
@@ -51,7 +51,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99372680948006441",
-        "dateCreated" : "2023-07-07",
+        "dateCreated" : "2013-05-07",
         "dateModified" : "2023-08-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99372680948006441 im Exportformat MARC21 XML",


### PR DESCRIPTION
MNG only states the data when the record was indexed into ALMA not initially catalogued. When migrating from ALEPH to ALMA the information from MARC 002 (fromer `describedBy.object.dateCreated`) was mapped to MARC 008/00-05. This commit reintroduce the initital cataluging date again and uses the alma indexing date only as fallback.


See: https://github.com/hbz/lobid-resources/issues/2114