### PR TITLE
Add search field `q.provenance`.

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -480,6 +480,50 @@
                 }
               }
             },
+            "custodialHistory": {
+              "properties": {
+                "contribution": {
+                  "properties": {
+                    "agent": {
+                      "properties": {
+                        "id": {
+                          "type": "keyword",
+                          "index": false,
+                          "copy_to": [
+                            "q.provenance"
+                          ]
+                        },
+                        "label": {
+                          "type": "text",
+                          "index": false,
+                          "copy_to": [
+                            "q.provenance"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "note": {
+                  "type": "text",
+                  "index": false,
+                  "copy_to": [
+                    "q.provenance"
+                  ]
+                },
+                "proof": {
+                  "properties": {
+                    "label": {
+                      "type": "text",
+                      "index": false,
+                      "copy_to": [
+                        "q.provenance"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
             "note": {
               "type": "text",
               "index": false,
@@ -488,7 +532,10 @@
               ]
             },
             "callNumber": {
-              "type": "keyword"
+              "type": "keyword",
+              "copy_to": [
+                "q.provenance"
+              ]
             },
             "serialNumber": {
               "type": "keyword"
@@ -502,7 +549,7 @@
             "inCollection": {
               "properties": {
                 "id": {
-                   "type": "keyword"
+                  "type": "keyword"
                 },
                 "label": {
                   "type": "text",
@@ -1181,6 +1228,11 @@
             },
             "date": {
               "type": "short"
+            },
+            "provenance": {
+              "type": "text",
+              "analyzer": "digibib_default",
+              "search_analyzer": "digibib_search"
             },
             "publisher": {
               "type": "text",

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -103,6 +103,11 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "\"Reader friendly\"", /*->*/ 1},
 			// all q tests are related to DigiBib
 			{ "q.date:2000", /*->*/ 4 },
+			{ "q.provenance:\"https\\://d-nb.info/gnd/131844024\"", /*->*/ 1 },
+			{ "q.provenance:hoboken", /*->*/ 1 },
+			{ "q.provenance:stempel", /*->*/ 2 },
+			{ "q.provenance:regi*", /*->*/ 2 },
+			{ "q.provenance:\"Sk 5130\"", /*->*/ 1 },
 			{ "q.publisher:Aachen", /*->*/ 2 },
 			{ "q.publisher:Aachen\\-Eilendorf", /*->*/ 1 },
 			{ "q.publisher:Eilendörf", /*->*/ 1 },


### PR DESCRIPTION
Complements #2232 by adding a search field for the relevant data (see #2199).

Feel free to drop the `index: false` directives for fields that should be searchable in lobid-resources as well.