### PR TITLE
Add workaround if cataloguing dates in 008 that are too long

### DIFF
--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -31,10 +31,16 @@ add_field("describedBy.resultOf.instrument.label","Software lobid-resources")
 copy_field("almaMmsId","describedBy.resultOf.object.id")
 prepend("describedBy.resultOf.object.id","https://lobid.org/marcxml/")
 
-# MNG is a ALMA-specific element (MNG  .b only states the indexing date into ALMA, while 008 is the initial cataloguing date.)
+# 008/00-05 has the initial cataloguing date. We use MNG info as fallback.
+# MNG is a ALMA-specific element (MNG  .b only states the indexing date into ALMA.)
 
 copy_field("008","@initialCataloguingDate")
-substring("@initialCataloguingDate","0","6")
+if any_match("@initialCataloguingDate", "^\\d{8}.*") # Due to cataloguing errors there seem to be year not represented by two but by four digits. The first step is a workaround.
+  substring("@initialCataloguingDate","2","6")
+elsif any_match("@initialCataloguingDate", "^\\d{6}.*") # 008/00-05 is the correct form for the cataloguing date in MARC.
+  substring("@initialCataloguingDate","0","6")
+end
+
 if any_match("@initialCataloguingDate","^[0-4].*")
   prepend("@initialCataloguingDate","20")
 elsif any_match("@initialCataloguingDate","\\d*")

