### PR TITLE
Close some more resources

### DIFF
--- a/src/main/java/de/hbz/lobid/helper/EtikettMaker.java
+++ b/src/main/java/de/hbz/lobid/helper/EtikettMaker.java
@@ -307,4 +307,18 @@ public class EtikettMaker implements EtikettMakerInterface {
         contextLocation = contextFname;
     }
 
+    public void close(){
+        if (pMap!=null) {
+            pMap.clear();
+        }
+        if (nMap!=null) {
+            nMap.clear();
+        }
+        if (context!= null) {
+            context.clear();
+        }
+        if (labels!=null) {
+            labels.clear();
+        }
+    }
 }

--- a/src/main/java/org/lobid/resources/ElasticsearchIndexer.java
+++ b/src/main/java/org/lobid/resources/ElasticsearchIndexer.java
@@ -137,6 +137,16 @@ public class ElasticsearchIndexer
 		usrb.setSettings(settings);
 		usrb.execute().actionGet();
 		LOG.info("... finished indexing of ES index '" + indexName + "'");
+		LOG.info("Closing ES resources ...");
+		if (tc!=null) {
+			tc.close();
+		}
+		if (client!=null) {
+			client.close();
+		}
+		if (unsuccessfullyLookup!=null) {
+			unsuccessfullyLookup.clear();
+		}
 	}
 
 	@Override

--- a/src/main/java/org/lobid/resources/EtikettJson.java
+++ b/src/main/java/org/lobid/resources/EtikettJson.java
@@ -74,6 +74,11 @@ public final class EtikettJson
     }
   }
 
+  @Override
+  protected void onCloseStream() {
+    etikettMaker.close();
+  }
+
   private String getEtikettForEveryUri(final Map<String, Object> jsonMap)
       throws IOException {
       // don't label the root id


### PR DESCRIPTION
See #1336.

Since f1720b0d844d5d668e39781d9072d07a1e25be69 running the instance doesn't exit so often anymore because there is no heap memory exception anymore. Thus the instance is no more restarted so frequently (via monit). Thus a new
 error surfaced:
the elasticsearch resources weren't properly closed, which results in an loss of elasticsearch connections because there where too many open and unclosed. Which breaks the ETL process, but without exiting. The process just hang.