### PR TITLE
Fix build by using proper mf dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
       MAVEN_OPTS: "-Xmx768M"
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Cache Maven packages
       uses: actions/cache@v4
       with:
@@ -54,4 +54,4 @@ jobs:
     - name: Build and Test with play
       run: |
         cd web
-        sbt -v +test
+        sbt  --java-home $JAVA_HOME test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
         cd ..
         git clone https://github.com/metafacture/metafacture-core.git
         cd metafacture-core
-        git checkout master
+        git checkout -b 7a64c159a2e2dfc7d1673c83699254ad148f4011
+        git reset --hard 7a64c159a2e2dfc7d1673c83699254ad148f4011
         ./gradlew publishToMavenLocal
         cd -
     - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-io</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-files</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-json</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -40,72 +40,72 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-biblio</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formeta</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-monitoring</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-strings</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formatting</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-elasticsearch</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-csv</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-flowcontrol</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-plumbing</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph-test</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-xml</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-mangling</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafix</artifactId>
-            <version>master-SNAPSHOT</version>
+            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" % "play-test_2.11" % "2.4.11",
   "org.apache.logging.log4j" % "log4j-core" % "2.9.1",
   "org.elasticsearch.plugin" % "parent-join-client" % "5.6.3",
-  "org.mockito" % "mockito-core" % "1.9.5" %Test,
+  "org.mockito" % "mockito-core" % "3.9.0" %Test,
   "com.google.gdata" % "core" % "1.47.1" exclude ("com.google.guava", "guava"),
   "org.easytesting" % "fest-assert" % "1.4" %Test,
   "org.xbib.elasticsearch.plugin" % "elasticsearch-plugin-bundle" % "5.4.1.0",
@@ -25,6 +25,8 @@ resolvers += "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
 javacOptions ++= Seq("-source", "11", "-target", "11")
+javaOptions in (Test,run) += "--add-opens=java.base/java.lang=ALL-UNNAMED"
+javaOptions in (Test,run) += "--add-opens=java.base/java.util=ALL-UNNAMED"
 
 import com.typesafe.sbteclipse.core.EclipsePlugin.EclipseKeys
 


### PR DESCRIPTION
See #2350:
As metafacture-core has updated its dependencies some the build here breaks because of incompatility of transitive dependencies.

Setting the mf-core to a working commit and consume this fixes the build.