### PR TITLE
Validate leapYear #2141

### DIFF
--- a/src/main/resources/alma/fix/describedBy.fix
+++ b/src/main/resources/alma/fix/describedBy.fix
@@ -66,6 +66,8 @@ replace_all("describedBy.resultOf.object.dateCreated","^(\\d{4})(\\d{2})(\\d{2})
 replace_all("describedBy.resultOf.object.dateModified","^(\\d{4})(\\d{2})(\\d{2})$","$1-$2-$3")
 replace_all("describedBy.resultOf.object.dateCreated","^(\\d{4})$","$1-01-01")
 replace_all("describedBy.resultOf.object.dateModified","^(\\d{4})$","$1-01-01")
+call_macro("leapYearChecker",date:"describedBy.resultOf.object.dateCreated")
+call_macro("leapYearChecker",date:"describedBy.resultOf.object.dateModified")
 
 add_array("describedBy.resultOf.object.type[]", "DataFeedItem")
 

--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -585,3 +585,11 @@ do put_macro("lobidResourcesFallbackLabel")
   end
 end
 
+# validate leap years
+do put_macro("leapYearChecker")
+  if any_match("$[date]","....-02-29")
+    unless any_match("$[date]","(((18|19|20)(04|08|[2468][048]|[13579][26]))|2000)-02-29")
+      replace_all("$[date]","(....-02)-29","$1-28")
+    end
+  end
+end

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -326,6 +326,8 @@ do list(path: "publication[]", "var": "$i")
   replace_all("$i.location[].*", "^\\[(.*)\\]$", "$1")
   replace_all("$i.location[].*", "\\s?[,:;]$", "")
   replace_all("$i.publishedBy[].*", "^[©]|\\s?[,:;/=]?$", "")
+  call_macro("leapYearChecker",date:"$i.startDate")
+  call_macro("leapYearChecker",date:"$i.endDate")
   uniq("$i.location[]")
 end
 

--- a/src/test/resources/alma-fix/990129250080206441.json
+++ b/src/test/resources/alma-fix/990129250080206441.json
@@ -1,0 +1,104 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990129250080206441#!",
+  "type" : [ "BibliographicResource", "Thesis", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Kristallographische Charakterisierung der ionenausgetauschten Phasen des Na-Schichtsilicates RUB-18 und deren thermisches Verhalten",
+  "almaMmsId" : "990129250080206441",
+  "hbzId" : "TT000509634",
+  "deprecatedUri" : "http://lobid.org/resources/TT000509634#!",
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990129250080206441",
+    "label" : "Webseite der hbz-Ressource 990129250080206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990129250080206441",
+        "dateCreated" : "1997-02-29",
+        "dateModified" : "2021-04-08",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990129250080206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-294#!",
+          "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-294#!",
+          "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990129250080206441",
+    "label" : "Culturegraph Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "extent" : "107 S.",
+  "thesisInformation" : [ "Bochum, Univ., Dipl.-Arbeit, 1997" ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "DIP 74",
+    "serialNumber" : "TEMP50012925008-000010",
+    "currentLibrary" : "IB",
+    "currentLocation" : "IB_GMG",
+    "heldBy" : {
+      "isil" : "DE-294-22",
+      "id" : "http://lobid.org/organisations/DE-294-22#!",
+      "label" : "Ruhr-Universität Bochum, Verbundbibliothek IB Fachbibliothek für Geographie, Geologie, Mathematik, Psychologie"
+    },
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma990129250080206441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/990129250080206441:DE-294-22:23126636480006471#!"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "vorgelegt von Kirsten Krink" ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Krink, Kirsten",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990129250080206441.json
+++ b/src/test/resources/alma-fix/990129250080206441.json
@@ -28,7 +28,7 @@
       },
       "object" : {
         "id" : "https://lobid.org/marcxml/990129250080206441",
-        "dateCreated" : "1997-02-29",
+        "dateCreated" : "1997-02-28",
         "dateModified" : "2021-04-08",
         "type" : [ "DataFeedItem" ],
         "label" : "hbz-Ressource 990129250080206441 im Exportformat MARC21 XML",

--- a/src/test/resources/alma-fix/990129250080206441.xml
+++ b/src/test/resources/alma-fix/990129250080206441.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>00671nam#a2200205#c#4500</leader>
+  <controlfield tag="005">20210408143221.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">970229|########xx#######m####|||#|#####c</controlfield>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="001">990129250080206441</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)TT000509634</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">294/Inst</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">294/Inst</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Krink, Kirsten</subfield>
+    <subfield code="4">aut</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Kristallographische Charakterisierung der ionenausgetauschten Phasen des Na-Schichtsilicates RUB-18 und deren thermisches Verhalten</subfield>
+    <subfield code="c">vorgelegt von Kirsten Krink</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">107 S.</subfield>
+  </datafield>
+  <datafield tag="502" ind1=" " ind2=" ">
+    <subfield code="a">Bochum, Univ., Dipl.-Arbeit, 1997</subfield>
+  </datafield>
+  <datafield tag="751" ind1=" " ind2=" ">
+    <subfield code="a">Bochum</subfield>
+    <subfield code="4">uvp</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||17</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">my||||||</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990129250080206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBO</subfield>
+    <subfield code="i">991024396659706471</subfield>
+    <subfield code="n">Universität Bochum</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">40</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2021-04-08 14:32:21 Europe/Berlin</subfield>
+    <subfield code="g">012925008-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-06 03:23:01 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">IB</subfield>
+    <subfield code="c">IB_GMG</subfield>
+    <subfield code="h">DIP 74</subfield>
+    <subfield code="8">22126636490006471</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2023-07-30 15:49:36</subfield>
+    <subfield code="8">22126636490006471</subfield>
+    <subfield code="M">49HBZ_UBO</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22126636490006471</subfield>
+    <subfield code="x">IB_GMG</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">IB_GMG</subfield>
+    <subfield code="p">S</subfield>
+    <subfield code="X">AMO_TL2_FIX</subfield>
+    <subfield code="U">2023-07-30 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2023-07-31 18:08:30 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="J">Fussnote: MinK</subfield>
+    <subfield code="n">DIP 74</subfield>
+    <subfield code="G">1</subfield>
+    <subfield code="M">49HBZ_UBO</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="L">HBZ01: TT000509634 | Anzahl  Beilagen: 1</subfield>
+    <subfield code="b">TEMP50012925008-000010</subfield>
+    <subfield code="O">SISIS-Vormerkzähler Migrationsjahr: 0 | SISIS-Buchdaten-Aufnahmedatum: 2008-05-23 | FussnoteIInt: 97/58</subfield>
+    <subfield code="N">Sigel: 294/22 | Klassifikation: 0 | SISIS-Ausleihzähler Migrationsjahr: 0</subfield>
+    <subfield code="a">23126636480006471</subfield>
+    <subfield code="c">DIP 74</subfield>
+    <subfield code="W">2023-07-30 17:49:36 Europe/Berlin</subfield>
+    <subfield code="u">IB</subfield>
+    <subfield code="w">IB</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 19 },
+			{ "title:der", /*->*/ 20 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 3 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 3 },
@@ -69,8 +69,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.startDate:1993", /*->*/ 3 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "publication.location:Berlin AND publication.startDate:[1992 TO 2017]", /*->*/ 5 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 144 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 164 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 145 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 165 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
See #2141

ElasticSearch throws `MapperParsingException` if leap year date 02-29 is not correct. I introduced a simple regex to test this part of this answer:

https://stackoverflow.com/a/8648129

Tests for range 1800-2099 and changes to date to 02-28 if leap year date is incorrect.