### PR TITLE
Use slf4j-reload4j instead #2305

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,11 +205,6 @@
             <artifactId>logback-core</artifactId>
             <version>${logback.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
-            <version>1.7.36</version>
-        </dependency>
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
I tried it myself and it seemed to work. @dr0i could you have a look?

Resolve #2305

The dependency was causing an error when testing the current metafacture master as snapshot.