### PR TITLE
Add subject.notation to aggregation API

### DIFF
--- a/web/app/controllers/resources/Application.java
+++ b/web/app/controllers/resources/Application.java
@@ -101,6 +101,8 @@ public class Application extends Controller {
 	public static final String AGENT_FIELD = "contribution.agent.id";
 	/** The internal ES field for issued years. */
 	public static final String ISSUED_FIELD = "publication.startDate";
+	/** The internal ES field for subject notation. */
+	public static final String SUBJECT_NOTATION = "subject.notation";
 	/** Access to the resources.conf config file. */
 	private final static File RESOURCES_CONF = new File("conf/resources.conf").exists() ?
 			new File("conf/resources.conf") : new File("conf/resources.conf_template")  ;

--- a/web/app/controllers/resources/Search.java
+++ b/web/app/controllers/resources/Search.java
@@ -7,6 +7,7 @@ import static controllers.resources.Application.ISSUED_FIELD;
 import static controllers.resources.Application.MEDIUM_FIELD;
 import static controllers.resources.Application.OWNER_AGGREGATION;
 import static controllers.resources.Application.SUBJECT_FIELD;
+import static controllers.resources.Application.SUBJECT_NOTATION;
 import static controllers.resources.Application.TOPIC_AGGREGATION;
 import static controllers.resources.Application.TYPE_FIELD;
 
@@ -119,7 +120,7 @@ public class Search {
 	 * The values supported for the `aggregations` query parameter.
 	 */
 	public static final List<String> SUPPORTED_AGGREGATIONS = Arrays.asList(
-			ISSUED_FIELD, SUBJECT_FIELD, TYPE_FIELD, MEDIUM_FIELD, OWNER_AGGREGATION,
+			ISSUED_FIELD, SUBJECT_FIELD, SUBJECT_NOTATION, TYPE_FIELD, MEDIUM_FIELD, OWNER_AGGREGATION,
 			AGENT_FIELD, SPATIAL_LABEL_FIELD, SPATIAL_GEO_FIELD, SPATIAL_ID_FIELD,
 			SUBJECT_ID_FIELD, TOPIC_AGGREGATION);
 


### PR DESCRIPTION
Enables aggregations for subject.notation.
To cut back the result to e.g. getting only RVK one can use a tailored query using subject.source.id. Example:

search?q=saussure AND subject.source.id:"https://d-nb.info/gnd/4449787-8"&format=json&aggregations=subject.notation

Resolves #2184.