### PR TITLE
Ignore temporary callnumber in permanent location.

### DIFF
--- a/src/main/resources/alma/fix/item.fix
+++ b/src/main/resources/alma/fix/item.fix
@@ -9,11 +9,16 @@ do list(path:"ITM  ", "var": "$i")
       add_field("hasItem[].$last.label", "lobid Bestandsressource")
       add_array("hasItem[].$last.type[]", "Item","PhysicalObject")
       if exists("$i.z") # Temporary call number subfield
-        copy_field("$i.z", "hasItem[].$last.callNumber")
-      elsif exists("$i.n") # Item call number subfield
-        copy_field("$i.n", "hasItem[].$last.callNumber")
-      else # $c = Call number subfield
-        copy_field("$i.c", "hasItem[].$last.callNumber")
+        unless in("$i.x", "$i.v") # Current location != Permanent location
+          copy_field("$i.z", "hasItem[].$last.callNumber")
+        end
+      end
+      unless exists("hasItem[].$last.callNumber")
+        if exists("$i.n") # Item call number subfield
+          copy_field("$i.n", "hasItem[].$last.callNumber")
+        else # $c = Call number subfield
+          copy_field("$i.c", "hasItem[].$last.callNumber")
+        end
       end
       copy_field("$i.B", "hasItem[].$last.inventoryNumber")
       copy_field("$i.H", "@ITM-H.$append")

