### PR TITLE
Drop callNumber from `q.provenance` search field.

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -543,10 +543,7 @@
               ]
             },
             "callNumber": {
-              "type": "keyword",
-              "copy_to": [
-                "q.provenance"
-              ]
+              "type": "keyword"
             },
             "serialNumber": {
               "type": "keyword"

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -107,7 +107,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "q.provenance:hoboken", /*->*/ 1 },
 			{ "q.provenance:stempel", /*->*/ 2 },
 			{ "q.provenance:regi*", /*->*/ 2 },
-			{ "q.provenance:\"Sk 5130\"", /*->*/ 1 },
+			{ "q.provenance:\"Sk 5130\"", /*->*/ 0 },
 			{ "q.publisher:Aachen", /*->*/ 2 },
 			{ "q.publisher:Aachen\\-Eilendorf", /*->*/ 1 },
 			{ "q.publisher:Eilendörf", /*->*/ 1 },


### PR DESCRIPTION
Resolves #2312.