### PR TITLE
Fix mapping for PublicationIssue #2330

### DIFF
--- a/src/main/resources/alma/fix/mediumAndType.fix
+++ b/src/main/resources/alma/fix/mediumAndType.fix
@@ -619,7 +619,7 @@ end
 # type: "PublicationIssue"
 
 
-if exists("zdbId")
+if any_contain("isPartOf[].*.hasSuperordinate[].*.id","ZDB")
   if exists("245??.n")
     unless any_contain("245??.n","...")
       add_field("type[].$append", "PublicationIssue")
@@ -628,10 +628,6 @@ if exists("zdbId")
     add_field("type[].$append", "PublicationIssue")
   end
 end
-
-# TODO: HT003176544 transforms but is not PublicationIssue in lobid ALEPH.
-# TODO: Also check if PublicationIssue and Periodical as type are mutual exclusive.
-# TODO: Check if there are other versions of PublicationIssue
 
 
 # type:"ReferenceSource"

--- a/src/test/resources/alma-fix/990054301770206441.json
+++ b/src/test/resources/alma-fix/990054301770206441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/990054301770206441#!",
-  "type" : [ "BibliographicResource", "Periodical", "PublicationIssue" ],
+  "type" : [ "BibliographicResource", "Periodical" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990086740340206441.json
+++ b/src/test/resources/alma-fix/990086740340206441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/990086740340206441#!",
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "PublicationIssue", "Book" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990103899140206441.json
+++ b/src/test/resources/alma-fix/990103899140206441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/990103899140206441#!",
-  "type" : [ "BibliographicResource", "Periodical", "PublicationIssue", "Statistics" ],
+  "type" : [ "BibliographicResource", "Periodical", "Statistics" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990114617880206441.json
+++ b/src/test/resources/alma-fix/990114617880206441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/990114617880206441#!",
-  "type" : [ "BibliographicResource", "Article" ],
+  "type" : [ "BibliographicResource", "PublicationIssue" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990118562160206441.json
+++ b/src/test/resources/alma-fix/990118562160206441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/990118562160206441#!",
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "PublicationIssue", "Book" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/990207856340206441.json
+++ b/src/test/resources/alma-fix/990207856340206441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/990207856340206441#!",
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "PublicationIssue", "Book" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"

--- a/src/test/resources/alma-fix/99370782520706441.json
+++ b/src/test/resources/alma-fix/99370782520706441.json
@@ -1,7 +1,7 @@
 {
   "@context" : "http://lobid.org/resources/context.jsonld",
   "id" : "http://lobid.org/resources/99370782520706441#!",
-  "type" : [ "BibliographicResource", "Book" ],
+  "type" : [ "BibliographicResource", "PublicationIssue", "Book" ],
   "medium" : [ {
     "label" : "Print",
     "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"


### PR DESCRIPTION
The previous mapping was incorrect checking if a resource had a `zdbId` but it should have checked if a resource had a parent with `zdbId`, see: 

https://github.com/hbz/lobid-resources/blob/7f982c13a25f9d6a4ef1a2c81a3749cf1cdaed36/src/main/resources/morph-hbz01-to-lobid.xml#L1829-L1835

This has been an wrong understanding that in MAB the 2. indicator was referring to the superordinate, see: 
https://service-wiki.hbz-nrw.de/spaces/SEM/pages/13238276/Beschreibung+Aleph-MAB-XML-Daten+Format+Inhalte#BeschreibungAlephMABXMLDaten(Format%2BInhalte)-Expandvon%C3%9Cberordnungen

Resolves #2330 