--- a/src/test/resources/alma-fix/99372715530306441.json
+++ b/src/test/resources/alma-fix/99372715530306441.json
@@ -1,0 +1,344 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99372715530306441#!",
+  "type" : [ "BibliographicResource", "Thesis", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Feldforschung in der Theaterarbeit mit Jugendlichen",
+  "almaMmsId" : "99372715530306441",
+  "hbzId" : "HT030130043",
+  "deprecatedUri" : "http://lobid.org/resources/HT030130043#!",
+  "isbn" : [ "9783968480893", "3968480899" ],
+  "oclcNumber" : [ "1390627981" ],
+  "otherTitleInformation" : [ "Bildungsprozesse und Praxisansätze zwischen Ethnografie und Theaterpädagogik" ],
+  "publication" : [ {
+    "startDate" : "2023",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "München" ],
+    "publishedBy" : [ "Kopaed" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99372715530306441",
+    "label" : "Webseite der hbz-Ressource 99372715530306441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99372715530306441",
+        "dateCreated" : "2023-08-02",
+        "dateModified" : "2025-07-27",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99372715530306441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-Bi10#!",
+          "label" : "Hochschule Bielefeld – University of Applied Sciences and Arts, Hochschulbibliothek"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-Bi10#!",
+          "label" : "Hochschule Bielefeld – University of Applied Sciences and Arts, Hochschulbibliothek"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-1116#!",
+          "label" : "Hochschule für Wirtschaft und Gesellschaft Ludwigshafen, Bibliothek"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99372715530306441",
+    "label" : "Culturegraph Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1390627981",
+    "label" : "OCLC Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT014892702#!",
+      "label" : "Kulturelle Bildung"
+    } ],
+    "numbering" : "70",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://digitale-objekte.hbz-nrw.de/storage2/2023/11/09/file_9/9459491.pdf"
+  } ],
+  "related" : [ {
+    "note" : [ "Online-Ausgabe" ],
+    "isbn" : [ "9783968486895", "3968486897" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "272 Seiten",
+  "note" : [ "Literaturverzeichnis: Seite 255-271" ],
+  "abstract" : [ "Ethnografie und Kulturelle Bildung, Feldforschung und Theater - das sind nicht unbedingt Sphären, die für gewöhnlich zusammengedacht werden. Kann das aktive Forschen in einem sozialen Feld wie z.B. auf einem Bauernhof, in einer Fabrik oder Fußgängerzone einen Probenprozess bereichern? Vor dem Hintergrund dieser Frage richtet sich dieses Buch an Menschen, die Theater in pädagogischen Zusammenhängen betreiben oder theoretisch betrachten. Es lädt dazu ein, über ein Zusammenspiel dieser scheinbar unterschiedlichen Bezugsrahmen und Ansätze nachzudenken und damit praktisch zu experimentieren. Denn - so die Kernthese, die das Buch im Kontext entwicklungsorientierter Bildungsforschung entfaltet: Ein didaktischer Ansatz, der Feldforschung und damit die Realität Sozialer Felder zur Entwicklung von szenischem Material in Probenprozessen des Theaters nutzt, besitzt nicht nur interessante ästhetische Qualitäten, sondern bahnt in besonderer Weise zentrale Momente ästhetischer Bildung an. Auf der Basis einer theoretischen Auseinandersetzung mit ethnografischen Verfahren, künstlerischer Forschung und Ästhetischer Bildung, sowie der Beobachtung eines feldforschungsorientierten Probenprozesses des Theater- und Performancekollektivs Frl. Wunder AG werden bildungstheoretische und ästhetische Parameter einer entsprechenden theaterpädagogischen Praxis mit Jugendlichen abgesteckt. Es entstehen nicht nur theoretische und didaktische Erkenntnisse über ein mögliches Zusammenspiel von Theaterpädagogik und ethnografischer Forschung, sondern auch ein theoretisch und empirisch fundierter Entwurf mit konkreten Aufgabenstellungen für die Probenarbeit." ],
+  "thesisInformation" : [ "Universität Hamburg, Dissertation, 2018" ],
+  "natureOfContent" : [ {
+    "label" : "Hochschulschrift",
+    "id" : "https://d-nb.info/gnd/4113937-9"
+  } ],
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "Bildung und Erziehung",
+    "notation" : "370"
+  }, {
+    "notation" : "24.03",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "BK (Basisklassifikation)",
+      "id" : "http://bartoc.org/en/node/18785"
+    }
+  }, {
+    "notation" : "DG 9440",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "RVK (Regensburger Verbundklassifikation)",
+      "id" : "https://d-nb.info/gnd/4449787-8"
+    }
+  }, {
+    "notation" : "AP 67400",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "RVK (Regensburger Verbundklassifikation)",
+      "id" : "https://d-nb.info/gnd/4449787-8"
+    }
+  }, {
+    "type" : [ "ComplexSubject" ],
+    "label" : "Jugend | Theaterarbeit | Theaterpädagogik | Feldforschung",
+    "componentList" : [ {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Jugend",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4028859-6",
+      "gndIdentifier" : "4028859-6",
+      "altLabel" : [ "Jugend (12-20 Jahre)", "Jugendalter", "Jugendlicher", "Teenager" ]
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Theaterarbeit",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4278709-9",
+      "gndIdentifier" : "4278709-9"
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Theaterpädagogik",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4126991-3",
+      "gndIdentifier" : "4126991-3",
+      "altLabel" : [ "Theaterdidaktik", "Dramapädagogik" ]
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Feldforschung",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4016674-0",
+      "gndIdentifier" : "4016674-0",
+      "altLabel" : [ "Feldarbeit (Empirische Sozialforschung)", "Feldstudie", "Field-research", "Field-work" ]
+    } ]
+  } ],
+  "subjectslabels" : [ "Jugend", "Theaterarbeit", "Theaterpädagogik", "Feldforschung" ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "Lutz-Scheurle",
+    "inventoryNumber" : "202308/548",
+    "serialNumber" : "91070130",
+    "currentLibrary" : "EFS",
+    "currentLocation" : "EFS_Haupt",
+    "heldBy" : {
+      "isil" : "DE-Dm13",
+      "id" : "http://lobid.org/organisations/DE-Dm13#!",
+      "label" : "Fachhochschule Dortmund, Hochschulbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-fdo.primo.exlibrisgroup.com/permalink/49HBZ_FDO/k375rg/alma99372715530306441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Dm13#!",
+      "label" : "Fachhochschule Dortmund, Hochschulbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/99372715530306441:DE-Dm13:2359609120006451#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "KMT Pfei",
+    "serialNumber" : "232533",
+    "currentLibrary" : "40",
+    "currentLocation" : "CB_FreiE-1",
+    "heldBy" : {
+      "isil" : "DE-Bi10",
+      "id" : "http://lobid.org/organisations/DE-Bi10#!",
+      "label" : "Hochschule Bielefeld – University of Applied Sciences and Arts, Hochschulbibliothek"
+    },
+    "seeAlso" : [ "https://fhb-bielefeld.digibib.net/search/katalog/record/(DE-605)HT030130043" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Bi10#!",
+      "label" : "Hochschule Bielefeld – University of Applied Sciences and Arts, Hochschulbibliothek"
+    } ],
+    "id" : "http://lobid.org/items/99372715530306441:DE-Bi10:2329778790006450#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "Pä 11 Pfe",
+    "inventoryNumber" : "23-1848",
+    "serialNumber" : "11257493",
+    "currentLibrary" : "RMC",
+    "currentLocation" : "BIB",
+    "heldBy" : {
+      "isil" : "DE-987",
+      "id" : "http://lobid.org/organisations/DE-987#!",
+      "label" : "Hochschule Koblenz, Bibliothek RheinMoselCampus"
+    },
+    "seeAlso" : [ "https://bibopac2.rac.hs-koblenz.de/webOPACClient-Koblenz/start.do?Query=0010=%22HT030130043%22" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-987#!",
+      "label" : "Hochschule Koblenz, Bibliothek RheinMoselCampus"
+    } ],
+    "id" : "http://lobid.org/items/99372715530306441:DE-987:2325194420008978#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "Sdo Pfei",
+    "inventoryNumber" : "100000044578",
+    "serialNumber" : "100000044578",
+    "currentLibrary" : "MG",
+    "currentLocation" : "MG_Public",
+    "heldBy" : {
+      "isil" : "DE-829",
+      "id" : "http://lobid.org/organisations/DE-829#!",
+      "label" : "Hochschule Niederrhein, Bibliothek"
+    },
+    "seeAlso" : [ "https://hs-niederrhein.digibib.net/search/katalog/record/(DE-605)HT030130043" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-829#!",
+      "label" : "Hochschule Niederrhein, Bibliothek"
+    } ],
+    "id" : "http://lobid.org/items/99372715530306441:DE-829:2347604300008056#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "HFB/319/Fb/PFE",
+    "serialNumber" : "307/001171",
+    "currentLibrary" : "38-319",
+    "currentLocation" : "38-319-KUN",
+    "heldBy" : {
+      "isil" : "DE-38-319",
+      "id" : "http://lobid.org/organisations/DE-38-319#!",
+      "label" : "Fachbibliothek Kunst & Textil, Department Kunst und Musik, Kunst & Kunsttheorie"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=99372715530306441&fdb=uni" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    } ],
+    "id" : "http://lobid.org/items/99372715530306441:DE-38-319:23357556820006476#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "KMT2224",
+    "inventoryNumber" : "23/7206",
+    "serialNumber" : "2524045",
+    "currentLibrary" : "P0001",
+    "currentLocation" : "11",
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr[q,any]=99372715530306441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    } ],
+    "id" : "http://lobid.org/items/99372715530306441:DE-466:23193729130006463#!"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Malte Pfeiffer" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "13748058X",
+      "id" : "https://d-nb.info/gnd/13748058X",
+      "label" : "Pfeiffer, Malte",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1982",
+      "sameAs" : [ "https://orcid.org/0009-0001-2171-6337" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "1064927602",
+      "id" : "https://d-nb.info/gnd/1064927602",
+      "label" : "kopaed verlagsgmbh",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "kopaed verlagsGmbH", "kopaed Verlags-GmbH", "kopaed", "Kopaed (Firma)" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/pbl",
+      "label" : "Verlag"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "35534-3",
+      "id" : "https://d-nb.info/gnd/35534-3",
+      "label" : "Universität Hamburg",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Uni Hamburg", "Uni HH", "University of Hamburg", "Hamburg University", "Hamburgische Universität", "Universidad de Hamburgo", "Université de Hambourg", "UH", "UHH" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/pbl",
+      "label" : "Verlag"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99372715530306441.json
+++ b/src/test/resources/alma-fix/99372715530306441.json
@@ -185,7 +185,7 @@
   "hasItem" : [ {
     "label" : "lobid Bestandsressource",
     "type" : [ "Item", "PhysicalObject" ],
-    "callNumber" : "Lutz-Scheurle",
+    "callNumber" : "KMT 186",
     "inventoryNumber" : "202308/548",
     "serialNumber" : "91070130",
     "currentLibrary" : "EFS",

--- a/src/test/resources/alma-fix/99372715530306441.xml
+++ b/src/test/resources/alma-fix/99372715530306441.xml
@@ -1,0 +1,916 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>03842cam a2200577 cb4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20250727215531.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">230802s2023    gw       m    ||| | ger c</controlfield>
+  <controlfield tag="001">99372715530306441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1390627981</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9783968480893</subfield>
+    <subfield code="c">kartoniert : EUR 22.80 (DE)</subfield>
+    <subfield code="9">978-3-96848-089-3</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT030130043</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DE-Bi10</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-Bi10</subfield>
+    <subfield code="d">1116</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DE</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2=" ">
+    <subfield code="a">370</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">24.03</subfield>
+    <subfield code="2">bkl</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">DG 9440</subfield>
+    <subfield code="2">rvk</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">AP 67400</subfield>
+    <subfield code="2">rvk</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Pfeiffer, Malte</subfield>
+    <subfield code="d">1982-</subfield>
+    <subfield code="0">(DE-588)13748058X</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/13748058X</subfield>
+    <subfield code="0">http://viaf.org/viaf/81666074</subfield>
+    <subfield code="B">GND-13748058X</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Feldforschung in der Theaterarbeit mit Jugendlichen</subfield>
+    <subfield code="b">Bildungsprozesse und Praxisansätze zwischen Ethnografie und Theaterpädagogik</subfield>
+    <subfield code="c">Malte Pfeiffer</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">München</subfield>
+    <subfield code="b">Kopaed</subfield>
+    <subfield code="c">[2023]</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="4">
+    <subfield code="c">© 2023</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">272 Seiten</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Kulturelle Bildung</subfield>
+    <subfield code="v">70</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="0">
+    <subfield code="a">Jugend</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4028859-6</subfield>
+    <subfield code="B">GND-040288595</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="1">
+    <subfield code="a">Theaterarbeit</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4278709-9</subfield>
+    <subfield code="B">GND-042787092</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="2">
+    <subfield code="a">Theaterpädagogik</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4126991-3</subfield>
+    <subfield code="B">GND-041269918</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="3">
+    <subfield code="a">Feldforschung</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4016674-0</subfield>
+    <subfield code="B">GND-040166740</subfield>
+  </datafield>
+  <datafield tag="965" ind1=" " ind2=" ">
+    <subfield code="u">https://digitale-objekte.hbz-nrw.de/storage2/2023/11/09/file_9/9459491.pdf</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1390627981</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-627)1850482373</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)KXP1850482373</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">su||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="i">
+    <subfield code="I">marc-FMT via MAB2MARC</subfield>
+    <subfield code="F">FMT</subfield>
+    <subfield code="A">BK</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|zur||||||17</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Kulturelle Bildung</subfield>
+    <subfield code="w">(DE-605)HT014892702</subfield>
+    <subfield code="v">70</subfield>
+    <subfield code="9">O:1</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="m">B:DE-101</subfield>
+    <subfield code="q">application/pdf</subfield>
+    <subfield code="u">https://digitale-objekte.hbz-nrw.de/storage2/2023/11/09/file_9/9459491.pdf</subfield>
+    <subfield code="3">Inhaltsverzeichnis</subfield>
+    <subfield code="9">O:PKN</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">kopaed verlagsgmbh</subfield>
+    <subfield code="0">(DE-588)1064927602</subfield>
+    <subfield code="4">pbl</subfield>
+    <subfield code="0">https://d-nb.info/gnd/1064927602</subfield>
+    <subfield code="0">http://viaf.org/viaf/313282151</subfield>
+    <subfield code="B">GND-1064927602</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">Universität Hamburg</subfield>
+    <subfield code="0">(DE-588)35534-3</subfield>
+    <subfield code="4">pbl</subfield>
+    <subfield code="0">https://d-nb.info/gnd/000355348</subfield>
+    <subfield code="0">http://viaf.org/viaf/133411557</subfield>
+    <subfield code="B">GND-000355348</subfield>
+  </datafield>
+  <datafield tag="751" ind1=" " ind2=" ">
+    <subfield code="a">Hamburg</subfield>
+    <subfield code="0">(DE-588)4023118-5</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="4">uvp</subfield>
+    <subfield code="0">https://d-nb.info/gnd/040231186</subfield>
+    <subfield code="B">GND-040231186</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2=" ">
+    <subfield code="i">Erscheint auch als</subfield>
+    <subfield code="n">Online-Ausgabe</subfield>
+    <subfield code="c">eISBN</subfield>
+    <subfield code="z">9783968486895</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Hochschulschrift</subfield>
+    <subfield code="0">(DE-588)4113937-9</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Literaturverzeichnis: Seite 255-271</subfield>
+  </datafield>
+  <datafield tag="502" ind1=" " ind2=" ">
+    <subfield code="b">Dissertation</subfield>
+    <subfield code="c">Universität Hamburg</subfield>
+    <subfield code="d">2018</subfield>
+  </datafield>
+  <datafield tag="520" ind1="3" ind2=" ">
+    <subfield code="a">Ethnografie und Kulturelle Bildung, Feldforschung und Theater - das sind nicht unbedingt Sphären, die für gewöhnlich zusammengedacht werden. Kann das aktive Forschen in einem sozialen Feld wie z.B. auf einem Bauernhof, in einer Fabrik oder Fußgängerzone einen Probenprozess bereichern? Vor dem Hintergrund dieser Frage richtet sich dieses Buch an Menschen, die Theater in pädagogischen Zusammenhängen betreiben oder theoretisch betrachten. Es lädt dazu ein, über ein Zusammenspiel dieser scheinbar unterschiedlichen Bezugsrahmen und Ansätze nachzudenken und damit praktisch zu experimentieren. Denn - so die Kernthese, die das Buch im Kontext entwicklungsorientierter Bildungsforschung entfaltet: Ein didaktischer Ansatz, der Feldforschung und damit die Realität Sozialer Felder zur Entwicklung von szenischem Material in Probenprozessen des Theaters nutzt, besitzt nicht nur interessante ästhetische Qualitäten, sondern bahnt in besonderer Weise zentrale Momente ästhetischer Bildung an. Auf der Basis einer theoretischen Auseinandersetzung mit ethnografischen Verfahren, künstlerischer Forschung und Ästhetischer Bildung, sowie der Beobachtung eines feldforschungsorientierten Probenprozesses des Theater- und Performancekollektivs Frl. Wunder AG werden bildungstheoretische und ästhetische Parameter einer entsprechenden theaterpädagogischen Praxis mit Jugendlichen abgesteckt. Es entstehen nicht nur theoretische und didaktische Erkenntnisse über ein mögliches Zusammenspiel von Theaterpädagogik und ethnografischer Forschung, sondern auch ein theoretisch und empirisch fundierter Entwurf mit konkreten Aufgabenstellungen für die Probenarbeit.</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99372715530306441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_FDO</subfield>
+    <subfield code="i">991005003304906451</subfield>
+    <subfield code="n">Fachhochschule Dortmund</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_HBI</subfield>
+    <subfield code="i">991005528632806450</subfield>
+    <subfield code="n">Hochschule Bielefeld</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_HSK</subfield>
+    <subfield code="i">991000339799508978</subfield>
+    <subfield code="n">Hochschule Koblenz - RheinAhrCampus</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_HSN</subfield>
+    <subfield code="i">991009033308508056</subfield>
+    <subfield code="n">Hochschule Niederrhein</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="i">991055684047806476</subfield>
+    <subfield code="n">Universität Köln</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="i">9925119866306463</subfield>
+    <subfield code="n">Universitätsbibliothek Paderborn</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">OTHER</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="h">20240129092043.0</subfield>
+    <subfield code="l">82</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2025-07-27 21:55:31 Europe/Berlin</subfield>
+    <subfield code="g">99372715530306441</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">1011235######49HBZ_HBI</subfield>
+    <subfield code="b">2023-08-02 09:37:29 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">EFS</subfield>
+    <subfield code="c">EFS_Haupt</subfield>
+    <subfield code="h">KMT 186</subfield>
+    <subfield code="8">2259609130006451</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-12-20 09:56:20</subfield>
+    <subfield code="8">2259609130006451</subfield>
+    <subfield code="b">2023-12-14 12:20:39</subfield>
+    <subfield code="M">49HBZ_FDO</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">Acquisition (PO line POL-2023-2496)</subfield>
+    <subfield code="c">FDO00201915916</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">2259609130006451</subfield>
+    <subfield code="x">EFS_Haupt</subfield>
+    <subfield code="v">EFS_Haupt</subfield>
+    <subfield code="p">ZZZ</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2023-12-20 12:05:57 Europe/Berlin</subfield>
+    <subfield code="Y">2025-07-11 17:01:53 Europe/Berlin</subfield>
+    <subfield code="n">KMT 186</subfield>
+    <subfield code="z">Lutz-Scheurle</subfield>
+    <subfield code="M">49HBZ_FDO</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">Acquisition (PO line POL-2023-2496)</subfield>
+    <subfield code="b">91070130</subfield>
+    <subfield code="a">2359609120006451</subfield>
+    <subfield code="c">KMT 186</subfield>
+    <subfield code="S">POL-2023-2496</subfield>
+    <subfield code="B">202308/548</subfield>
+    <subfield code="D">2023-12-20 11:05:57</subfield>
+    <subfield code="W">2023-12-14 13:20:39 Europe/Berlin</subfield>
+    <subfield code="u">EFS</subfield>
+    <subfield code="w">EFS</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">40</subfield>
+    <subfield code="c">CB_FreiE-1</subfield>
+    <subfield code="h">KMT Pfei</subfield>
+    <subfield code="8">2229778800006450</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-09-26 10:24:41</subfield>
+    <subfield code="8">2229778800006450</subfield>
+    <subfield code="b">2023-08-02 07:38:21</subfield>
+    <subfield code="M">49HBZ_HBI</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">Acquisition (PO line HBI-23-2690)</subfield>
+    <subfield code="c">1005689</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">2229778800006450</subfield>
+    <subfield code="x">CB_FreiE-1</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">CB_FreiE-1</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2023-09-14 16:12:17 Europe/Berlin</subfield>
+    <subfield code="Y">2024-11-05 11:07:36 Europe/Berlin</subfield>
+    <subfield code="M">49HBZ_HBI</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">Acquisition (PO line HBI-23-2690)</subfield>
+    <subfield code="b">232533</subfield>
+    <subfield code="a">2329778790006450</subfield>
+    <subfield code="c">KMT Pfei</subfield>
+    <subfield code="S">HBI-23-2690</subfield>
+    <subfield code="W">2023-08-02 09:38:21 Europe/Berlin</subfield>
+    <subfield code="u">40</subfield>
+    <subfield code="w">40</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">RMC</subfield>
+    <subfield code="c">BIB</subfield>
+    <subfield code="h">Pä 11 Pfe</subfield>
+    <subfield code="8">2225194430008978</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2024-09-19 07:11:31</subfield>
+    <subfield code="8">2225194430008978</subfield>
+    <subfield code="M">49HBZ_HSK</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">2225194430008978</subfield>
+    <subfield code="x">BIB</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">BIB</subfield>
+    <subfield code="p">itempolicy_FH</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2024-09-18 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2024-09-19 09:12:14 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="M">49HBZ_HSK</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="L">ClassificationNo: 13 | SISIS-Magazindrucker: 0 | HBZ01: HT030130043 | Keine Beilagen: 1</subfield>
+    <subfield code="b">11257493</subfield>
+    <subfield code="O">SISIS-Ausleihzähler vorletztes Migrationsjahr: 0 | SISIS-Vormerkzähler Migrationsjahr: 0 | SISIS-Buchdaten-Aufnahmedatum: 2023-12-11</subfield>
+    <subfield code="N">Fernleihkonditionen: 0 | Sigel: 987 | Klassifikation: 13 | Altersbegrenzung: 0 | SISIS-Ausleihzähler Migrationsjahr: 0 | SISIS-Ausleihzähler Vor-Migrationsjahr: 0</subfield>
+    <subfield code="a">2325194420008978</subfield>
+    <subfield code="c">Pä 11 Pfe</subfield>
+    <subfield code="B">23-1848</subfield>
+    <subfield code="W">2024-09-19 09:11:31 Europe/Berlin</subfield>
+    <subfield code="u">RMC</subfield>
+    <subfield code="w">RMC</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">MG</subfield>
+    <subfield code="c">MG_Public</subfield>
+    <subfield code="h">Sdo Pfei</subfield>
+    <subfield code="8">2247604310008056</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-08-14 11:14:50</subfield>
+    <subfield code="8">2247604310008056</subfield>
+    <subfield code="b">2023-07-25 14:40:35</subfield>
+    <subfield code="M">49HBZ_HSN</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="c">03000000903</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">2247604310008056</subfield>
+    <subfield code="x">MG_Public</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">MG_Public</subfield>
+    <subfield code="p">ZZZ</subfield>
+    <subfield code="X">03000000065</subfield>
+    <subfield code="U">2023-08-09 13:18:31 Europe/Berlin</subfield>
+    <subfield code="Y">2025-04-08 08:34:00 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">Sdo Pfei</subfield>
+    <subfield code="G">1</subfield>
+    <subfield code="M">49HBZ_HSN</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="L">ClassificationNo: 0 | SISIS-Magazindrucker: 0 | Keine Beilagen: 1</subfield>
+    <subfield code="b">100000044578</subfield>
+    <subfield code="O">SISIS-Ausleihzähler vorletztes Migrationsjahr: 0 | SISIS-Vormerkzähler Migrationsjahr: 0 | SISIS-Buchdaten-Aufnahmedatum: 2023-06-23</subfield>
+    <subfield code="N">Fernleihkonditionen: 0 | Sigel: 829 | Klassifikation: 0 | Altersbegrenzung: 0 | SISIS-Ausleihzähler Migrationsjahr: 0 | SISIS-Ausleihzähler Vor-Migrationsjahr: 0</subfield>
+    <subfield code="a">2347604300008056</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="c">Sdo Pfei</subfield>
+    <subfield code="S">HNBIB-42684</subfield>
+    <subfield code="B">100000044578</subfield>
+    <subfield code="D">2023-08-14 11:18:31</subfield>
+    <subfield code="W">2023-07-25 16:40:35 Europe/Berlin</subfield>
+    <subfield code="u">MG</subfield>
+    <subfield code="w">MG</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">38-319</subfield>
+    <subfield code="c">38-319-KUN</subfield>
+    <subfield code="8">22357556830006476</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2024-01-31 10:39:47</subfield>
+    <subfield code="8">22357556830006476</subfield>
+    <subfield code="b">2024-01-29 08:20:54</subfield>
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">Acquisition (PO line POL-4879)</subfield>
+    <subfield code="c">38Medardt</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22357556830006476</subfield>
+    <subfield code="x">38-319-KUN</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">38-319-KUN</subfield>
+    <subfield code="p">X</subfield>
+    <subfield code="X">38Medardt</subfield>
+    <subfield code="U">2024-01-29 11:39:46 Europe/Berlin</subfield>
+    <subfield code="Y">2024-01-31 11:47:56 Europe/Berlin</subfield>
+    <subfield code="n">HFB/319/Fb/PFE</subfield>
+    <subfield code="G">1</subfield>
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">Acquisition (PO line POL-4879)</subfield>
+    <subfield code="b">307/001171</subfield>
+    <subfield code="a">23357556820006476</subfield>
+    <subfield code="S">POL-4879</subfield>
+    <subfield code="W">2024-01-29 09:20:54 Europe/Berlin</subfield>
+    <subfield code="u">38-319</subfield>
+    <subfield code="w">38-319</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">P0001</subfield>
+    <subfield code="c">11</subfield>
+    <subfield code="8">22193729140006463</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-10-31 10:40:04</subfield>
+    <subfield code="8">22193729140006463</subfield>
+    <subfield code="b">2023-08-10 12:52:00</subfield>
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">Acquisition (PO line POL-23-9538)</subfield>
+    <subfield code="c">j.boldt</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22193729140006463</subfield>
+    <subfield code="x">11</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">11</subfield>
+    <subfield code="p">20</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2023-09-15 11:40:02 Europe/Berlin</subfield>
+    <subfield code="Y">2025-03-13 09:51:56 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">KMT2224</subfield>
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">Acquisition (PO line POL-23-9538)</subfield>
+    <subfield code="b">2524045</subfield>
+    <subfield code="a">23193729130006463</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="S">POL-23-9538</subfield>
+    <subfield code="B">23/7206</subfield>
+    <subfield code="D">2023-09-15 09:40:00</subfield>
+    <subfield code="W">2023-08-10 14:52:00 Europe/Berlin</subfield>
+    <subfield code="u">P0001</subfield>
+    <subfield code="w">P0001</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4278709-9</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4278709-9</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-042787092</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Jugend</subfield>
+    <subfield code="g">12-20 Jahre</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040288595</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Jugendalter</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040288595</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Jugendlicher</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040288595</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Teenager</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040288595</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">http://d-nb.info/gnd/4028859-6</subfield>
+    <subfield code="2">uri</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040288595</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">13748058X</subfield>
+    <subfield code="0">http://d-nb.info/gnd/13748058X</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-13748058X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0009-0001-2171-6337</subfield>
+    <subfield code="9">v:Herkunft: mm001</subfield>
+    <subfield code="2">orcid</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-13748058X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4023118-5</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4023118-5</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">Q1055</subfield>
+    <subfield code="2">wikidata</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2911297</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">relation/62782</subfield>
+    <subfield code="2">opensm</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Großhamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hamburgischer Staat</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Groß-Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hampuri</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hamborg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Wolne i Hanzeatyckie Miasto Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hanbao</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Freistaat Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">FHH</subfield>
+    <subfield code="4">abku</subfield>
+    <subfield code="i">Abkuerzung</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Gamburg</subfield>
+    <subfield code="g">Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hamburgh</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Bundesstaat Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Kayserliche Freye Reichs-Stadt Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Kaiserliche Freie Reichsstadt Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hamburgisches Staatsgebiet</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">HH</subfield>
+    <subfield code="4">abku</subfield>
+    <subfield code="i">Abkuerzung</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Freie und Hansestadt Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hansestadt Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Free and Hanseatic City of Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Ville Libre et Hanséatique de Hambourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hambourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Amburgo</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hamburgo</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Freie Hansestadt Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hamburgum</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hammonia</subfield>
+    <subfield code="g">Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Hammipolis</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Augusta Gambriviorum</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040231186</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Uni Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Uni HH</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">University of Hamburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Hamburg University</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Hamburgische Universität</subfield>
+    <subfield code="4">nauv</subfield>
+    <subfield code="i">Unveraenderte Form</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Universidad de Hamburgo</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Université de Hambourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">UH</subfield>
+    <subfield code="4">abku</subfield>
+    <subfield code="i">Abkuerzung</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">UHH</subfield>
+    <subfield code="4">abku</subfield>
+    <subfield code="i">Abkuerzung</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">35534-3</subfield>
+    <subfield code="0">http://d-nb.info/gnd/35534-3</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0000 0001 2287 2617</subfield>
+    <subfield code="2">isni</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">Q156725</subfield>
+    <subfield code="2">wikidata</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">00g30e956</subfield>
+    <subfield code="2">ror</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000355348</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">kopaed verlagsGmbH</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1064927602</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">kopaed Verlags-GmbH</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1064927602</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">kopaed</subfield>
+    <subfield code="4">nauv</subfield>
+    <subfield code="i">Unveraenderte Form</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1064927602</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Kopaed</subfield>
+    <subfield code="g">Firma</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1064927602</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">1064927602</subfield>
+    <subfield code="0">http://d-nb.info/gnd/1064927602</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1064927602</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Theaterdidaktik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-041269918</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Dramapädagogik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-041269918</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4126991-3</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4126991-3</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-041269918</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Feldarbeit</subfield>
+    <subfield code="g">Empirische Sozialforschung</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040166740</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Feldstudie</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040166740</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Field-research</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040166740</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Field-work</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040166740</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4016674-0</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4016674-0</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040166740</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 20 },
+			{ "title:der", /*->*/ 21 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 4 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 4 },
@@ -69,8 +69,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.startDate:1993", /*->*/ 4 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "publication.location:Berlin AND publication.startDate:[1992 TO 2017]", /*->*/ 5 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 155 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 176 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 156 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 177 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
In #1803 (eab045c), the temporary callnumber was introduced as the preferred callnumber (as per the decision by FEx Daten). But some local workflows keep the temporary callnumber even when the item is removed from the temporary location and transferred back to the permanent location, which has been reported in `hbz-Support-Ticket#2346067`. Hence, the temporary callnumber must not be considered in those cases.

In Alma, the transfer is recorded through a simple switch ("Item is in temporary location" = Yes/No). But this information is not transported in the Alma Publishing.