### PR TITLE
Adjust `dnbId` and `zdbId` mapping #2353

### DIFF
--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -135,6 +135,20 @@ do list(path:"035  ", "var":"$i")
 end
 replace_all("oclcNumber[].*", "\\(OCoLC\\)","")
 
+# 035 - System Control Number (R) - Subfield: $a (NR)
+do list(path:"035  ", "var":"$i")
+  unless exists("zdbId")
+    if all_match("$i.a", "\\(DE-600\\)(.+)")
+      copy_field("$i.a", "zdbId")
+    end
+  end
+  unless exists("dnbId")
+    if all_match("$i.a", "\\(DE-101\\)")
+    copy_field("$i.a", "dnbId")
+  end
+end
+end
+
 #160 - 016 - National Bibliographic Agency Control Number (R)
 do list(path:"0167 ", "var":"$i")
   unless exists("zdbId")
@@ -144,16 +158,9 @@ do list(path:"0167 ", "var":"$i")
   end
 
 # dnbId
-  if any_match("$i.2","DE-101")
-    copy_field("$i.a","dnbId")
-  end
-end
-
-# 035 - System Control Number (R) - Subfield: $a (NR)
-do list(path:"035  ", "var":"$i")
-  unless exists("zdbId")
-    if all_match("$i.a", "\\(DE-600\\)(.+)")
-      copy_field("$i.a", "zdbId")
+  unless exists("dnbId")
+    if any_match("$i.2","DE-101")
+      copy_field("$i.a","dnbId")
     end
   end
 end
@@ -162,7 +169,7 @@ end
 replace_all("zdbId", "\\(DE-600\\)","")
 replace_all("zdbId", "\\(DE-599\\)ZDB","")
 replace_all("zdbId", "(\\d{1,7})-* ?-*([Xx\\d])","$1-$2") # CZ entries have incorrect whitespaces sometimes in the zdbId, we need to adjust them so only one "-" separates the first group of numbers from the last number.
-
+replace_all("dnbId", "\\(DE-101\\)","")
 
 copy_field("almaMmsId","rpbId")
 lookup("rpbId","almaMmsId2rpbId",delete:"true")

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -167,10 +167,13 @@ do list(path:"0167 ", "var":"$i")
   end
 end
 
-# clean up ZDB
+# clean up ZDB & DNB id
 replace_all("zdbId", "\\(DE-600\\)","")
 replace_all("zdbId", "\\(DE-599\\)ZDB","")
 replace_all("zdbId", "(\\d{1,7})-* ?-*([Xx\\d])","$1-$2") # CZ entries have incorrect whitespaces sometimes in the zdbId, we need to adjust them so only one "-" separates the first group of numbers from the last number.
+unless any_match("zdbId","\\d{1,7}-[Xx\\d]")
+  remove_field("zdbId")
+end
 replace_all("dnbId", "\\(DE-101\\)","")
 
 copy_field("almaMmsId","rpbId")

--- a/src/main/resources/alma/fix/identifiers.fix
+++ b/src/main/resources/alma/fix/identifiers.fix
@@ -143,10 +143,10 @@ do list(path:"035  ", "var":"$i")
     end
   end
   unless exists("dnbId")
-    if all_match("$i.a", "\\(DE-101\\)")
-    copy_field("$i.a", "dnbId")
+    if all_match("$i.a", "\\(DE-101\\)(\\d{8,9}[X\\d]?)")
+      copy_field("$i.a", "dnbId")
+    end
   end
-end
 end
 
 #160 - 016 - National Bibliographic Agency Control Number (R)
@@ -160,7 +160,9 @@ do list(path:"0167 ", "var":"$i")
 # dnbId
   unless exists("dnbId")
     if any_match("$i.2","DE-101")
-      copy_field("$i.a","dnbId")
+      if any_match("$i.a","\\d{8,9}[X\\d]?")
+        copy_field("$i.a","dnbId")
+      end
     end
   end
 end

