### PR TITLE
Support non-GND subjects in `subject` queries (RPB-282)

### DIFF
--- a/web/app/views/rss.scala.html
+++ b/web/app/views/rss.scala.html
@@ -12,12 +12,17 @@
             @for((doc, i) <- hits;
                 ids <- (doc \ "almaMmsId").asOpt[JsValue].orElse((doc \ "hbzId").asOpt[JsValue]).orElse((doc \ "rpbId").asOpt[JsValue]);
                 id = ids.asOpt[Seq[JsValue]].getOrElse(Seq(ids))(0).as[String];
-                dateCreated = ((doc \ "describedBy" \ "dateCreated").asOpt[String].getOrElse((doc \ "describedBy" \ "resultOf"  \ "object" \ "dateCreated").as[String]))
+                describedBy = (doc \ "describedBy").asOpt[JsValue]
             ) {
                 <item>
                     <title>@((doc \ "title").asOpt[String].getOrElse(id))</title>
                     <link>@controllers.resources.Application.CONFIG.getString("host") @resources.routes.Application.resource(id, null)</link>
-                    <pubDate>@controllers.resources.Application.RSS_DATE_FORMAT.format(controllers.resources.Application.LOBID_DATE_FORMAT.parse(dateCreated))</pubDate>
+                    @describedBy.map(description =>
+                        <pubDate>
+                            @controllers.resources.Application.RSS_DATE_FORMAT.format(controllers.resources.Application.LOBID_DATE_FORMAT.parse(
+                            ((description \ "dateCreated").asOpt[String].getOrElse((description \ "resultOf"  \ "object" \ "dateCreated").as[String]))))
+                        </pubDate>
+                    )
                     <description><![CDATA[@tags.result_doc(doc)]]></description>
                 </item>
             }

--- a/web/test/resources/rpb/a4329464.json
+++ b/web/test/resources/rpb/a4329464.json
@@ -1,0 +1,106 @@
+{
+  "extent": "Illustrationen",
+  "rpbId": "a4329464",
+  "subject": [
+    {
+      "id": "http://purl.org/lobid/rpb#n736050",
+      "label": "Sportverein",
+      "source": {
+        "id": "http://purl.org/lobid/rpb",
+        "label": "Systematik der Rheinland-Pfälzischen Bibliographie"
+      },
+      "type": [
+        "Concept"
+      ]
+    },
+    {
+      "componentList": [
+        {
+          "id": "http://rpb.lobid.org/sw/n920756",
+          "label": "Eisstockclub Lauterecken ",
+          "source": {
+            "id": "http://rpb.lobid.org/sw",
+            "label": "RPB-Sachsystematik"
+          }
+        },
+        {
+          "id": "Geschichte 1981-2024",
+          "label": "Geschichte 1981-2024",
+          "source": {
+            "id": "https://d-nb.info/gnd/7749153-1",
+            "label": "Gemeinsame Normdatei (GND)"
+          }
+        }
+      ],
+      "label": "Eisstockclub Lauterecken  | Geschichte 1981-2024",
+      "type": [
+        "ComplexSubject"
+      ]
+    }
+  ],
+  "responsibilityStatement": [
+    "von Axel Stenzhorn"
+  ],
+  "inCollection": [
+    {
+      "id": "http://lobid.org/resources/HT013494180#!",
+      "label": "Rheinland-Pfälzische Bibliographie",
+      "type": [
+        "Collection"
+      ]
+    }
+  ],
+  "type": [
+    "BibliographicResource",
+    "Article"
+  ],
+  "title": "Der Eisstockclub Lauterecken - einziger Verein dieser Art in Rheinland-Pfalz",
+  "@context": "http://lobid.org/resources/context.jsonld",
+  "contribution": [
+    {
+      "agent": {
+        "id": "Stenzhorn, Axel",
+        "label": "Stenzhorn, Axel",
+        "type": [
+          "Person"
+        ]
+      },
+      "role": {
+        "id": "http://id.loc.gov/vocabulary/relators/aut",
+        "label": "Verfasser/in"
+      },
+      "type": [
+        "Contribution"
+      ]
+    }
+  ],
+  "publication": [
+    {
+      "type": [
+        "PublicationEvent"
+      ],
+      "startDate": "2024"
+    }
+  ],
+  "containedIn": [
+    {
+      "id": "http://lobid.org/resources/990054874190206441#!",
+      "label": "Westrichkalender ..."
+    }
+  ],
+  "id": "https://lobid.org/resources/a4329464",
+  "bibliographicCitation": "Westrichkalender ... 68 (2025)   Seite 177-180",
+  "spatial": [
+    {
+      "id": "https://rpb.lobid.org/spatial#n33608058",
+      "label": "Lauterecken, Stadt",
+      "source": {
+        "id": "https://rpb.lobid.org/spatial",
+        "label": "RPB-Raumsystematik"
+      },
+      "type": [
+        "Concept"
+      ]
+    }
+  ]
+}

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 21 },
+			{ "title:der", /*->*/ 22 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 4 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 4 },
@@ -52,6 +52,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "subject.componentList.label.unstemmed:Düsseldorfer", /*->*/ 0 },
 			{ "subject.componentList.id:\"https\\://d-nb.info/gnd/4042570-8\"", /*->*/ 2 },
 			{ "subject.componentList.gndIdentifier:4042570-8", /*->*/ 2 },
