### PR TITLE
Add URI to detail page #2126

### DIFF
--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -196,6 +196,7 @@
   @result_field("ISSN", "issn", doc, TableRow.VALUES, node = Option(doc))
   @result_field("HBZ ID", "hbzId", doc, TableRow.VALUES, node = Option(doc))
   @result_field("ZDB ID", "zdbId", doc, TableRow.VALUES, node = Option(doc))
+  @result_field("ALMA MMS ID", "almaMmsId", doc, TableRow.VALUES, node = Option(doc))
   @withPrefixedLink("DOI", "https://dx.doi.org/", doc \ "doi")
   @withPrefixedLink("URN", "https://nbn-resolving.org/", doc \ "urn")
   @result_field("Umfang", "extent", doc, TableRow.VALUES)

--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -178,6 +178,7 @@
 }
 
 @table(){
+  @result_field("URI", "id", doc, TableRow.VALUES, node = Option(doc))
   <tr><td>Titel</td><td>@((doc\"title").asOpt[String].getOrElse(""))@for(corporateBodyForTitle <- (doc \ "corporateBodyForTitle").asOpt[Seq[String]]){. @corporateBodyForTitle}</td></tr>
   @result_field("Titelzusatz", "otherTitleInformation", doc, TableRow.VALUES)
   @result_field("Alternativer Titel", "alternativeTitle", doc, TableRow.VALUES)

--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -195,6 +195,7 @@
   @result_field("ISBN", "isbn", doc, TableRow.VALUES, node = Option(doc))
   @result_field("ISSN", "issn", doc, TableRow.VALUES, node = Option(doc))
   @result_field("HBZ ID", "hbzId", doc, TableRow.VALUES, node = Option(doc))
+  @result_field("ZDB ID", "zdbId", doc, TableRow.VALUES, node = Option(doc))
   @withPrefixedLink("DOI", "https://dx.doi.org/", doc \ "doi")
   @withPrefixedLink("URN", "https://nbn-resolving.org/", doc \ "urn")
   @result_field("Umfang", "extent", doc, TableRow.VALUES)

--- a/web/app/views/tags/result_doc.scala.html
+++ b/web/app/views/tags/result_doc.scala.html
@@ -194,6 +194,7 @@
   @result_field("Auflage", "edition", doc, TableRow.VALUES)
   @result_field("ISBN", "isbn", doc, TableRow.VALUES, node = Option(doc))
   @result_field("ISSN", "issn", doc, TableRow.VALUES, node = Option(doc))
+  @result_field("HBZ ID", "hbzId", doc, TableRow.VALUES, node = Option(doc))
   @withPrefixedLink("DOI", "https://dx.doi.org/", doc \ "doi")
   @withPrefixedLink("URN", "https://nbn-resolving.org/", doc \ "urn")
   @result_field("Umfang", "extent", doc, TableRow.VALUES)


### PR DESCRIPTION
I added the URI, the hbz id, zdb id and alma mms id to the detail page.
Is that good or too much?

When working on the details page. 
Personally I would also prefer not to list only one but all type and medium statements. See #2017 But I am not sure how to fix this.

https://github.com/hbz/lobid-resources/blob/d32db657cc774e69d86cf5ac42614694c21a0893/web/app/views/tags/result_doc.scala.html#L79-L85

Seems only to allow for one, Could you help here @fsteeg 