### PR TITLE
Revert "Fix indentation"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,14 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    - name: Install metafacture-core-snapshots
-      run: |
-        cd ..
-        git clone https://github.com/metafacture/metafacture-core.git
-        cd metafacture-core
-        git checkout master
-        ./gradlew publishToMavenLocal
-        cd -
+     - name: Install metafacture-core-snapshots
+       run: |
+         cd ..
+         git clone https://github.com/metafacture/metafacture-core.git
+         cd metafacture-core
+         git checkout master
+         ./gradlew publishToMavenLocal
+         cd -
     - name: Build with Maven
       run: |
         mvn install


### PR DESCRIPTION
This reverts commit 61978730f99525ea2e229ea2bb0238f82c3981dd.

This quickfix had no documentation. In order to properly document the problem #2346.
 I suggest to revert this ~~PR~~ commit and redo the commits with proper documentation.