### PR TITLE
Fixes to make the current mf master runnable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
         cd ..
         git clone https://github.com/metafacture/metafacture-core.git
         cd metafacture-core
-        git checkout -b 7a64c159a2e2dfc7d1673c83699254ad148f4011
-        git reset --hard 7a64c159a2e2dfc7d1673c83699254ad148f4011
+        git checkout -b f2cf79da098258a2bc034da6bf7178f704fb5db4
+        git reset --hard f2cf79da098258a2bc034da6bf7178f704fb5db4
         ./gradlew publishToMavenLocal
         cd -
     - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -178,12 +178,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.14.2</version>
+            <version>2.21.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.21.1</version>
         </dependency>
         <dependency>
             <groupId>com.ning</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-io</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-files</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-json</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -40,72 +40,72 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-biblio</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formeta</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-monitoring</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-strings</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formatting</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-elasticsearch</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-csv</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-flowcontrol</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-plumbing</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph-test</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-xml</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-mangling</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafix</artifactId>
-            <version>7a64c159a2e2dfc7d1673c83699254ad148f4011-SNAPSHOT</version>
+            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonMetafixTest.java
+++ b/src/test/java/org/lobid/resources/AlmaMarc21XmlToLobidJsonMetafixTest.java
@@ -163,7 +163,7 @@ public final class AlmaMarc21XmlToLobidJsonMetafixTest {
 
     private String getJsonStringFromFile(String filenameJson, ObjectMapper mapper) throws IOException {
         JsonNode expectedJsonNode = mapper.readTree(new File(filenameJson));
-        Object expectedJsonObject = mapper.readValue(expectedJsonNode.toString(), Object.class);
+        Object expectedJsonObject = mapper.convertValue(expectedJsonNode, Object.class);
         return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(expectedJsonObject) + "\n";
     }
 }

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -10,6 +10,7 @@ unmanagedResourceDirectories in Compile += baseDirectory.value / "../src/main/re
 libraryDependencies ++= Seq(
   cache,
   javaWs,
+  "com.google.inject" % "guice" % "6.0.0",
   "com.typesafe.play" % "play-test_2.11" % "2.4.11",
   "org.apache.logging.log4j" % "log4j-core" % "2.9.1",
   "org.elasticsearch.plugin" % "parent-join-client" % "5.6.3",
@@ -19,6 +20,8 @@ libraryDependencies ++= Seq(
   "org.xbib.elasticsearch.plugin" % "elasticsearch-plugin-bundle" % "5.4.1.0",
   "org.lobid" % "lobid-resources" % "1.0.2-SNAPSHOT" changing()
 )
+
+dependencyOverrides += "com.google.inject" % "guice" % "6.0.0"
 
 resolvers += "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2/repository"
 


### PR DESCRIPTION
See #2350 and #2348

This PR harmonizes the Jackson versions as well as enforces guice 6.0.0 as suggested by @fsteeg 

This would also fix the problems with the current metafacture master.