### PR TITLE
Avoid duplicating MARC 500 (General Note).

### DIFF
--- a/src/main/resources/alma/fix/otherFields.fix
+++ b/src/main/resources/alma/fix/otherFields.fix
@@ -112,7 +112,9 @@ replace_all("extent", "  ", " ")
 # 500 - General Note (R) Subfield: $a (NR)
 add_array("note[]")
 do list(path:"500  ", "var": "$i")
-  copy_field("$i.a", "note[].$append")
+  unless any_contain("$i.a","In:")
+    copy_field("$i.a", "note[].$append")
+  end
 end
 uniq("note[]")
 

--- a/src/test/resources/alma-fix/990110714900206441.json
+++ b/src/test/resources/alma-fix/990110714900206441.json
@@ -83,7 +83,6 @@
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]
   } ],
-  "note" : [ "In: Bürgerbuch Gronau und Epe. - 4. 1993/94 (1993) S. 68, 70-71 : Ill." ],
   "bibliographicCitation" : "Bürgerbuch Gronau und Epe. - 4. 1993/94 (1993) S. 68, 70-71 : Ill.",
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N548040",

--- a/src/test/resources/alma-fix/990110881770206441.json
+++ b/src/test/resources/alma-fix/990110881770206441.json
@@ -83,7 +83,6 @@
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]
   } ],
-  "note" : [ "In: Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb." ],
   "bibliographicCitation" : "Wirtschaftsspiegel. - 38 (1983) H. 7, S. 24-25 : 1 Abb.",
   "subject" : [ {
     "id" : "https://nwbib.de/subjects#N543000",

--- a/src/test/resources/alma-fix/990112067120206441.json
+++ b/src/test/resources/alma-fix/990112067120206441.json
@@ -88,7 +88,6 @@
     "label" : "Nordrhein-Westfälische Bibliographie (NWBib)",
     "type" : [ "Collection" ]
   } ],
-  "note" : [ "In: Heimatbuch des Kreises Viersen. - 47 (1996) S. 131-143 : Ill." ],
   "bibliographicCitation" : "Heimatbuch des Kreises Viersen. - 47 (1996) S. 131-143 : Ill.",
   "natureOfContent" : [ {
     "label" : "Tagebuch",

--- a/src/test/resources/alma-fix/990126426530206441.json
+++ b/src/test/resources/alma-fix/990126426530206441.json
@@ -84,7 +84,6 @@
     "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
     "label" : "Deutsch"
   } ],
-  "note" : [ "In: Energie Spektr.. - 11 (1996) Nr. 3 S. 18/21 : Abb.; 2 Lit." ],
   "bibliographicCitation" : "Energie Spektr.. - 11 (1996) Nr. 3 S. 18/21 : Abb.; 2 Lit.",
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",


### PR DESCRIPTION
If the field contains a citation ("In:"), the content gets added to both `note` and `bibliographicCitation`.

Ex.: 990110402310206441