+			{ "subject=Eisstockclub Lauterecken", /*->*/ 1 },
+			{ "subject=http://rpb.lobid.org/sw/n920756", /*->*/ 1 },
 			{ "(title:Westfalen OR title:Münsterland) AND NOT contribution.agent.id:\"https\\://d-nb.info/gnd/2019209-5\"", /*->*/ 8 },
 			{ "subject.componentList.label:Westfalen", /*->*/ 11 },
 			{ "subject.componentList.label:Westfälen", /*->*/ 11 },
@@ -164,9 +166,18 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 		for (Object[] testCase : objects) {
 			String s = (String) testCase[0];
 			Integer hits = (Integer) testCase[1];
-			result.add(new Object[] { new Queries.Builder().q(s), /*->*/ hits });
+			result.add(new Object[] { queryFor(s), /*->*/ hits });
 		}
 		return result;
+	}
+
+	private static Queries.Builder queryFor(String s) {
+		String[] queryParamNameAndValue = s.split("=");
+		Queries.Builder queryBuilder = new Queries.Builder();
+		return queryParamNameAndValue.length == 2
+				&& queryParamNameAndValue[0].equals("subject")
+						? queryBuilder.subject(queryParamNameAndValue[1])
+						: queryBuilder.q(queryParamNameAndValue[0]);
 	}
 
 	private int expectedResultCount;

--- a/web/test/tests/LocalIndexSetup.java
+++ b/web/test/tests/LocalIndexSetup.java
@@ -19,11 +19,12 @@ public abstract class LocalIndexSetup {
 	private static LocalIndex index;
 	private static final String TEST_CONFIG =
 		"../src/main/resources/alma/index-config.json";
-	private static final String TEST_DATA = "../src/test/resources/alma-fix";
+	private static final String ALMA_TEST_DATA = "../src/test/resources/alma-fix";
+	private static final String RPB_TEST_DATA = "test/resources/rpb";
 
 	@BeforeClass
 	public static void setup() {
-		index = new LocalIndex(TEST_CONFIG,TEST_DATA,null);
+		index = new LocalIndex(TEST_CONFIG, ALMA_TEST_DATA, RPB_TEST_DATA);
 		Search.elasticsearchClient = index.getNode().client();
 	}
 


### PR DESCRIPTION
- Support tests of `subject` query param in IndexIntegrationTest
- Add RPD test data using non-GND subject in subject.componentList
- Handle missing `describedBy` field of RPB data in rss.scala.html
- Support non-GND subjects in Queries.SubjectQuery

Required for https://jira.hbz-nrw.de/browse/RPB-282