--- a/src/test/resources/alma-fix/99376075559506441.json
+++ b/src/test/resources/alma-fix/99376075559506441.json
@@ -1,0 +1,152 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99376075559506441#!",
+  "type" : [ "BibliographicResource", "Thesis", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Studien zum biologischen Giftnachweis an der Maus",
+  "almaMmsId" : "99376075559506441",
+  "hbzId" : "HT031258369",
+  "deprecatedUri" : "http://lobid.org/resources/HT031258369#!",
+  "oclcNumber" : [ "720811918" ],
+  "dnbId" : "L350270023",
+  "manufacture" : [ {
+    "dateStatement" : "1934",
+    "startDate" : "1934",
+    "type" : [ "Event" ],
+    "location" : [ "Tübingen" ],
+    "manufacturedBy" : [ "Becht" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99376075559506441",
+    "label" : "Webseite der hbz-Ressource 99376075559506441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99376075559506441",
+        "dateCreated" : "2025-08-22",
+        "dateModified" : "2026-02-05",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99376075559506441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-38M#!",
+          "label" : "ZB MED - Informationszentrum Lebenswissenschaften, Köln"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-38M#!",
+          "label" : "ZB MED - Informationszentrum Lebenswissenschaften, Köln"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-38M#!",
+          "label" : "ZB MED - Informationszentrum Lebenswissenschaften, Köln"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "natureOfContent" : [ {
+    "label" : "Hochschulschrift",
+    "id" : "https://d-nb.info/gnd/4113937-9"
+  } ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "Eu. Dis. Tübingen 1934: Guttmann",
+    "serialNumber" : "4683756-01",
+    "currentLibrary" : "KOELN",
+    "currentLocation" : "V_Eu_Diss",
+    "heldBy" : {
+      "isil" : "DE-38M",
+      "id" : "http://lobid.org/organisations/DE-38M#!",
+      "label" : "ZB MED - Informationszentrum Lebenswissenschaften, Köln"
+    },
+    "seeAlso" : [ "https://www.livivo.de/doc/99376075559506441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38M#!",
+      "label" : "ZB MED - Informationszentrum Lebenswissenschaften, Köln",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376075559506441:DE-38M:23156451990006472#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99376075559506441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/720811918",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/L350270023",
+    "label" : "DNB-Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "https://lobid.org/collections#nrwLastCopies",
+    "label" : "nrwLastCopies",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "26 Seiten",
+  "thesisInformation" : [ "Eberhard-Karls-Universität zu Tübingen, Dissertation, 1934, U 34.2412" ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "vorgelegt von Beate Guttmann" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "12533642X",
+      "id" : "https://d-nb.info/gnd/12533642X",
+      "label" : "Guttmann, Beate",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1911"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "36187-2",
+      "id" : "https://d-nb.info/gnd/36187-2",
+      "label" : "Eberhard Karls Universität Tübingen",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Eberhard-Karls-Universität Tübingen", "Eberhard-Karls-Universität", "Württembergische Eberhard-Karls-Universität", "Alma Mater Tubingensis", "Königlich Württembergische Eberhard-Karls-Universität", "K. Eberhard-Karls-Universität", "Tjubingenskij universitet Karla-Ėbercharda", "Universitet Karla-Ėbercharda", "Eberhard-Karls-Hochschule", "Königlich Württembergische Eberhard-Karls-Hochschule", "Eberhard Karls University", "Université (Tübingen)", "Württembergische Universität Tübingen", "Königliche Universität Tübingen", "Academia Tubingensis", "Academia (Tübingen)", "Universitas Tubingensis", "Universitas (Tübingen)", "Landesuniversität Tübingen", "Königlich Württembergische Universität Tübingen", "Univ. Tübingen", "University of Tübingen", "Accademia Tubingensis", "Accademia (Tübingen)", "University of Tubingen", "Tübingen University", "K. Universität Tübingen", "Königliche Eberhard-Karls-Universität", "Tuebingen University", "Universität Tübingen", "University of Tuebingen", "Ernst Bloch Universität Tübingen" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/dgg",
+      "label" : "Grad-verleihende Institution"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99376075559506441.json
+++ b/src/test/resources/alma-fix/99376075559506441.json
@@ -11,7 +11,6 @@
   "hbzId" : "HT031258369",
   "deprecatedUri" : "http://lobid.org/resources/HT031258369#!",
   "oclcNumber" : [ "720811918" ],
-  "dnbId" : "L350270023",
   "manufacture" : [ {
     "dateStatement" : "1934",
     "startDate" : "1934",
@@ -94,9 +93,6 @@
   }, {
     "id" : "http://worldcat.org/oclc/720811918",
     "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/L350270023",
-    "label" : "DNB-Ressource"
   } ],
   "inCollection" : [ {
     "id" : "https://nrw.digibib.net/search/hbzvk/",

--- a/src/test/resources/alma-fix/99376075559506441.xml
+++ b/src/test/resources/alma-fix/99376075559506441.xml
@@ -1,0 +1,508 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01122cam a2200349 c 4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20250822135759.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">250822s1934    gw ||||| m    00| | ger c</controlfield>
+  <controlfield tag="001">99376075559506441</controlfield>
+  <datafield tag="015" ind1=" " ind2=" ">
+    <subfield code="a">00,L01</subfield>
+    <subfield code="2">dnb</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">L350270023</subfield>
+    <subfield code="2">DE-101</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">720811918</subfield>
+    <subfield code="2">(OCoLC)</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT031258369</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DE-38M</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-38M</subfield>
+    <subfield code="d">DE-38M</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DXDE</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Guttmann, Beate</subfield>
+    <subfield code="d">1911-</subfield>
+    <subfield code="0">(DE-588)12533642X</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/12533642X</subfield>
+    <subfield code="0">http://viaf.org/viaf/52648570</subfield>
+    <subfield code="B">GND-12533642X</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Studien zum biologischen Giftnachweis an der Maus</subfield>
+    <subfield code="c">vorgelegt von Beate Guttmann</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="3">
+    <subfield code="a">Tübingen</subfield>
+    <subfield code="b">Becht</subfield>
+    <subfield code="c">1934</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">26 Seiten</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-627)1417860995</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-576)347860990</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)BSZ347860990</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)720811918</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">Eberhard Karls Universität Tübingen</subfield>
+    <subfield code="0">(DE-588)36187-2</subfield>
+    <subfield code="4">dgg</subfield>
+    <subfield code="0">https://d-nb.info/gnd/000361879</subfield>
+    <subfield code="0">http://viaf.org/viaf/141412593</subfield>
+    <subfield code="B">GND-000361879</subfield>
+  </datafield>
+  <datafield tag="751" ind1=" " ind2=" ">
+    <subfield code="a">Tübingen</subfield>
+    <subfield code="0">(DE-588)4061147-4</subfield>
+    <subfield code="4">uvp</subfield>
+    <subfield code="0">https://d-nb.info/gnd/040611477</subfield>
+    <subfield code="B">GND-040611477</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Hochschulschrift</subfield>
+    <subfield code="0">(DE-588)4113937-9</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="502" ind1=" " ind2=" ">
+    <subfield code="b">Dissertation</subfield>
+    <subfield code="c">Eberhard-Karls-Universität zu Tübingen</subfield>
+    <subfield code="d">1934</subfield>
+    <subfield code="o">U 34.2412</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99376075559506441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ZBM</subfield>
+    <subfield code="i">991013999320906472</subfield>
+    <subfield code="n">ZB MED</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">K10PLUS NZ</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">57</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-02-05 12:54:57 Europe/Berlin</subfield>
+    <subfield code="g">99376075559506441</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">Sawatzky######49HBZ_ZBM</subfield>
+    <subfield code="b">2025-08-22 13:55:07 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">KOELN</subfield>
+    <subfield code="c">V_Eu_Diss</subfield>
+    <subfield code="h">Eu. Dis. Tübingen 1934: Guttmann</subfield>
+    <subfield code="8">22156452010006472</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2025-08-22 11:55:52</subfield>
+    <subfield code="8">22156452010006472</subfield>
+    <subfield code="b">2025-08-22 11:55:47</subfield>
+    <subfield code="M">49HBZ_ZBM</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">Sawatzky</subfield>
+    <subfield code="c">Sawatzky</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22156452010006472</subfield>
+    <subfield code="x">V_Eu_Diss</subfield>
+    <subfield code="f">PHDTHESIS</subfield>
+    <subfield code="v">V_Eu_Diss</subfield>
+    <subfield code="p">L</subfield>
+    <subfield code="X">Sawatzky</subfield>
+    <subfield code="U">2025-08-22 13:56:26 Europe/Berlin</subfield>
+    <subfield code="Y">2025-08-22 13:56:26 Europe/Berlin</subfield>
+    <subfield code="M">49HBZ_ZBM</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">Sawatzky</subfield>
+    <subfield code="b">4683756-01</subfield>
+    <subfield code="a">23156451990006472</subfield>
+    <subfield code="c">Eu. Dis. Tübingen 1934: Guttmann</subfield>
+    <subfield code="W">2025-08-22 13:56:26 Europe/Berlin</subfield>
+    <subfield code="u">KOELN</subfield>
+    <subfield code="w">KOELN</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4061147-4</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4061147-4</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2820860</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Twingia</subfield>
+    <subfield code="9">v:1078</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tjubingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Universitätsstadt Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tubingae</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tubinga</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tüwingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Stadt Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tūbingin</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tūbingan</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tūbīnġin</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tūbīnġan</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Tūbīngin</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="9">U:Arab</subfield>
+    <subfield code="9">L:ara</subfield>
+    <subfield code="a">توبنگن</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="9">U:Arab</subfield>
+    <subfield code="9">L:ara</subfield>
+    <subfield code="a">توبينغن</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="9">U:Arab</subfield>
+    <subfield code="9">L:per</subfield>
+    <subfield code="a">توبینگن</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040611477</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">12533642X</subfield>
+    <subfield code="0">http://d-nb.info/gnd/12533642X</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-12533642X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Eberhard-Karls-Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Eberhard-Karls-Universität</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Württembergische Eberhard-Karls-Universität</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Alma Mater Tubingensis</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Königlich Württembergische Eberhard-Karls-Universität</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">K. Eberhard-Karls-Universität</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Tjubingenskij universitet Karla-Ėbercharda</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Universitet Karla-Ėbercharda</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Eberhard-Karls-Hochschule</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Königlich Württembergische Eberhard-Karls-Hochschule</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Eberhard Karls University</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Université</subfield>
+    <subfield code="g">Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Württembergische Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Königliche Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Academia Tubingensis</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Academia</subfield>
+    <subfield code="g">Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Universitas Tubingensis</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Universitas</subfield>
+    <subfield code="g">Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Landesuniversität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Königlich Württembergische Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Univ. Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">University of Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Accademia Tubingensis</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Accademia</subfield>
+    <subfield code="g">Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">University of Tubingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Tübingen University</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">K. Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Königliche Eberhard-Karls-Universität</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Tuebingen University</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">University of Tuebingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Ernst Bloch Universität Tübingen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">36187-2</subfield>
+    <subfield code="0">http://d-nb.info/gnd/36187-2</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0000 0001 2190 1447</subfield>
+    <subfield code="2">isni</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">Q153978</subfield>
+    <subfield code="2">wikidata</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">03a1kwz48</subfield>
+    <subfield code="2">ror</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-000361879</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/99376189217406441.json
+++ b/src/test/resources/alma-fix/99376189217406441.json
@@ -1,0 +1,166 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99376189217406441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Ein Weihnachtsmärchen",
+  "almaMmsId" : "99376189217406441",
+  "hbzId" : "HT031300603",
+  "deprecatedUri" : "http://lobid.org/resources/HT031300603#!",
+  "isbn" : [ "3876278201", "9783876278209" ],
+  "oclcNumber" : [ "633552607" ],
+  "dnbId" : "80A22,650",
+  "edition" : [ "2. Aufl" ],
+  "publication" : [ {
+    "dateStatement" : "1976",
+    "startDate" : "1976",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Hanau" ],
+    "publishedBy" : [ "Peters" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99376189217406441",
+    "label" : "Webseite der hbz-Ressource 99376189217406441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99376189217406441",
+        "dateCreated" : "2025-10-29",
+        "dateModified" : "2026-02-05",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99376189217406441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-361#!",
+          "label" : "Universitätsbibliothek Bielefeld"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-361#!",
+          "label" : "Universitätsbibliothek Bielefeld"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-361#!",
+          "label" : "Universitätsbibliothek Bielefeld"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "subject" : [ {
+    "notation" : "BU 4700",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "RVK (Regensburger Verbundklassifikation)",
+      "id" : "https://d-nb.info/gnd/4449787-8"
+    }
+  } ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "ON715.60 S947W(2)",
+    "inventoryNumber" : "G25",
+    "serialNumber" : "UBBI-00133326",
+    "currentLibrary" : "UB_BI",
+    "currentLocation" : "156_Mono",
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=HT031300603" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376189217406441:DE-361:23388544820006442#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99376189217406441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/633552607",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://d-nb.info/80A22,650",
+    "label" : "DNB-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "label" : "Peters-Bilderbücher"
+    } ],
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "https://lobid.org/collections#nrwLastCopies",
+    "label" : "nrwLastCopies",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "[24] S. : überwiegend Ill. (farb.)",
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Bilder von Yutaka Sugita. Text von Kurt Baumann" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "1089464398",
+      "id" : "https://d-nb.info/gnd/1089464398",
+      "label" : "Sugita, Yutaka",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1930",
+      "dateOfDeath" : "2017"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "133058425",
+      "id" : "https://d-nb.info/gnd/133058425",
+      "label" : "Baumann, Kurt",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1935",
+      "dateOfDeath" : "1988"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/oth",
+      "label" : "Sonstige"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99376189217406441.json
+++ b/src/test/resources/alma-fix/99376189217406441.json
@@ -12,7 +12,6 @@
   "deprecatedUri" : "http://lobid.org/resources/HT031300603#!",
   "isbn" : [ "3876278201", "9783876278209" ],
   "oclcNumber" : [ "633552607" ],
-  "dnbId" : "80A22,650",
   "edition" : [ "2. Aufl" ],
   "publication" : [ {
     "dateStatement" : "1976",
@@ -101,9 +100,6 @@
   }, {
     "id" : "http://worldcat.org/oclc/633552607",
     "label" : "OCLC-Ressource"
-  }, {
-    "id" : "https://d-nb.info/80A22,650",
-    "label" : "DNB-Ressource"
   } ],
   "isPartOf" : [ {
     "hasSuperordinate" : [ {

--- a/src/test/resources/alma-fix/99376189217406441.xml
+++ b/src/test/resources/alma-fix/99376189217406441.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01099cam a2200373 c 4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20251029154434.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">251029s1976    xx |||||      00| | ger c</controlfield>
+  <controlfield tag="001">99376189217406441</controlfield>
+  <datafield tag="015" ind1=" " ind2=" ">
+    <subfield code="a">80,A22,0584</subfield>
+    <subfield code="2">dnb</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">80A22,650</subfield>
+    <subfield code="2">DE-101</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">633552607</subfield>
+    <subfield code="2">(OCoLC)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">3876278201</subfield>
+    <subfield code="9">3-87627-820-1</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT031300603</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DE-361</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-361</subfield>
+    <subfield code="d">DE-361</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">BU 4700</subfield>
+    <subfield code="2">rvk</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Sugita, Yutaka</subfield>
+    <subfield code="d">1930-2017</subfield>
+    <subfield code="0">(DE-588)1089464398</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/1089464398</subfield>
+    <subfield code="0">http://viaf.org/viaf/109098145</subfield>
+    <subfield code="B">GND-1089464398</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">&lt;&lt;Ein&gt;&gt; Weihnachtsmärchen</subfield>
+    <subfield code="c">Bilder von Yutaka Sugita. Text von Kurt Baumann</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">2. Aufl.</subfield>
+  </datafield>
+  <datafield tag="263" ind1=" " ind2=" ">
+    <subfield code="a">Pp. : DM 17.80</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Hanau</subfield>
+    <subfield code="b">Peters</subfield>
+    <subfield code="c">1976</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">[24] S.</subfield>
+    <subfield code="b">überwiegend Ill. (farb.)</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="490" ind1="0" ind2=" ">
+    <subfield code="a">Peters-Bilderbücher</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-627)1606770683</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-576)081473591</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)BSZ081473591</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)633552607</subfield>
+  </datafield>
+  <datafield tag="960" ind1="1" ind2=" ">
+    <subfield code="b">Mindestkatalogisat</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Baumann, Kurt</subfield>
+    <subfield code="d">1935-1988</subfield>
+    <subfield code="0">(DE-588)133058425</subfield>
+    <subfield code="4">oth</subfield>
+    <subfield code="0">https://d-nb.info/gnd/133058425</subfield>
+    <subfield code="0">http://viaf.org/viaf/118530270</subfield>
+    <subfield code="B">GND-133058425</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99376189217406441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BIE</subfield>
+    <subfield code="i">991026241034706442</subfield>
+    <subfield code="n">Universität Bielefeld</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">K10PLUS NZ</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">74</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-02-05 19:54:39 Europe/Berlin</subfield>
+    <subfield code="g">99376189217406441</subfield>
+    <subfield code="j">50</subfield>
+    <subfield code="a">mklawunde######49HBZ_BIE</subfield>
+    <subfield code="b">2025-10-29 15:44:34 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">UB_BI</subfield>
+    <subfield code="c">156_Mono</subfield>
+    <subfield code="h">ON715.60 S947W(2)</subfield>
+    <subfield code="8">22388544840006442</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2025-10-29 14:48:07</subfield>
+    <subfield code="8">22388544840006442</subfield>
+    <subfield code="b">2025-10-29 14:48:05</subfield>
+    <subfield code="M">49HBZ_BIE</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">mklawunde</subfield>
+    <subfield code="c">mklawunde</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22388544840006442</subfield>
+    <subfield code="x">156_Mono</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">156_Mono</subfield>
+    <subfield code="p">item_00</subfield>
+    <subfield code="X">heuer</subfield>
+    <subfield code="U">2025-10-29 15:48:20 Europe/Berlin</subfield>
+    <subfield code="Y">2025-11-05 15:27:14 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="M">49HBZ_BIE</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">mklawunde</subfield>
+    <subfield code="b">UBBI-00133326</subfield>
+    <subfield code="a">23388544820006442</subfield>
+    <subfield code="c">ON715.60 S947W(2)</subfield>
+    <subfield code="B">G25</subfield>
+    <subfield code="W">2025-10-29 15:48:20 Europe/Berlin</subfield>
+    <subfield code="u">UB_BI</subfield>
+    <subfield code="w">UB_BI</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">1089464398</subfield>
+    <subfield code="0">http://d-nb.info/gnd/1089464398</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1089464398</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">133058425</subfield>
+    <subfield code="0">http://d-nb.info/gnd/133058425</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-133058425</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 23 },
+			{ "title:der", /*->*/ 24 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 5 },
@@ -73,8 +73,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.location:Koln", /*->*/ 7 },
 			{ "publication.startDate:1993", /*->*/ 4 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 196 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 223 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 198 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 225 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
Resolves #2353

As discussed with N.D. from Verbund we should prefer 035 instead of 016. I keep the 016 mapping if 035 is missing. Also introduced regex filters to ignore invalid `dnbId` and `zdbId`