### PR TITLE
Some fixes from JSON Schema Validation and comparisson from old transformations

### DIFF
--- a/src/main/resources/alma/fix/contribution.fix
+++ b/src/main/resources/alma/fix/contribution.fix
@@ -17,56 +17,58 @@ add_array("contribution[]")
 do list(path:"100[01] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
-        add_field("$i.4","cre")
-      elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
-        add_field("$i.4","edt")
-      elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
-        add_field("$i.4","aut")
-      else
-        add_field("$i.4","cre")
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
+          add_field("$i.4","cre")
+        elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
+          add_field("$i.4","edt")
+        elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
+          add_field("$i.4","aut")
+        else
+          add_field("$i.4","cre")
+        end
       end
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+          call_macro("gndPersonCombinedLabel",field:"$i")
+          copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","Person")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          # dateOfBirthAndDeath #will be split on a later stage
+          unless exists("$i.d.1")
+            copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
+          end
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-        call_macro("gndPersonCombinedLabel",field:"$i")
-        copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","Person")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        # dateOfBirthAndDeath #will be split on a later stage
-        unless exists("$i.d.1")
-          copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
-        end
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -79,48 +81,50 @@ end
 do list(path:"700[01] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      add_field("$i.4","ctb")
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        add_field("$i.4","ctb")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+          call_macro("gndPersonCombinedLabel",field:"$i")
+          copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","Person")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          # dateOfBirthAndDeath #will be split on a later stage
+          unless exists("$i.d.1")
+            copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
+          end
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-        call_macro("gndPersonCombinedLabel",field:"$i")
-        copy_field("$i.@combinedLabel","contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","Person")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        # dateOfBirthAndDeath #will be split on a later stage
-        unless exists("$i.d.1")
-          copy_field("$i.d","contribution[].$last.agent.dateOfBirthAndDeath")
-        end
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -135,52 +139,54 @@ end
 do list(path:"110[012] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
-        add_field("$i.4","cre")
-      elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
-        add_field("$i.4","edt")
-      elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
-        add_field("$i.4","aut")
-      else
-        add_field("$i.4","cre")
-      end
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
-            end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
-          end
+  if exists("$i.a")
+                unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        if any_match("type[]","ArchivedWebPage|Miscellaneous|Bibliography|Statistics|Legislation|PublishedScore|Game|Image|Map|Standard")
+          add_field("$i.4","cre")
+        elsif any_match("type[]","Periodical|Collection|Series|Newspaper|Journal|PublicationIssue|EditedVolume|Proceedings|Festschrift|ReferenceSource")
+          add_field("$i.4","edt")
+        elsif any_match("type[]","Book|MultiVolumeBook|Article|Thesis|OfficialPublication|Schoolbook|Biography|Report")
+          add_field("$i.4","aut")
+        else
+          add_field("$i.4","cre")
         end
-        # name
-          call_macro("gndOtherCombinedLabel",field:"$i")
-          copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","CorporateBody")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
+            end
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
+          end
+          # name
+            call_macro("gndOtherCombinedLabel",field:"$i")
+            copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","CorporateBody")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
+        end
       end
     end
   end
@@ -194,44 +200,46 @@ end
 do list(path:"710[012] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    call_macro("rolesFromSubfieldE")
-    unless exists("$i.4")
-      add_field("$i.4","ctb")
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      call_macro("rolesFromSubfieldE")
+      unless exists("$i.4")
+        add_field("$i.4","ctb")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+            call_macro("gndOtherCombinedLabel",field:"$i")
+            copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","CorporateBody")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-          call_macro("gndOtherCombinedLabel",field:"$i")
-          copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","CorporateBody")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end
@@ -245,43 +253,45 @@ end
 do list(path:"111[012] |711[012] ", "var":"$i")
   # in some cases (e.g. 99370763882706441) we have an invalid repeated subfield $a
   # since in the invalid record one cannot untangle the info easily (creates dublicate info and no roles) the fix scipts if the subfield $a is an array.
-  unless exists("$i.a.1")
-    unless exists("$i.4")
-      add_field("$i.4","oth")
-    end
-    do list(path: "$i.4", "var":"$j")
-      if any_match("$j","[A-Za-z]{3}")
-        add_hash("contribution[].$append.agent")
-        do list(path:"$i.0","var":"$k")
-          if all_match("$k", "^\\(DE-588\\).+$")
-        # GND identifier
-            paste("contribution[].$last.agent.gndIdentifier","$k")
-        # GND Identifier id
-            paste("contribution[].$last.agent.id","$k")
-          end
-        # GND idn as variable
-          if exists("$i.B")
-            do list(path: "$i.B","var":"$gnd")
-              unless exists("contribution[].$last.agent.@gndIdn")
-                copy_field("$gnd","contribution[].$last.agent.@gndIdn")
-              end
+  if exists("$i.a")
+    unless exists("$i.a.1")
+      unless exists("$i.4")
+        add_field("$i.4","oth")
+      end
+      do list(path: "$i.4", "var":"$j")
+        if any_match("$j","[A-Za-z]{3}")
+          add_hash("contribution[].$append.agent")
+          do list(path:"$i.0","var":"$k")
+            if all_match("$k", "^\\(DE-588\\).+$")
+          # GND identifier
+              paste("contribution[].$last.agent.gndIdentifier","$k")
+          # GND Identifier id
+              paste("contribution[].$last.agent.id","$k")
             end
-          elsif any_match("$k","^.*DNB\\|(.*)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
-          elsif any_match("$k","^\\(DE-101\\)(.+)$")
-            copy_field("$k", "contribution[].$last.agent.@gndIdn")
-            replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+          # GND idn as variable
+            if exists("$i.B")
+              do list(path: "$i.B","var":"$gnd")
+                unless exists("contribution[].$last.agent.@gndIdn")
+                  copy_field("$gnd","contribution[].$last.agent.@gndIdn")
+                end
+              end
+            elsif any_match("$k","^.*DNB\\|(.*)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^.*DNB\\|(.*)$","GND-$1")
+            elsif any_match("$k","^\\(DE-101\\)(.+)$")
+              copy_field("$k", "contribution[].$last.agent.@gndIdn")
+              replace_all("contribution[].$last.agent.@gndIdn", "^\\(DE-101\\)(.+)$","GND-$1")
+            end
           end
+          # name
+          call_macro("gndEventCombinedLabel",field:"$i")
+          copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
+          # type
+          add_array("contribution[].$last.agent.type[]","ConferenceOrEvent")
+          # role
+          copy_field("$j","contribution[].$last.role.id")
+          call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
         end
-        # name
-        call_macro("gndEventCombinedLabel",field:"$i")
-        copy_field("$i.@combinedLabel", "contribution[].$last.agent.label")
-        # type
-        add_array("contribution[].$last.agent.type[]","ConferenceOrEvent")
-        # role
-        copy_field("$j","contribution[].$last.role.id")
-        call_macro("alternateGraphicRepresentationArrayOfObjects",targetArray:"contribution[]",targetField:".agent",variable:"$i")
       end
     end
   end

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -15,8 +15,8 @@ do list(path: "0247?", "var": "$i")
     elsif any_match("$i.a",".*urn:nbn:de.*")
       replace_all("$i.a","^.*(urn:nbn:de.*)$","$1")
       copy_field("$i.a","urn[].$append")
-    elsif any_match("$i.a",".*doi.*((10\\.(\\d)+/(\\S)+).*)")
-      replace_all("$i.a",".*doi.*(10\\.(\\d)+/(\\S)+).*","$1")
+    elsif any_match("$i.a",".*doi.*((10\\.(\\d){4,9}/(\\S)+).*)")
+      replace_all("$i.a",".*doi.*(10\\.(\\d){4,9}/(\\S)+).*","$1")
       copy_field("$i.a","@doiInUrn")
     end
   end
@@ -102,9 +102,11 @@ add_array("doi[]")
 do list(path:"0247?", "var":"$i")
   if all_equal("$i.2","doi")
     if none_contain("$i.a","http")
-      copy_field("$i.a","doi[].$append")
-    elsif any_match("$i.a",".*doi.*((10\\.(\\d)+/(\\S)+).*)")
-      replace_all("$i.a",".*doi.*(10\\.(\\d)+/(\\S)+).*","$1")
+      if any_match("$i.a","(10\\.(\\d){4,9}/(\\S)+)")
+        copy_field("$i.a","doi[].$append")
+      end
+    elsif any_match("$i.a",".*doi.*((10\\.(\\d){4,9}/(\\S)+).*)")
+      replace_all("$i.a",".*doi.*(10\\.(\\d){4,9}/(\\S)+).*","$1")
       copy_field("$i.a","doi[].$append")
     end
   end
@@ -116,11 +118,11 @@ copy_field("@doiInUrn", "doi[].$append")
 # 856 - Electronic Location and Access (R) - Subfield: $u (R) $3 (NR)
 # 1. Indicator: 4 = HTTP
 do list(path:"856??", "var":"$i")
-  if all_match("$i.u", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*") # Volltext
+  if all_match("$i.u", ".*doi.org.*(10\\.(\\d){4,9}/(\\S)+).*") # Volltext
     copy_field("$i.u", "doi[].$append")
   end
 end
-replace_all("doi[].*", ".*doi.org.*(10\\.(\\d)+/(\\S)+).*", "$1")
+replace_all("doi[].*", ".*doi.org.*(10\\.(\\d){4,9}/(\\S)+).*", "$1")
 uniq("doi[]")
 
 # 035 - System Control Number (R) - Subfield: $a (NR)

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -837,7 +837,7 @@ prepend("exampleOfWork.language[].*.id", "http://id.loc.gov/vocabulary/iso639-2/
 # 730 - Added Entry-Uniform Title (R)
 
 add_array("containsExampleOfWork[]")
-do list(path:"700?2|710?2|711?2|730?2", "var": "$i")
+do list(path:"700?2|710?2|711?2", "var": "$i")
   add_array("containsExampleOfWork[].$append.label")
   add_array("containsExampleOfWork[].$last.creatorOfWork")
   copy_field("$i.a","containsExampleOfWork[].$last.creatorOfWork.$append")
@@ -848,6 +848,26 @@ do list(path:"700?2|710?2|711?2|730?2", "var": "$i")
   copy_field("$i.r","containsExampleOfWork[].$last.label.$append")
   join_field("containsExampleOfWork[].$last.label", ". ")
   join_field("containsExampleOfWork[].$last.creatorOfWork", " ")
+  copy_field("$i.n","containsExampleOfWork[].$last.workNumbering")
+  copy_field("$i.r","containsExampleOfWork[].$last.musicalKey")
+  add_array("containsExampleOfWork[].$last.type[]","Work")
+  add_array("containsExampleOfWork[].$last.instrumentation[]")
+  do list(path:"$i.m","var":"$j")
+    copy_field("$j","containsExampleOfWork[].$last.instrumentation[].$append")
+  end
+  do list(path: "$i.0", "var":"$k")
+    if any_match("$k", "^\\(DE-588\\).+$")
+      copy_field("$k", "containsExampleOfWork[].$last.id")
+      replace_all("containsExampleOfWork[].$last.id","^\\(DE-588\\)(.+$)","https://d-nb.info/gnd/$1")
+    end
+  end
+end
+
+do list(path:"730?2", "var": "$i")
+  add_array("containsExampleOfWork[].$append.label")
+  copy_field("$i.a","containsExampleOfWork[].$last.label.$append")
+  copy_field("$i.d","containsExampleOfWork[].$last.label.$append")
+  join_field("containsExampleOfWork[].$last.label", " ")
   copy_field("$i.n","containsExampleOfWork[].$last.workNumbering")
   copy_field("$i.r","containsExampleOfWork[].$last.musicalKey")
   add_array("containsExampleOfWork[].$last.type[]","Work")

--- a/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
+++ b/src/main/resources/alma/fix/relatedRessourcesAndLinks.fix
@@ -140,6 +140,25 @@ do list(path: "4900?", "var": "$i")
   join_field("isPartOf[].$last.numbering")
 end
 
+unless exists("830??")
+  do list(path: "4901?", "var": "$i")
+    add_hash("isPartOf[].$append")
+    add_array("isPartOf[].$last.hasSuperordinate[]")
+    add_hash( "isPartOf[].$last.hasSuperordinate[].$append")
+    add_array("isPartOf[].$last.hasSuperordinate[].$last.label")
+    do list(path:"$i.a", "var":"$j")
+      copy_field("$j", "isPartOf[].$last.hasSuperordinate[].$last.label.$append")
+    end
+    join_field("isPartOf[].$last.hasSuperordinate[].$last.label", " / ")
+    call_macro("alternateGraphicRepresentationIsPartOf",variable:"$i")
+
+    add_array("isPartOf[].$last.numbering")
+    do list(path:"$i.v", "var":"$j")
+      copy_field("$j", "isPartOf[].$last.numbering.$append")
+    end
+    join_field("isPartOf[].$last.numbering")
+  end
+end
 
 # 830 - Series Added Entry-Uniform Title (R) - Subfield: $w (R), $a (NR), $v (NR)
 # Element can be repeatable with local entries they have subfield $M.
@@ -160,7 +179,7 @@ do list(path: "830??", "var": "$i")
   end
 end
 
-do list(path: "4901?", "var": "$j")
+do list(path: "4901?", "var": "$j") #alternateGraphicRepresentation for 830 is included in 4901?
   call_macro("alternateGraphicRepresentationIsPartOf",variable:"$j")
 end
 

--- a/src/test/resources/alma-fix/99371068478706441.json
+++ b/src/test/resources/alma-fix/99371068478706441.json
@@ -189,7 +189,7 @@
     } ]
   },
   "containsExampleOfWork" : [ {
-    "creatorOfWork" : "Gabriel revelation.",
+    "label" : "Gabriel revelation.",
     "type" : [ "Work" ]
   } ],
   "language" : [ {

--- a/src/test/resources/alma-fix/99371068478706441.json
+++ b/src/test/resources/alma-fix/99371068478706441.json
@@ -1,0 +1,232 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99371068478706441#!",
+  "type" : [ "BibliographicResource", "Bibliography", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Messiahs and resurrection in The Gabriel revelation",
+  "almaMmsId" : "99371068478706441",
+  "isbn" : [ "9786612873935", "6612873930", "9781441114860", "1441114866", "9781282873933", "1282873938", "9781441131614", "1441131612" ],
+  "oclcNumber" : [ "676697105" ],
+  "edition" : [ "1st ed" ],
+  "publication" : [ {
+    "dateStatement" : "c2009.",
+    "startDate" : "2009",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "London", "New York, NY" ],
+    "publishedBy" : [ "Continuum" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99371068478706441",
+    "label" : "Webseite der hbz-Ressource 99371068478706441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99371068478706441",
+        "dateCreated" : "2008-10-22",
+        "dateModified" : "2026-04-22",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99371068478706441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "Ebookcentral Proquest"
+        },
+        "provider" : {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "Ebookcentral Proquest"
+        },
+        "modifiedBy" : [ {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "Ebookcentral Proquest"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Gabriel revelation."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Christianity / Origin."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "296.1/5",
+    "notation" : "296.1/5",
+    "version" : "22"
+  } ],
+  "subjectslabels" : [ "Gabriel revelation.", "Christianity / Origin." ],
+  "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FHM/openurl?u.ignore_date_coverage=true&portfolio_pid=5346864950006485&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FHM/openurl?u.ignore_date_coverage=true&rft.mms_id=991006420250906485",
+    "heldBy" : {
+      "isil" : "DE-836",
+      "id" : "http://lobid.org/organisations/DE-836#!",
+      "label" : "FH Münster, Hochschulbibliothek"
+    },
+    "seeAlso" : [ "https://fhb-muenster.digibib.net/search/katalog/record/(DE-605)99371068478706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-836#!",
+      "label" : "FH Münster, Hochschulbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371068478706441:DE-836:5346864950006485#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_RHW/openurl?u.ignore_date_coverage=true&portfolio_pid=5325053670006479&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_RHW/openurl?u.ignore_date_coverage=true&rft.mms_id=991002769402006479",
+    "heldBy" : {
+      "isil" : "DE-1383",
+      "id" : "http://lobid.org/organisations/DE-1383#!",
+      "label" : "Hochschule Rhein-Waal, Bibliothek"
+    },
+    "seeAlso" : [ "https://hsb-rhein-waal.digibib.net/search/katalog/record/(DE-605)99371068478706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-1383#!",
+      "label" : "Hochschule Rhein-Waal, Bibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371068478706441:DE-1383:5325053670006479#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_RHW/openurl?u.ignore_date_coverage=true&portfolio_pid=5346645520006479&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_RHW/openurl?u.ignore_date_coverage=true&rft.mms_id=991002769402006479",
+    "heldBy" : {
+      "isil" : "DE-1383",
+      "id" : "http://lobid.org/organisations/DE-1383#!",
+      "label" : "Hochschule Rhein-Waal, Bibliothek"
+    },
+    "seeAlso" : [ "https://hsb-rhein-waal.digibib.net/search/katalog/record/(DE-605)99371068478706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-1383#!",
+      "label" : "Hochschule Rhein-Waal, Bibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371068478706441:DE-1383:5346645520006479#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53666469080006449&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=991044869593806449",
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,99371068478706441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371068478706441:DE-6:53666469080006449#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99371068478706441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/676697105",
+    "label" : "OCLC-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "label" : "Kogod library of Judaic studies ;"
+    } ],
+    "numbering" : "6",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "related" : [ {
+    "isbn" : [ "9780826425072", "0826425070" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
+  "exampleOfWork" : {
+    "language" : [ {
+      "id" : "http://id.loc.gov/vocabulary/iso639-2/heb",
+      "label" : "Hebräisch"
+    } ]
+  },
+  "containsExampleOfWork" : [ {
+    "creatorOfWork" : "Gabriel revelation.",
+    "type" : [ "Work" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
+    "label" : "Englisch"
+  }, {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/heb",
+    "label" : "Hebräisch"
+  } ],
+  "extent" : "1 online resource (139 p.)",
+  "note" : [ "\"Shalom Hartman Institute.\"" ],
+  "abstract" : [ "An exploration of the formation of the conception of 'catastrophic messianism' in the Gabriel Revelation. It features a discussion of the text \"The Gabriel Revelation\" - an apocalyptic text written on stone at the turn of the Common Era. It explores the formation of the conception of 'catastrophic messianism' in the Gabriel Revelation." ],
+  "langNote" : [ "English with Hebrew, Hebrew translated to English" ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "by Israel Knohl." ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Knohl, Israel",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/cre",
+      "label" : "Schöpfer/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Mekhon Shalom Harṭman (Jerusalem)",
+      "type" : [ "CorporateBody" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99371068478706441.xml
+++ b/src/test/resources/alma-fix/99371068478706441.xml
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>02295nam  2200565 a 4500</leader>
+  <controlfield tag="001">99371068478706441</controlfield>
+  <controlfield tag="005">20260415133603.0</controlfield>
+  <controlfield tag="006">m     o  d |      </controlfield>
+  <controlfield tag="007">cr -n---------</controlfield>
+  <controlfield tag="008">081022s2009    enka    ob    001 0 eng  </controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9786612873935</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781441114860</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1441114866</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781282873933</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1282873938</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781441131614</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1441131612</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)2670000000054839</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EBL)601820</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)676697105</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC601820</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC6158797</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Perlego)805723</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)992670000000054839</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MiAaPQ</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="e">pn</subfield>
+    <subfield code="c">MiAaPQ</subfield>
+    <subfield code="d">MiAaPQ</subfield>
+  </datafield>
+  <datafield tag="041" ind1="1" ind2=" ">
+    <subfield code="a">eng</subfield>
+    <subfield code="a">heb</subfield>
+    <subfield code="h">heb</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">BR129</subfield>
+    <subfield code="b">.K55 2009</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2=" ">
+    <subfield code="a">296.1/5</subfield>
+    <subfield code="2">22</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Knohl, Israel.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Messiahs and resurrection in The Gabriel revelation /</subfield>
+    <subfield code="c">by Israel Knohl.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">1st ed.</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">London ;</subfield>
+    <subfield code="a">New York, NY :</subfield>
+    <subfield code="b">Continuum,</subfield>
+    <subfield code="c">c2009.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (139 p.)</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">The Kogod library of Judaic studies ;</subfield>
+    <subfield code="v">6</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">"Shalom Hartman Institute."</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references (p. [117]) and indexes.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">Text, translation, and commentary -- Structure, themes, and historical context -- The Antichrist in the Gabriel revelation and related texts -- The Gabriel revelation and the birth of Christianity.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">An exploration of the formation of the conception of 'catastrophic messianism' in the Gabriel Revelation. It features a discussion of the text "The Gabriel Revelation" - an apocalyptic text written on stone at the turn of the Common Era. It explores the formation of the conception of 'catastrophic messianism' in the Gabriel Revelation.</subfield>
+  </datafield>
+  <datafield tag="546" ind1=" " ind2=" ">
+    <subfield code="a">English with Hebrew, Hebrew translated to English.</subfield>
+  </datafield>
+  <datafield tag="588" ind1=" " ind2=" ">
+    <subfield code="a">Description based on print version record.</subfield>
+  </datafield>
+  <datafield tag="630" ind1="0" ind2="0">
+    <subfield code="a">Gabriel revelation.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Christianity</subfield>
+    <subfield code="x">Origin.</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">Mekhon Shalom Harṭman (Jerusalem)</subfield>
+  </datafield>
+  <datafield tag="730" ind1="0" ind2="2">
+    <subfield code="a">Gabriel revelation.</subfield>
+    <subfield code="l">English &amp; Hebrew.</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">9780826425072</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">0826425070</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Kogod library of Judaic studies ;</subfield>
+    <subfield code="v">6.</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">BOOK</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99371068478706441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_FHM</subfield>
+    <subfield code="i">991006420250906485</subfield>
+    <subfield code="n">FH / KA Münster</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_RHW</subfield>
+    <subfield code="i">991002769402006479</subfield>
+    <subfield code="n">Hochschule Rhein-Waal</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="i">991044869593806449</subfield>
+    <subfield code="n">Universität Münster</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">system</subfield>
+    <subfield code="f">EBC</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">106</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-04-22 00:44:32 Europe/Berlin</subfield>
+    <subfield code="g">992670000000054839</subfield>
+    <subfield code="a">CKB</subfield>
+    <subfield code="b">2021-11-22 01:01:07 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ebook Central</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5346864950006485</subfield>
+    <subfield code="h">fhms-ez</subfield>
+    <subfield code="M">49HBZ_FHM</subfield>
+    <subfield code="p">6140729030006485</subfield>
+    <subfield code="q">Ebook Central Perpetual, DDA and Subscription Titles</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">614330000000000002</subfield>
+    <subfield code="y">2026-04-06 13:57:12 Europe/Berlin</subfield>
+    <subfield code="w">2022-07-08 13:08:35 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5346864950006485&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2022-07-08 11:08:35</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="t">POL-2023-7903</subfield>
+    <subfield code="S">6240729020006485</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991006420250906485</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">5346864950006485</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ebook Central</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5325053670006479</subfield>
+    <subfield code="h">ezProxy</subfield>
+    <subfield code="M">49HBZ_RHW</subfield>
+    <subfield code="p">6119553160006479</subfield>
+    <subfield code="q">Ebook Central Perpetual, DDA and Subscription Titles</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">614330000000000002</subfield>
+    <subfield code="y">2026-04-07 05:52:29 Europe/Berlin</subfield>
+    <subfield code="w">2023-08-21 18:06:16 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5325053670006479&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2023-08-21 16:06:16</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="S">6219553150006479</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991002769402006479</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">5325053670006479</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ebook Central</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5346645520006479</subfield>
+    <subfield code="h">DEFAULT</subfield>
+    <subfield code="M">49HBZ_RHW</subfield>
+    <subfield code="p">6143122000006479</subfield>
+    <subfield code="q">Ebook Central Academic Complete</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">614200000000000002</subfield>
+    <subfield code="y">2026-01-01 00:13:06 Europe/Berlin</subfield>
+    <subfield code="w">2025-02-21 15:03:19 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5346645520006479&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2025-02-21 14:03:19</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="t">POL-390</subfield>
+    <subfield code="S">6243121990006479</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991002769402006479</subfield>
+    <subfield code="b">Not Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">5346645520006479</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ebook Central</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53666469080006449</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="p">61648640590006449</subfield>
+    <subfield code="q">Proquest (Ebook Central)</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">614330000000000002</subfield>
+    <subfield code="y">2026-04-06 13:16:16 Europe/Berlin</subfield>
+    <subfield code="w">2023-07-07 23:21:22 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53666469080006449&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2023-07-07 21:21:22</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62659001800006449</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991044869593806449</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">53666469080006449</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/99371186211706441.json
+++ b/src/test/resources/alma-fix/99371186211706441.json
@@ -209,6 +209,13 @@
     "id" : "https://doi.org/10.1007/978-3-7091-7673-3",
     "label" : "DOI-Link"
   } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "label" : "Few-Body Systems, Supplementa"
+    } ],
+    "numbering" : "17/1977",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
   "fulltextOnline" : [ {
     "id" : "https://doi.org/10.1007/978-3-7091-7673-3",
     "label" : "DOI-Link"

--- a/src/test/resources/alma-fix/99371360677806441.json
+++ b/src/test/resources/alma-fix/99371360677806441.json
@@ -12,7 +12,6 @@
   "title" : "Hydrologie, Climat et Biogeochimie du Bassin du Congo",
   "almaMmsId" : "99371360677806441",
   "isbn" : [ "9781119842125", "1119842123", "9781119842101", "1119842107", "9781119842118", "1119842115" ],
-  "doi" : [ "1002/9781119842125" ],
   "oclcNumber" : [ "1298389577" ],
   "otherTitleInformation" : [ "Une Base Pour L'Avenir" ],
   "edition" : [ "1st ed" ],
@@ -168,19 +167,12 @@
   }, {
     "id" : "http://worldcat.org/oclc/1298389577",
     "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://doi.org/1002/9781119842125",
-    "label" : "DOI-Link"
   } ],
   "isPartOf" : [ {
     "hasSuperordinate" : [ {
       "label" : "Geophysical Monograph"
     } ],
     "type" : [ "IsPartOfRelation" ]
-  } ],
-  "fulltextOnline" : [ {
-    "id" : "https://doi.org/1002/9781119842125",
-    "label" : "DOI-Link"
   } ],
   "related" : [ {
     "isbn" : [ "9781119842095", "1119842093" ]

--- a/src/test/resources/alma-fix/99371360677806441.json
+++ b/src/test/resources/alma-fix/99371360677806441.json
@@ -1,0 +1,234 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99371360677806441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Hydrologie, Climat et Biogeochimie du Bassin du Congo",
+  "almaMmsId" : "99371360677806441",
+  "isbn" : [ "9781119842125", "1119842123", "9781119842101", "1119842107", "9781119842118", "1119842115" ],
+  "doi" : [ "1002/9781119842125" ],
+  "oclcNumber" : [ "1298389577" ],
+  "otherTitleInformation" : [ "Une Base Pour L'Avenir" ],
+  "edition" : [ "1st ed" ],
+  "publication" : [ {
+    "dateStatement" : "2022.",
+    "startDate" : "2022",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Newark" ],
+    "publishedBy" : [ "American Geophysical Union" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99371360677806441",
+    "label" : "Webseite der hbz-Ressource 99371360677806441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99371360677806441",
+        "dateCreated" : "2022-02-16",
+        "dateModified" : "2026-04-23",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99371360677806441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "Ebookcentral Proquest"
+        },
+        "provider" : {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "Ebookcentral Proquest"
+        },
+        "modifiedBy" : [ {
+          "id" : "https://ebookcentral.proquest.com/",
+          "label" : "Ebookcentral Proquest"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Hydrology."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Climatology."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "551.48",
+    "notation" : "551.48",
+    "version" : "23"
+  } ],
+  "subjectslabels" : [ "Hydrology.", "Climatology." ],
+  "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_BRS/openurl?u.ignore_date_coverage=true&portfolio_pid=53108691550006452&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_BRS/openurl?u.ignore_date_coverage=true&rft.mms_id=991005991340006452",
+    "heldBy" : {
+      "isil" : "DE-1044",
+      "id" : "http://lobid.org/organisations/DE-1044#!",
+      "label" : "Hochschul- und Kreisbibliothek Bonn-Rhein-Sieg"
+    },
+    "seeAlso" : [ "https://bib-discover.bib.h-brs.de/discovery/search?query=any,contains,99371360677806441&tab=Everything&search_scope=1044_and_CI&vid=49HBZ_BRS:1044&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-1044#!",
+      "label" : "Hochschul- und Kreisbibliothek Bonn-Rhein-Sieg",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371360677806441:DE-1044:53108691550006452#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_KHO/openurl?u.ignore_date_coverage=true&portfolio_pid=5335116340006474&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_KHO/openurl?u.ignore_date_coverage=true&rft.mms_id=991007171097106474",
+    "heldBy" : {
+      "isil" : "DE-1032",
+      "id" : "http://lobid.org/organisations/DE-1032#!",
+      "label" : "Katholische Hochschule Nordrhein-Westfalen (katho), Hochschulbibliothek"
+    },
+    "seeAlso" : [ "https://research.ebsco.com/c/xkyosu/search/results?q=99371360677806441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-1032#!",
+      "label" : "Katholische Hochschule Nordrhein-Westfalen (katho), Hochschulbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371360677806441:DE-1032:5335116340006474#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UDE/openurl?u.ignore_date_coverage=true&portfolio_pid=53477215450006446&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UDE/openurl?u.ignore_date_coverage=true&rft.mms_id=99208935149306446",
+    "heldBy" : {
+      "isil" : "DE-465",
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen"
+    },
+    "seeAlso" : [ "https://primo.uni-due.de/discovery/search?query=any,contains,99371360677806441&tab=Everything&search_scope=MyInst_and_CI_custom&vid=49HBZ_UDE:UDE&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371360677806441:DE-465:53477215450006446#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53170536600006463&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=9925036202506463",
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr[q,any]=99371360677806441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99371360677806441:DE-466:53170536600006463#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99371360677806441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1298389577",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://doi.org/1002/9781119842125",
+    "label" : "DOI-Link"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "label" : "Geophysical Monograph"
+    } ],
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/1002/9781119842125",
+    "label" : "DOI-Link"
+  } ],
+  "related" : [ {
+    "isbn" : [ "9781119842095", "1119842093" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/fre",
+    "label" : "Französisch"
+  } ],
+  "extent" : "1 online resource (621 pages)",
+  "abstract" : [ "Nouvelles découvertes scientifiques dans le bassin du Congo grâce à des collaborations internationales. Le Congo est le deuxième plus grand bassin fluvial du monde et abrite 120 millions d'habitants. La compréhension du cycle de l'eau, des sédiments et des nutriments est importante car la région est confrontée à des changements climatiques et anthropiques. Hydrologie, climat et biogéochimie du bassin du Congo: une base pour l'avenir explore les variations et les influences sur les précipitations, l'hydrologie et l'hydraulique, et la dynamique des sédiments et du carbone. Il présente des contributions d'experts de la région et de leurs collaborateurs internationaux." ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Tshimanga, Raphael M.",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Moukandi, Guy",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Alsdorf, Douglas",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctb",
+      "label" : "Beitragende/r"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99371360677806441.xml
+++ b/src/test/resources/alma-fix/99371360677806441.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>10208nam a22005173i 4500</leader>
+  <controlfield tag="001">99371360677806441</controlfield>
+  <controlfield tag="005">20260415123729.0</controlfield>
+  <controlfield tag="006">m     o  d |      </controlfield>
+  <controlfield tag="007">cr#cnu||||||||</controlfield>
+  <controlfield tag="008">220216s2022    xx      o     ||||0 fre d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781119842125</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1119842123</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781119842101</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1119842107</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9781119842118</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1119842115</subfield>
+  </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="a">1002/9781119842125</subfield>
+    <subfield code="2">doi</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(PPN)275774066</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC6886051</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Au-PeEL)EBL6886051</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)21167526500041</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(NjHacI)9921167526500041</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Perlego)3261489</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1298389577</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)9921167526500041</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MiAaPQ</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="e">pn</subfield>
+    <subfield code="c">MiAaPQ</subfield>
+    <subfield code="d">MiAaPQ</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">GB661.2</subfield>
+    <subfield code="b">.H937 2022</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">551.48</subfield>
+    <subfield code="2">23</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Tshimanga, Raphael M.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Hydrologie, Climat et Biogeochimie du Bassin du Congo :</subfield>
+    <subfield code="b">Une Base Pour L'Avenir.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">1st ed.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Newark :</subfield>
+    <subfield code="b">American Geophysical Union,</subfield>
+    <subfield code="c">2022.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="4">
+    <subfield code="c">©2022.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (621 pages)</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Geophysical Monograph</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">Liste des contributeurs ix Préface xvii 1 Recherche sur le bassin du Congo : construire une base pour l'avenir 1Raphael M. Tshimanga, Guy D. Moukandi N'kaya, Alain Laraque, Sharon E. Nicholson, Jean-Marie Kileshye Onema, Raymond Lumbuenamo, et Douglas Alsdorf Partie I Influences sur la pluviométrie 2 Climat de l'Afrique centrale : avancées et lacunes 15Wilfried Pokam Mba, Derbetini Appolinaire Vondou, et Pierre Honore Kamsu-Tamo 3 Le régime pluviométrique et convectif sur l'Afrique équatoriale, en particulier sur le bassin du Congo 25Sharon E. Nicholson 4 Influence de la paramétrisation du «slab-ocean» dans le modèle climatique regional RegCM4 en Afrique centrale 51François Xavier Mengouna, Derbetini A. Vondou, Armand Joel Komkoua Mbienda, Thierry C. Fotso-Nguemo, Denis Sonkoué, Zéphirin Yepdo-Djomou, et Pascal M. Igri 5 Comprendre l'influence de la variabilité climatique sur l'hydrologie des eaux de surface dans le bassin du Congo 65Christopher E. Ndehedehe, Vagner G. Ferreira, Augusto Getirana, et Nathan O. Agutu 6 Dynamique hydroclimatique de la rivière Oubangui amont à Mobaye, République centrafricaine : étude comparée du rôle de la savane et de la forêt équatoriale 87Cyriaque-Rufin Nguimalet, Didier Orange, Jean-Pascal Waterendji, et Athanase Yambele 7 Évaluation des produits 3B42 et 3B43 de Tropical Rainfall Measuring Mission (TRMM) par rapport aux observations des stations météorologiques synoptiques sur le Cameroun 103Pascal M. Igri, Roméo Stève Tanessong, Derbetini Appolinaire Vondou, Wilfried Pokam Mba, Taguemfo Kammalac Jores, Samuel Kaïssassou, Guy Merlin Guenang, Armand Joel Komkoua Mbienda, et Zéphirin Yepdo-Djomou Partie II Variations des pluviométrie et du ruissellement 8 Nouveau regard sur l'hydrologie dans le bassin du Congo, à partir de l'étude des chroniques hydro-pluviométriques pluri-décennales 129Guy D. Moukandi N'kaya, Alain Laraque, Jean-Emmanuel Paturel, Georges Gulemvuga Guzanga, Gil Mahé, et Raphael M. Tshimanga 9 Changements historiques dans les régimes pluviométriques sur le bassin du Congo et impacts sur le ruissellement (1903-2010) 151Christopher E. Ndehedehe et Nathan O. Agutu 10 Bilan hydrique et sécheresses dans les conditions actuelles et futures dans le bassin du fleuve Congo 171Venkataramana Sridhar, Hyunwoo Kang, Syed A. Ali, Gode B. Bola, Raphael M. Tshimanga, et Venkataraman Lakshmi 11 Variabilité spatio-temporelle des sécheresses dans le bassin du fleuve Congo : le rôle du transport de l'humidité atmosphérique 193Robert Sorí, Milica Stojanovic, Raquel Nieto, Margarida L. R. Liberato, et Luis Gimeno Partie III Hydrologie et hydraulique 12 Deux décennies de la modélisation et la prédiction hydrologiques dans le bassin du Congo : progrès et perspectives pour les investigations futures 213Raphael M. Tshimanga 13 Sources et puits d'eau des zones humides de la Cuvette Centrale en utilisant de multiples mesures de télédétection et un modèle hydrologique 245Ting Yuan, Hyongki Lee, R. Edward Beighley, Hahn Chul Jung, et Raphael M. Tshimanga 14 Analyse du rôle de la Cuvette Centrale dans l'hydrologie du bassin versant du Congo 255Pankyes Datok, Clément Fabre, Sabine Sauvage, Guy D. Moukandi N'kaya, Adrien Paris, Vanessa Dos Santos, Alain Laraque, et José-Miguel Sánchez-Pérez 15 Estimation de la bathymétrie pour la modélisation de l'hydraulique des canaux multifilaires : application au cours moyen du fleuve Congo 283Andrew B. Carr, Mark A. Trigg, Raphael M. Tshimanga, Mark W. Smith, Duncan J. Borman, et Paul D. Bates 16 Examen des applications des techniques de télédétection à la recherche hydrologique en Afrique subsaharienne, avec un accent particulier sur le bassin du Congo 303Guy J.-P. Schumann, Delwyn K. Moller, Louise Croneborg-Jones, et Konstantinos M. Andreadis 17 Hydrologie spatiale et applications dans le bassin du Congo 333Christophe Brachet, Alice Andral, Georges Gulemvuga Guzanga, Blaise-Leandre Tondo, Pierre-Olivier Malaterre, et Sebastien Legrand 18 Suivi des variables hydrologiques par télédétection et modélisation dans le basin du fleuve Congo 345Adrien Paris, Stéphane Calmant, Marielle Gosset, Ayan S. Fleischmann, Tainá Sampaio Xavier Conchy, Pierre-André Garambois, Jean-Pierre Bricquet, Fabrice Papa, Raphael M. Tshimanga, Georges Gulemvuga Guzanga, Vinícius Alencar Siqueira, Blaise-Leandre Tondo, Rodrigo Paiva, Joecila Santos da Silva, et Alain Laraque 19 Variations hydrologiques à long terme du bassin de l'Ogooué 375Sakaros Bogning, Fréderic Frappart, Gil Mahé, Fernando Niño, Adrien Paris, Joëlle Sihon, Franck Ghomsi, Fabien Blarel, Jean-Pierre Bricquet, Raphaël Onguene, Jacques Etame, Frédérique Seyler, Marie-Claire Paiz, et Jean-Jacques Braun Partie IV Sédiments et carbone 20 Dynamique du carbone fluvial dans le continuum terre-océan des grands fleuves tropicaux : l'Amazone et le Congo 403Jeffrey E. Richey, Robert G. M. Spencer, Travis W. Drake, et Nicholas D. Ward 21 Mesure des changements géomorphologiques sur le fleuve Congo à l'aide de cartes de navigation centenaires 425Mark A. Trigg, Andrew B. Carr, Mark W. Smith, et Raphael M. Tshimanga 22 Sélection du site, conception et mise en oeuvre d'un programme d'échantillonnage des sédiments sur le fleuve Kasaï, un affluent majeur du fleuve Congo 441Catherine A. Mushi, Preksedis M. Ndomba, Raphael M. Tshimanga, Mark A. Trigg, Jeffrey Neal, Gode B. Bola, Pierre Mulamba Kabuya, Andrew B. Carr, Jules T. Beya, Paul D. Bates, et Felix Mtalo 23 Nouvelles mesures de la dynamique de l'eau et du transport des sédiments le long du bief moyen du fleuve Congo et de la rivière Kasaï 463Raphael M. Tshimanga, Mark A. Trigg, Jeffrey Neal, Preksedis M. Ndomba, Denis A. Hughes, Andrew B. Carr, Pierre Mulamba Kabuya, Gode B. Bola, Catherine A. Mushi, Jules T. Beya, Felly K. Ngandu, Gabriel M. Mokango, Felix Mtalo, et Paul D. Bates Partie V Ressources en eau 24 Vers un cadre de classification des bassins versants pour les prévisions hydrologiques et la gestion des ressources en eau dans le bassin non jaugé du fleuve Congo : une approche a priori 487Raphael M. Tshimanga, Gode B. Bola, Pierre Mulamba Kabuya, Landry Nkaba, Jeffrey Neal, Laurence Hawker, Mark A. Trigg, Paul D. Bates, Denis A. Hughes, Alain Laraque, Ross Woods, et Thorsten Wagener 25 Les enjeux environnementaux du projet de transfert d'eau de l'Oubangui vers le lac Tchad 517Chanel Nzango, Pascal Bartout, Laurent Touchart, et Cyriaque-Rufin Nguimalet 26 Variabilite du lac Tchad : quelle gestion hydraulique pour preserver les ressources naturelles ? 531Hadiza Kiari Fougou et Jacques Lemoalle 27 Evaluation des risques d'inondation à périodes de retour multiples dans le bassin du fleuve Congo 537Gode B. Bola, Raphael M. Tshimanga, Jeffrey Neal, Laurence Hawker, Mark A. Trigg, Lukanda Mwamba, et Paul D. Bates 28 Mettre les usagers de la rivière au coeur de la recherche sur l'hydraulique et la morphologie dans le bassin du Congo 561Mark A. Trigg, Raphael M. Tshimanga, Preksedis M. Ndomba, Felix Mtalo, Denis A. Hughes, Catherine A. Mushi, Gode B. Bola, Pierre Mulamba Kabuya, Andrew B. Carr, Mark Bernhofen, Jeffrey Neal, Jules T. Beya, Felly K. Ngandu, et Paul D. Bates Index.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">Nouvelles découvertes scientifiques dans le bassin du Congo grâce à des collaborations internationales. Le Congo est le deuxième plus grand bassin fluvial du monde et abrite 120 millions d'habitants. La compréhension du cycle de l'eau, des sédiments et des nutriments est importante car la région est confrontée à des changements climatiques et anthropiques. Hydrologie, climat et biogéochimie du bassin du Congo: une base pour l'avenir explore les variations et les influences sur les précipitations, l'hydrologie et l'hydraulique, et la dynamique des sédiments et du carbone. Il présente des contributions d'experts de la région et de leurs collaborateurs internationaux.</subfield>
+  </datafield>
+  <datafield tag="588" ind1=" " ind2=" ">
+    <subfield code="a">Description based on publisher supplied metadata and other sources.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Hydrology.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Climatology.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Moukandi, Guy.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Alsdorf, Douglas.</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">9781119842095</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">1119842093</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Geophysical Monograph</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">BOOK</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99371360677806441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRS</subfield>
+    <subfield code="i">991005991340006452</subfield>
+    <subfield code="n">Hochschule Bonn-Rhein-Sieg</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_KHO</subfield>
+    <subfield code="i">991007171097106474</subfield>
+    <subfield code="n">Katholische Hochschule Nordrhein-Westfalen</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="i">99208935149306446</subfield>
+    <subfield code="n">Universität Duisburg-Essen</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="i">9925036202506463</subfield>
+    <subfield code="n">Universitätsbibliothek Paderborn</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">system</subfield>
+    <subfield code="f">CKB</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">104</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-04-23 00:14:56 Europe/Berlin</subfield>
+    <subfield code="g">9921167526500041</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="b">2022-05-16 02:05:23 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Wiley Online Library</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53108691550006452</subfield>
+    <subfield code="M">49HBZ_BRS</subfield>
+    <subfield code="p">6183814950006452</subfield>
+    <subfield code="q">Wiley Online Library eBooks</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615410000000002415</subfield>
+    <subfield code="y">2025-08-23 23:27:03 Europe/Berlin</subfield>
+    <subfield code="w">2025-08-23 23:26:56 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53108691550006452&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2025-08-23 21:26:56</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="t">POL-2023-6374</subfield>
+    <subfield code="S">6283814940006452</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991005991340006452</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">53108691550006452</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Wiley Online Library</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5335116340006474</subfield>
+    <subfield code="M">49HBZ_KHO</subfield>
+    <subfield code="p">6134969350006474</subfield>
+    <subfield code="q">Wiley Online Library UBCM All Ebooks with German Language Titles</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615290000000000032</subfield>
+    <subfield code="y">2025-01-01 00:05:20 Europe/Berlin</subfield>
+    <subfield code="w">2024-01-16 10:20:30 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5335116340006474&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2024-01-16 09:20:30</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="g">Aachen</subfield>
+    <subfield code="t">POL2024-670</subfield>
+    <subfield code="S">6234979350006474</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991007171097106474</subfield>
+    <subfield code="b">Not Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">5335116340006474</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Wiley Online Library</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53477215450006446</subfield>
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="k">Zugriff für autorisierte Nutzer:innen</subfield>
+    <subfield code="p">61477064770006446</subfield>
+    <subfield code="q">Wiley Online Library (Zugriff bis 31.12.2026)</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">613800000000000228</subfield>
+    <subfield code="y">2024-02-02 14:23:27 Europe/Berlin</subfield>
+    <subfield code="w">2024-02-02 14:23:27 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53477215450006446&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2024-02-02 13:23:27</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62477064760006446</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=99208935149306446</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">53477215450006446</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Wiley Online Library</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53170536600006463</subfield>
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="p">61165840100006463</subfield>
+    <subfield code="q">Wiley Online Library - AutoHoldings Books</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615410000000002415</subfield>
+    <subfield code="y">2022-08-02 12:28:25 Europe/Berlin</subfield>
+    <subfield code="w">2022-08-02 12:28:08 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53170536600006463&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2022-08-02 10:28:08</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62165840090006463</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=9925036202506463</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">53170536600006463</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/99376636359506441.json
+++ b/src/test/resources/alma-fix/99376636359506441.json
@@ -1,0 +1,299 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99376636359506441#!",
+  "type" : [ "BibliographicResource", "Bibliography", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Liminal spaces of writing in adolescent and adult education",
+  "almaMmsId" : "99376636359506441",
+  "isbn" : [ "1666997331", "9781666997330", "1666904015", "9781666904017" ],
+  "doi" : [ "10.5040/9781666997330" ],
+  "oclcNumber" : [ "1293451012" ],
+  "edition" : [ "1st ed" ],
+  "publication" : [ {
+    "dateStatement" : "2022.",
+    "startDate" : "2022",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Maryland" ],
+    "publishedBy" : [ "Lexington Books" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99376636359506441",
+    "label" : "Webseite der hbz-Ressource 99376636359506441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99376636359506441",
+        "dateCreated" : "2022-09-19",
+        "dateModified" : "2026-04-23",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99376636359506441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/XX-UkLoBP#!",
+          "label" : "lobid Organisation"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/XX-UkLoBP#!",
+          "label" : "lobid Organisation"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "English language / Rhetoric / Study and teaching / Psychological aspects."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Liminality."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Literacy."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Academic writing / Study and teaching."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "English language / Composition and exercises / Study and teaching (Secondary)"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "English language / Rhetoric / Study and teaching / Education (Continuing education)"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "FAST (Faceted Application of Subject Terminology)",
+      "id" : "http://fast.oclc.org/"
+    },
+    "label" : "Literacy."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "FAST (Faceted Application of Subject Terminology)",
+      "id" : "http://fast.oclc.org/"
+    },
+    "label" : "Liminality."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "FAST (Faceted Application of Subject Terminology)",
+      "id" : "http://fast.oclc.org/"
+    },
+    "label" : "English language / Rhetoric / Study and teaching / Psychological aspects."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "FAST (Faceted Application of Subject Terminology)",
+      "id" : "http://fast.oclc.org/"
+    },
+    "label" : "English language / Composition and exercises / Study and teaching (Secondary)"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "FAST (Faceted Application of Subject Terminology)",
+      "id" : "http://fast.oclc.org/"
+    },
+    "label" : "Academic writing / Study and teaching."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "808.042071",
+    "notation" : "808.042071",
+    "version" : "23"
+  } ],
+  "subjectslabels" : [ "English language / Rhetoric / Study and teaching / Psychological aspects.", "Liminality.", "Literacy.", "Academic writing / Study and teaching.", "English language / Composition and exercises / Study and teaching (Secondary)", "English language / Rhetoric / Study and teaching / Education (Continuing education)" ],
+  "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_RUW/openurl?u.ignore_date_coverage=true&portfolio_pid=5344935700006453&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_RUW/openurl?u.ignore_date_coverage=true&rft.mms_id=991004268876006453",
+    "heldBy" : {
+      "isil" : "DE-1393",
+      "id" : "http://lobid.org/organisations/DE-1393#!",
+      "label" : "Hochschule Ruhr West, Hochschulbibliothek"
+    },
+    "seeAlso" : [ "https://hsb-ruhr-west.digibib.net/search/katalog/record/(DE-605)99376636359506441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-1393#!",
+      "label" : "Hochschule Ruhr West, Hochschulbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376636359506441:DE-1393:5344935700006453#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&portfolio_pid=53220306140006471&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBO/openurl?u.ignore_date_coverage=true&rft.mms_id=991028123948006471",
+    "heldBy" : {
+      "isil" : "DE-294",
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-ubo.primo.exlibrisgroup.com/permalink/49HBZ_UBO/mnkbqv/alma99376636359506441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-294#!",
+      "label" : "Ruhr-Universität Bochum, Universitätsbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376636359506441:DE-294:53220306140006471#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53706917740006449&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=991045225046606449",
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,99376636359506441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376636359506441:DE-6:53706917740006449#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99376636359506441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1293451012",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://doi.org/10.5040/9781666997330",
+    "label" : "DOI-Link"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.5040/9781666997330",
+    "label" : "DOI-Link"
+  } ],
+  "related" : [ {
+    "isbn" : [ "9781666904000", "1666904007" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
+    "label" : "Englisch"
+  } ],
+  "extent" : "1 online resource (225 pages) : illustrations",
+  "abstract" : [ "\"Liminal Spaces of Writing in Adolescent and Adult Education sheds new light on persistent issues plaguing student writing. Through a compilation of approaches centered around the convergence of structure and agency in practicing writing, the book offers invaluable insights into cultivating agentic student writing for literacy researchers\"--" ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "edited by Mellinee Lesley [and three others]." ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Beach, Whitney",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Graham, Rachel",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Jones, Elizabeth Davis",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Jung, Jin Kyeong",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Saldana, Rene",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt",
+      "label" : "Herausgeber/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt",
+      "label" : "Herausgeber/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99376636359506441.json
+++ b/src/test/resources/alma-fix/99376636359506441.json
@@ -286,14 +286,5 @@
       "label" : "Herausgeber/in"
     },
     "type" : [ "Contribution" ]
-  }, {
-    "agent" : {
-      "type" : [ "Person" ]
-    },
-    "role" : {
-      "id" : "http://id.loc.gov/vocabulary/relators/edt",
-      "label" : "Herausgeber/in"
-    },
-    "type" : [ "Contribution" ]
   } ]
 }

--- a/src/test/resources/alma-fix/99376636359506441.xml
+++ b/src/test/resources/alma-fix/99376636359506441.xml
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01294nam a2200337 i 4500</leader>
+  <controlfield tag="001">99376636359506441</controlfield>
+  <controlfield tag="005">20230629222819.0</controlfield>
+  <controlfield tag="006">m     o  d        </controlfield>
+  <controlfield tag="007">cr cnu||||||||</controlfield>
+  <controlfield tag="008">220919s2022    mdua    ob    001 0 eng d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1-66699-733-1</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">1-66690-401-5</subfield>
+  </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="a">10.5040/9781666997330</subfield>
+    <subfield code="2">doi</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)4100000012510359</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC6876351</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1293451012</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(UkLoBP)BP9781666997330BC</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)994100000012510359</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">UkLoBP</subfield>
+    <subfield code="b">eng</subfield>
+    <subfield code="e">rda</subfield>
+    <subfield code="c">UkLoBP</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">PE1404</subfield>
+    <subfield code="b">.L565 2022</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2=" ">
+    <subfield code="a">808.042071</subfield>
+    <subfield code="2">23</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Liminal spaces of writing in adolescent and adult education /</subfield>
+    <subfield code="c">edited by Mellinee Lesley [and three others].</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">1st ed.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Maryland :</subfield>
+    <subfield code="b">Lexington Books,</subfield>
+    <subfield code="c">2022.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="2">
+    <subfield code="a">New York :</subfield>
+    <subfield code="b">Bloomsbury Publishing (US),</subfield>
+    <subfield code="c">2025.</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (225 pages) :</subfield>
+    <subfield code="b">illustrations</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="347" ind1=" " ind2=" ">
+    <subfield code="a">text file</subfield>
+    <subfield code="b">rdaft</subfield>
+    <subfield code="2">HTML</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references and index.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2=" ">
+    <subfield code="a">Introduction: The role of liminality in developing useful writing / René Saldaña, Jr., Mellinee Lesley, Julie Smit, Jin Kyeong Jung -- More than the second 'R' : revisiting writing instruction for young adults / Kristine E. Pytash and Mellinee Lesley -- Why we write : the scribal identities of adolescents working against standardization / R. Joseph Rodriguez -- The shifting identities of literacy graduates : from learners of writing instruction to novice teachers of adolescent writers / Thea Yurkewecz-Stellato, Shelby Erhard, and Richard Rappold -- In search of the aesthetic : an arts-based approach to writing up our research / Elizabeth Stewart and René Saldaña, Jr. -- Literacy legacies / Stephanie Millet -- Creating a liminal writing class for multilingual adolescent writers / Jin Kyeong Jung -- Video games in the middle school reading classroom : a cultural canon or a social bomb? / Elizabeth Davis Jones -- Writing interviews / Kelly DeLong -- Writing catharsis : inviting students to think and then write outside of the box / Rachel R. Graham -- "I really wish more girls would tell their story" : adolescent girls' composing for advocacy in the liminal space of digital media / Mellinee Lesley -- Voices from an "underperforming" English class / Whitney Beach -- "Places so far that I could only dream" : an interview with Cameron James / Cameron James, Mellinee Lesley and René Saldaña, Jr.</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">"Liminal Spaces of Writing in Adolescent and Adult Education sheds new light on persistent issues plaguing student writing. Through a compilation of approaches centered around the convergence of structure and agency in practicing writing, the book offers invaluable insights into cultivating agentic student writing for literacy researchers"--</subfield>
+    <subfield code="c">Provided by publisher.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">English language</subfield>
+    <subfield code="x">Rhetoric</subfield>
+    <subfield code="x">Study and teaching</subfield>
+    <subfield code="x">Psychological aspects.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Literacy.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00999859</subfield>
+    <subfield code="0">http://id.worldcat.org/fast/999859</subfield>
+    <subfield code="B">OCLC-fst00999859</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Liminality.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00998872</subfield>
+    <subfield code="0">http://id.worldcat.org/fast/998872</subfield>
+    <subfield code="B">OCLC-fst00998872</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">English language</subfield>
+    <subfield code="x">Rhetoric</subfield>
+    <subfield code="x">Study and teaching</subfield>
+    <subfield code="x">Psychological aspects.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00911606</subfield>
+    <subfield code="0">http://id.worldcat.org/fast/911606</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">English language</subfield>
+    <subfield code="x">Composition and exercises</subfield>
+    <subfield code="x">Study and teaching (Secondary)</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00911043</subfield>
+    <subfield code="0">http://id.worldcat.org/fast/911043</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Academic writing</subfield>
+    <subfield code="x">Study and teaching.</subfield>
+    <subfield code="2">fast</subfield>
+    <subfield code="0">(OCoLC)fst00795104</subfield>
+    <subfield code="0">http://id.worldcat.org/fast/795104</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Teaching Methods &amp; Materials.</subfield>
+    <subfield code="2">bisacsh</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Secondary.</subfield>
+    <subfield code="2">bisacsh</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">EDUCATION.</subfield>
+    <subfield code="2">bisacsh</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="7">
+    <subfield code="a">Adult &amp; Continuing Education.</subfield>
+    <subfield code="2">bisacsh</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Liminality.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Literacy.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Academic writing</subfield>
+    <subfield code="x">Study and teaching.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">English language</subfield>
+    <subfield code="x">Composition and exercises</subfield>
+    <subfield code="x">Study and teaching (Secondary)</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">English language</subfield>
+    <subfield code="x">Rhetoric</subfield>
+    <subfield code="x">Study and teaching</subfield>
+    <subfield code="x">Education (Continuing education)</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Essays</subfield>
+    <subfield code="2">lcgft</subfield>
+    <subfield code="0">http://id.loc.gov/authorities/genreForms/gf2014026094</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Beach, Whitney,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Graham, Rachel,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Jones, Elizabeth Davis,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Jung, Jin Kyeong,</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Saldana, Rene,</subfield>
+    <subfield code="e">editor.</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="e">editor.</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">1-66690-400-7</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">BOOK</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99376636359506441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_RUW</subfield>
+    <subfield code="i">991004268876006453</subfield>
+    <subfield code="n">Hochschule Ruhr West</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBO</subfield>
+    <subfield code="i">991028123948006471</subfield>
+    <subfield code="n">Universität Bochum</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="i">991045225046606449</subfield>
+    <subfield code="n">Universität Münster</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">system</subfield>
+    <subfield code="f">BLOOMSBURY</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">112</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-04-23 00:22:51 Europe/Berlin</subfield>
+    <subfield code="g">994100000012510359</subfield>
+    <subfield code="a">CKB</subfield>
+    <subfield code="b">2026-03-01 02:08:45 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">BECK</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5344935700006453</subfield>
+    <subfield code="h">DEFAULT</subfield>
+    <subfield code="M">49HBZ_RUW</subfield>
+    <subfield code="p">6126608750006453</subfield>
+    <subfield code="q">Beck-eLibrary All Books</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615410000000002714</subfield>
+    <subfield code="y">2026-03-01 00:55:26 Europe/Berlin</subfield>
+    <subfield code="w">2026-03-01 00:55:26 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5344935700006453&amp;Force_direct=true</subfield>
+    <subfield code="v">electronic inventory creator</subfield>
+    <subfield code="z">2026-02-28 23:55:26</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="S">6226608740006453</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991004268876006453</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">5344935700006453</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">BECK</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53220306140006471</subfield>
+    <subfield code="M">49HBZ_UBO</subfield>
+    <subfield code="p">61185229140006471</subfield>
+    <subfield code="q">Beck-eLibrary All Books</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615410000000002714</subfield>
+    <subfield code="y">2026-03-01 00:40:27 Europe/Berlin</subfield>
+    <subfield code="w">2026-03-01 00:40:27 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53220306140006471&amp;Force_direct=true</subfield>
+    <subfield code="v">electronic inventory creator</subfield>
+    <subfield code="z">2026-02-28 23:40:27</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="t">POL-1824</subfield>
+    <subfield code="S">62185229130006471</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991028123948006471</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">53220306140006471</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">BECK</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53706917740006449</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="p">61626434700006449</subfield>
+    <subfield code="q">EBA - Beck-eLibrary All Titles</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615450000000001955</subfield>
+    <subfield code="y">2026-03-19 12:35:34 Europe/Berlin</subfield>
+    <subfield code="w">2026-03-07 06:50:34 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53706917740006449&amp;Force_direct=true</subfield>
+    <subfield code="v">electronic inventory creator</subfield>
+    <subfield code="z">2026-03-07 05:50:34</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62626434690006449</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991045225046606449</subfield>
+    <subfield code="b">Not Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">53706917740006449</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">http://id.worldcat.org/fast/998872</subfield>
+    <subfield code="2">uri</subfield>
+    <subfield code="A">FAST</subfield>
+    <subfield code="B">OCLC-fst00998872</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Illiteracy</subfield>
+    <subfield code="A">FAST</subfield>
+    <subfield code="B">OCLC-fst00999859</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">http://id.worldcat.org/fast/999859</subfield>
+    <subfield code="2">uri</subfield>
+    <subfield code="A">FAST</subfield>
+    <subfield code="B">OCLC-fst00999859</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -74,7 +74,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.startDate:1993", /*->*/ 4 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
 			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 196 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 220 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 223 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
This PR introduces mechanism that:
- adds a fallback `isPartOfRelation`
- adds a specific transformtaion for `containsExampleOfWork` for `730`
- skips broken doi`s
- skips `contribution` without `$$a`