--- a/src/test/resources/alma-fix/99374515437806441.json
+++ b/src/test/resources/alma-fix/99374515437806441.json
@@ -1,0 +1,176 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99374515437806441#!",
+  "type" : [ "BibliographicResource", "Bibliography", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Remote sensing of climate",
+  "almaMmsId" : "99374515437806441",
+  "isbn" : [ "9780443217302", "0443217300" ],
+  "publication" : [ {
+    "startDate" : "2024",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Amsterdam", "Cambridge, MA" ],
+    "publishedBy" : [ "Elsevier" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99374515437806441",
+    "label" : "Webseite der hbz-Ressource 99374515437806441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99374515437806441",
+        "dateCreated" : "2020-24-08",
+        "dateModified" : "2024-10-30",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99374515437806441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "ebookcentral.proquest.com"
+        },
+        "provider" : {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "ebookcentral.proquest.com"
+        },
+        "modifiedBy" : [ {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "ebookcentral.proquest.com"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99374515437806441",
+    "label" : "Culturegraph Ressource"
+  } ],
+  "related" : [ {
+    "note" : [ "Print version:" ],
+    "isbn" : [ "9780443217319", "0443217319" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
+  "extent" : "1 online resource (458 pages)",
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Climatology / Remote sensing."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "551.6",
+    "notation" : "551.6"
+  } ],
+  "subjectslabels" : [ "Climatology / Remote sensing." ],
+  "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_OWL/openurl?u.ignore_date_coverage=true&portfolio_pid=5353389590006468&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_OWL/openurl?u.ignore_date_coverage=true&rft.mms_id=991004397752606468",
+    "heldBy" : {
+      "isil" : "DE-743",
+      "id" : "http://lobid.org/organisations/DE-743#!",
+      "label" : "Technische Hochschule Ostwestfalen-Lippe, Service Kommunikation Information Medien"
+    },
+    "seeAlso" : [ "https://th-owl.digibib.net/search/katalog/record/(DE-605)99374515437806441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-743#!",
+      "label" : "Technische Hochschule Ostwestfalen-Lippe, Service Kommunikation Information Medien"
+    } ],
+    "id" : "http://lobid.org/items/99374515437806441:DE-743:5353389590006468#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&portfolio_pid=53379905320006470&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBT/openurl?u.ignore_date_coverage=true&rft.mms_id=9928037879906470",
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma99374515437806441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    } ],
+    "id" : "http://lobid.org/items/99374515437806441:DE-385:53379905320006470#!"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "edited by Timothy Dube [and three others]." ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Dube, Timothy",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt",
+      "label" : "Herausgeber/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Shekede, Munyaradzi Davis",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Shoko, Cletah",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Mushore, Terence",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99374515437806441.json
+++ b/src/test/resources/alma-fix/99374515437806441.json
@@ -36,7 +36,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/99374515437806441",
-        "dateCreated" : "2020-24-08",
+        "dateCreated" : "2024-08-16",
         "dateModified" : "2024-10-30",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 99374515437806441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/99374515437806441.xml
+++ b/src/test/resources/alma-fix/99374515437806441.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>10686nam a22004453i 4500</leader>
+  <controlfield tag="001">99374515437806441</controlfield>
+  <controlfield tag="005">20241028201707.0</controlfield>
+  <controlfield tag="006">m     o  d |      </controlfield>
+  <controlfield tag="007">cr#cnu||||||||</controlfield>
+  <controlfield tag="008">20240816s2024    ne    o ob    001 0 eng d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9780443217302</subfield>
+    <subfield code="q">(electronic bk.)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">0-443-21730-0</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC31601972</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Au-PeEL)EBL31601972</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)33987495800041</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)9933987495800041</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MiAaPQ</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="e">pn</subfield>
+    <subfield code="c">MiAaPQ</subfield>
+    <subfield code="d">MiAaPQ</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">QC981.6</subfield>
+    <subfield code="b">.R46 2024</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">RC981</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2=" ">
+    <subfield code="a">551.6</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Remote sensing of climate /</subfield>
+    <subfield code="c">edited by Timothy Dube [and three others].</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Amsterdam ;</subfield>
+    <subfield code="a">Cambridge, MA :</subfield>
+    <subfield code="b">Elsevier,</subfield>
+    <subfield code="c">[2024]</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="4">
+    <subfield code="c">©2024.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (458 pages)</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">Intro -- Remote Sensing of Climate -- Copyright -- Contents -- Contributors -- About the editors -- Chapter 1: Remote sensing of climate variability: An introduction -- 1. Introduction -- 2. Drought -- 3. Drivers of climate variability and climate change -- 3.1. El Niño and La Nina -- 3.2. Solar activity -- 3.3. Volcanic eruptions -- 3.4. Anthropogenic activities -- 4. Evolution of climate science -- 5. Evidence of climate change and variability -- 6. Remote sensing of climate change and variability -- 7. Conclusion -- References -- Chapter 2: Remote sensing technological advancements and applications in climate variability analysis studies -- 1. Introduction -- 2. Overview of climate variability analysis and their associated impacts -- 3. Remote sensing data applications and associated challenges for climate variability analysis -- 4. Technological advancements in remote sensing tools and application in climate variability studies -- 5. Conclusions -- References -- Chapter 3: Big data and analytical algorithms for climate variability -- 1. Introduction -- 2. Trends in big data analytics for climate change -- 3. Types of big data analytics -- 3.1. Descriptive analytics -- 3.2. Diagnostic analytics -- 3.3. Prescriptive analytics -- 3.4. Cognitive analytics -- 3.5. Behavioral analytics -- 3.6. Quantitative analytics -- 4. Types of analytical algorithms -- 4.1. Regression algorithms -- 4.2. Classification algorithms -- 4.3. Clustering algorithms -- 5. Applications of big data analytics in climate change -- 5.1. Predictive modeling for extreme weather events -- 5.2. Energy efficiency and intelligence -- 5.3. Smart farming, agriculture, and forestry -- 5.4. Sustainable urban planning and infrastructure -- 5.5. Natural disaster and disease assessment -- 6. Conclusion -- References -- Chapter 4: Climate variability and agriculture -- 1. Introduction.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="8" ind2=" ">
+    <subfield code="a">2. Monitoring climate variability and its impacts on agriculture -- 2.1. Monitoring climate variables -- 2.2. Approaches for monitoring droughts -- 2.3. Remote sensing applications in drought monitoring -- 3. Climate change adaptation strategies for agricultural systems -- 3.1. Types of adaptation strategies in agriculture -- 3.2. Opportunities and barriers for adapting to climate change in agriculture -- 4. Climate change mitigation in the agriculture sector -- 4.1. Cropland emission mitigation -- 4.2. Enhancing soil carbon sequestration -- 4.3. Livestock management -- 5. Case studies showcasing mitigation strategies in agriculture -- 6. Policy frameworks for climate change and agriculture -- 7. Gaps and opportunities for policy and institutional support for climate change adaptation and mitigation in agriculture -- 8. Conclusion -- References -- Chapter 5: Climate variability and rangeland ecosystems -- 1. Introduction -- 2. Global rangeland spatial extent -- 3. Effects of climate change and variability on rangeland ecosystems -- 3.1. Effect of climate change on woody vegetation -- 3.2. Climate variability effects on herbaceous plant diversity -- 3.3. Effect of climate change on rangeland productivity -- 4. Role of remote sensing in assessing the impacts of climate change and variability on rangelands -- 4.1. Operational decision support systems for monitoring the rangeland changes -- 4.2. Multisource datasets and their capabilities in mapping and monitoring climate change variability in rangeland enviro ... -- 5. Integrated climate and satellite-based products for precision modeling and projection of climate variability on rangeland -- 6. Advancements in remote sensing applications and analysis in rangeland productivity and climate variability monitoring -- 7. Summary and conclusion -- References.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="8" ind2=" ">
+    <subfield code="a">Chapter 6: Climate variability and natural ecosystems productivity -- 1. Introduction -- 2. Climate variability -- 3. Climate variability effects on natural ecosystems in different regions of the world -- 4. Natural ecosystem productivity and the carbon cycle -- 5. Climate variability effects on natural ecosystem productivity and the carbon cycle -- 6. Climate variability and spatial variations in natural ecosystem productivity -- 7. Climate change mitigation in natural ecosystems -- 8. Case studies of potentially viable mitigation strategies -- 9. Social security nets in Ethiopia -- 10. Climate change mitigation -- 11. Conclusion -- References -- Chapter 7: Application of remote sensing techniques to monitor climate variability effects on groundwater-dependent ecosy ... -- 1. Introduction -- 2. Remote sensing-based indicators of GDE health -- 3. Remote sensing of climate variability impacts on GDEs -- 4. Response of GDEs to climate variability -- 5. Remote sensing approaches for mapping and characterizing GDEs -- 6. Identification, delineation, mapping, and monitoring of GDEs using remote sensing capabilities -- 7. Remotely sensed algorithms on GDE assessment and monitoring -- 8. Advanced indices for GDE mapping -- 9. Conclusion and recommendations -- References -- Chapter 8: Climate variability and water resources -- 1. Introduction -- 1.1. Background and significance -- 1.2. Role of remote sensing in assessing climate variability impacts on water resources -- 1.3. Importance of understanding the interactions between climate variability and water availability -- 2. Remote sensing principles and techniques -- 2.1. Overview of remote sensing in water resources monitoring -- 2.2. Sensors and platforms used for remote sensing of climate variability -- 2.3. Data acquisition and preprocessing techniques.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="8" ind2=" ">
+    <subfield code="a">2.4. Remote sensing data types relevant to water resources analysis -- 3. Climate variability and its impacts on water resources -- 3.1. Understanding climate variability patterns and drivers -- 3.2. Key climate variables affecting water resources -- 3.3. Impacts of climate variability on hydrological processes and water availability -- 4. Remote sensing applications for water resources assessment -- 4.1. Estimation of precipitation using remote sensing data -- 4.2. Remote sensing-based monitoring of ET and soil moisture -- 4.3. Mapping and monitoring of surface water resources using remote sensing -- 4.4. Remote sensing techniques for groundwater assessment -- 5. Methodologies for analyzing climate variability impacts -- 5.1. Time-series analysis of remote sensing data for climate trend detection -- 5.2. Modeling approaches for understanding climate-water interactions -- 5.3. Integration of remote sensing with hydrological models for water resources assessment -- 6. Case studies and examples -- 6.1. Case study 1: Remote sensing of climate impacts on river flow and streamflow patterns -- 6.2. Case study 2: Monitoring the impact of climate variability on reservoir storage -- 6.3. Case study 3: Remote sensing-based assessment of drought and its effects on water resources -- 7. Challenges and future directions -- 7.1. Limitations and uncertainties in remote sensing-based analysis of climate variability and water resources -- 7.2. Data availability and quality considerations -- 7.3. Advancements and future prospects in remote sensing technology for water resources assessment -- 8. Conclusion -- 8.1. Summary of key findings -- 8.2. Importance of remote sensing in understanding climate variability impacts on water resources -- 8.3. Recommendations for further research and applications -- References.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="8" ind2=" ">
+    <subfield code="a">Chapter 9: Remote sensing of climate variability and flooding -- 1. Introduction -- 2. Remote sensing applications for climate variability and flood monitoring -- 3. Analytical approaches to the remote sensing of climate variability and flood monitoring -- 4. Case studies on the remote sensing of climate variability and flood monitoring -- 5. Strengths and weaknesses of the remote sensing of climate variability and flooding -- 6. Conclusion -- References -- Chapter 10: Climate variability and drought -- 1. Introduction -- 1.1. Seasonal drought -- 1.2. Irregular drought -- 1.3. Partial drought -- 1.4. Permanent drought -- 2. Climate variability and drought -- 2.1. Drivers of climate variability -- 2.2. Concept of drought and drought types -- 3. Remote sensing of drought: Drought monitoring -- 4. Drought indices for drought monitoring and early warning systems -- 4.1. Satellite data-driven drought indices -- 4.1.1. Vegetation Condition Index -- 4.1.2. Normalized Difference Vegetation Index -- 4.2. Data-driven drought indices -- 4.2.1. Percent of Normal -- 4.2.2. Palmer Drought Severity Index -- 4.2.3. Crop Moisture Index -- 4.2.4. The deciles index -- 4.2.5. Standardized Precipitation Index -- 5. Drought impacts on agriculture, ecosystems, human health and social systems, water resources -- 5.1. Drought and water resources -- 5.2. Drought and human health -- 5.3. Drought and terrestrial ecosystems -- 5.4. Drought and agriculture -- 5.5. Drought mitigation and adaptation measures -- 6. Outlook on climate variability and adaptation -- 7. Opportunities, progress, and prospects -- References -- Chapter 11: Climate variability and aquatic weed proliferation -- 1. Introduction -- 2. Impacts of pollution, climate variability, and aquatic species proliferation on open-water ecosystems -- 3. Remote sensing of climate variability and aquatic weed proliferation.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="8" ind2=" ">
+    <subfield code="a">4. Advanced algorithms for assessing the impacts of climate variability and aquatic weed proliferation.</subfield>
+  </datafield>
+  <datafield tag="588" ind1=" " ind2=" ">
+    <subfield code="a">Description based on publisher supplied metadata and other sources.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Climatology</subfield>
+    <subfield code="x">Remote sensing.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Dube, Timothy,</subfield>
+    <subfield code="e">editor.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Shekede, Munyaradzi Davis.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Shoko, Cletah.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Mushore, Terence.</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="i">Print version:</subfield>
+    <subfield code="z">0443217319</subfield>
+    <subfield code="z">9780443217319</subfield>
+    <subfield code="w">(OCoLC)1405364557</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">BOOK</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99374515437806441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_OWL</subfield>
+    <subfield code="i">991004397752606468</subfield>
+    <subfield code="n">Hochschule Ostwestfalen-Lippe</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="i">9928037879906470</subfield>
+    <subfield code="n">UB Trier</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">system</subfield>
+    <subfield code="f">EBC</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">84</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2024-10-30 00:35:11 Europe/Berlin</subfield>
+    <subfield code="g">9933987495800041</subfield>
+    <subfield code="j">00</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="b">2024-08-19 00:39:45 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ebook Central</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5353389590006468</subfield>
+    <subfield code="M">49HBZ_OWL</subfield>
+    <subfield code="p">6143463550006468</subfield>
+    <subfield code="q">Ebook Central Perpetual, DDA and Subscription Titles</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">614330000000000002</subfield>
+    <subfield code="y">2024-08-22 02:17:29 Europe/Berlin</subfield>
+    <subfield code="w">2024-08-22 02:17:11 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5353389590006468&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2024-08-22 00:17:11</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">6243463540006468</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991004397752606468</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="8">5353389590006468</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Elsevier ScienceDirect</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53379905320006470</subfield>
+    <subfield code="h">DEFAULT</subfield>
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="p">61376076640006470</subfield>
+    <subfield code="q">eBook - Earth and Planetary Sciences 2024</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615410000000003234</subfield>
+    <subfield code="y">2025-01-01 00:00:49 Europe/Berlin</subfield>
+    <subfield code="w">2024-08-19 00:37:27 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53379905320006470&amp;Force_direct=true</subfield>
+    <subfield code="v">electronic inventory creator</subfield>
+    <subfield code="z">2024-08-18 22:37:27</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="t">BE24-6426</subfield>
+    <subfield code="S">62376076630006470</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=9928037879906470</subfield>
+    <subfield code="b">Not Available</subfield>
+    <subfield code="8">53379905320006470</subfield>
+  </datafield>
+</record>


### PR DESCRIPTION
As stated in https://github.com/hbz/lobid-resources/issues/2114#issuecomment-2572433239 some issues popped up with cataloguing dates that are too long consisting of 8 instead of 6 digits. 

Since 008/06 should not be an digit I have introduced a workaround if the date is to long.
@maipet can you have a look if this workaround makes sense?

Thanks.