### PR TITLE
Make web app install steps more explicit #2271

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Build the web application:
 See the `.github/workflows/build.yml` file for details on the CI config
 used by Github Actions.
 
+To run the tests:
+
+- `cd web`
+- `sbt test`
+
 ## Eclipse setup
 
 Replace `test` with other Play commands, e.g.
@@ -62,12 +67,6 @@ in Eclipse: `Preferences` \> `General` \> `Workspace` \>
 
 Copy `web/conf/resources.conf_template` to `conf/resources.conf` and
 configure that file to your need.
-
-Use `"start 8000"` to run in production background mode on port 8000
-(hit Ctrl+D to exit logs). To restart a production instance running in
-the background, you can use the included `restart.sh` script (configured
-to use port 8000). For more information, see the [Play
-documentation](https://playframework.com/documentation/2.4.x/Home).
 
 ## Example of getting the data
 

--- a/web/conf/resources.conf_template
+++ b/web/conf/resources.conf_template
@@ -39,7 +39,6 @@ index = {
 	cluster = {
 		name = "weywot"
 		hosts = ["weywot14.hbz-nrw.de", "weywot15.hbz-nrw.de"]
-		#hosts = ["10.9.0.13", "10.9.0.14"]
 		#hosts = [] # use local index created from local test data
 		port = 9300
 		hosts9300 = "weywot13"


### PR DESCRIPTION
Resolves #2271

I adjusted the README so that the steps are more explicit on how to run the web app.

PS: I only wanted to assign @fsteeg somehow I cannot unassign @dr0i 