### PR TITLE
Detangle multiple reproductions in 533 #2011

### DIFF
--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -303,23 +303,46 @@ end
 # 533 - Reproduction Note (R)
 
 do list(path:"533  ", "var": "$i")
-  add_hash( "publication[].$append")
-  add_array("publication[].$last.type[]","SecondaryPublicationEvent")
-  add_array("publication[].$last.location[]")
-  do list(path:"$i.b","var":"$j")
-    copy_field("$j", "publication[].$last.location[].$append")
-  end
-  add_array("publication[].$last.description[]")
-  copy_field("$i.a", "publication[].$last.description[].$append")
-  add_array("publication[].$last.publishedBy[]")
-  copy_field("$i.c", "publication[].$last.publishedBy[].$append")
-  do list(path: "$i.d", "var":"$j")
-    call_macro("publicationDateCleaner",date:"$j")
-    unless exists("publication[].$last.startDate")
-      call_macro("publicationStartDate",date:"$j",dateTarget:"publication[].$last.startDate")
+  unless is_array("$i.c") # Check if multiple SecondaryPublication are combined in 533
+    add_hash( "publication[].$append")
+    add_array("publication[].$last.type[]","SecondaryPublicationEvent")
+    add_array("publication[].$last.location[]")
+    do list(path:"$i.b","var":"$j")
+      copy_field("$j", "publication[].$last.location[].$append")
     end
-    unless exists("publication[].$last.endDate")
-      call_macro("publicationEndDate",date:"$j",dateTarget:"publication[].$last.endDate")
+    add_array("publication[].$last.description[]")
+    copy_field("$i.a", "publication[].$last.description[].$append")
+    add_array("publication[].$last.publishedBy[]")
+    copy_field("$i.c", "publication[].$last.publishedBy[].$append")
+    do list(path: "$i.d", "var":"$j")
+      call_macro("publicationDateCleaner",date:"$j")
+      unless exists("publication[].$last.startDate")
+        call_macro("publicationStartDate",date:"$j",dateTarget:"publication[].$last.startDate")
+      end
+      unless exists("publication[].$last.endDate")
+        call_macro("publicationEndDate",date:"$j",dateTarget:"publication[].$last.endDate")
+      end
+    end
+  end
+  if is_array("$i.c")  # Check if multiple SecondaryPublication are combined in 533
+    do list_as($LOCATION:"$i.b",$PUBLISHER:"$i.c")
+      add_hash( "publication[].$append")
+      add_array("publication[].$last.type[]","SecondaryPublicationEvent")
+      add_array("publication[].$last.location[]")
+      copy_field("$LOCATION", "publication[].$last.location[].$append")
+      add_array("publication[].$last.description[]")
+      copy_field("$i.a", "publication[].$last.description[].$append")
+      add_array("publication[].$last.publishedBy[]")
+      copy_field("$PUBLISHER", "publication[].$last.publishedBy[].$append")
+      do list(path: "$i.d", "var":"$j")
+        call_macro("publicationDateCleaner",date:"$j")
+        unless exists("publication[].$last.startDate")
+          call_macro("publicationStartDate",date:"$j",dateTarget:"publication[].$last.startDate")
+        end
+        unless exists("publication[].$last.endDate")
+          call_macro("publicationEndDate",date:"$j",dateTarget:"publication[].$last.endDate")
+        end
+      end
     end
   end
 end

--- a/src/test/resources/alma-fix/990054089950206441.json
+++ b/src/test/resources/alma-fix/990054089950206441.json
@@ -48,9 +48,29 @@
     "publishedBy" : [ "[Verlag nicht ermittelbar]" ]
   }, {
     "type" : [ "SecondaryPublicationEvent" ],
-    "location" : [ "Hamburg", "Wohltorf", "Berlin", "Woodbridge, Conn.", "Dortmund" ],
+    "location" : [ "Hamburg" ],
     "description" : [ "Mikrofiche-Ausg." ],
-    "publishedBy" : [ "Alphacom", "IOS-Echo-GmbH", "ADN", "Primary Source Media", "Mikrofilmarchiv der Deutschsprachigen Presse e. V., MFA" ]
+    "publishedBy" : [ "Alphacom" ]
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "location" : [ "Wohltorf" ],
+    "description" : [ "Mikrofiche-Ausg." ],
+    "publishedBy" : [ "IOS-Echo-GmbH" ]
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "location" : [ "Berlin" ],
+    "description" : [ "Mikrofiche-Ausg." ],
+    "publishedBy" : [ "ADN" ]
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "location" : [ "Woodbridge, Conn." ],
+    "description" : [ "Mikrofiche-Ausg." ],
+    "publishedBy" : [ "Primary Source Media" ]
+  }, {
+    "type" : [ "SecondaryPublicationEvent" ],
+    "location" : [ "Dortmund" ],
+    "description" : [ "Mikrofiche-Ausg." ],
+    "publishedBy" : [ "Mikrofilmarchiv der Deutschsprachigen Presse e. V., MFA" ]
   } ],
   "shortTitle" : [ "Spiegel", "SPILB" ],
   "describedBy" : {


### PR DESCRIPTION
533 mixes multiple secondary publication events in one element. I detangle this with this PR.