### PR TITLE
Only remove duplicate tokens in the same position for DigiBib search fields.

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -53,7 +53,7 @@
               "digibib_string_normalizer",
               "snowball",
               "digibib_standardnumber",
-              "unique"
+              "digibib_remove_duplicates"
             ]
           },
           "digibib_search": {
@@ -68,7 +68,7 @@
               "digibib_string_normalizer",
               "snowball",
               "digibib_standardnumber",
-              "unique"
+              "digibib_remove_duplicates"
             ]
           },
           "digibib_unstemmed": {
@@ -82,7 +82,7 @@
               "icu_folding",
               "digibib_simple_hyphen",
               "german_normalize",
-              "unique"
+              "digibib_remove_duplicates"
             ]
           }
         },
@@ -152,6 +152,10 @@
               "zur",
               "über"
             ]
+          },
+          "digibib_remove_duplicates": {
+            "type": "unique",
+            "only_on_same_position": true
           },
           "digibib_simple_hyphen": {
             "type": "hyphen",

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -151,6 +151,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "q.all:HT072067630", /*->*/ 0 },
 			{ "q.all:(Erleben \\- Verstehen & Lernen)", /*->*/ 5 },
 			{ "q.all:(Lexicography \\: Selected Papers)", /*->*/ 1 },
+			{ "q.all:(Lernen Lernen)", /*->*/ 4 },
+			{ "q.all:\"Lernen Lernen\"", /*->*/ 4 },
 			{ "contribution.agent.label.digibib:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label.digibib:Westfälen", /*->*/ 5 },
 			{ "contribution.agent.label.digibib:Westfälisch", /*->*/ 5 },

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -152,7 +152,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "q.all:(Erleben \\- Verstehen & Lernen)", /*->*/ 5 },
 			{ "q.all:(Lexicography \\: Selected Papers)", /*->*/ 1 },
 			{ "q.all:(Lernen Lernen)", /*->*/ 4 },
-			{ "q.all:\"Lernen Lernen\"", /*->*/ 4 },
+			{ "q.all:\"Lernen Lernen\"", /*->*/ 1 },
 			{ "contribution.agent.label.digibib:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label.digibib:Westfälen", /*->*/ 5 },
 			{ "contribution.agent.label.digibib:Westfälisch", /*->*/ 5 },


### PR DESCRIPTION
Fixes searching for repeated tokens in a search field (e.g., author "Liu, Liu"; reported in [DOX-2434](https://jira.hbz-nrw.de/browse/DOX-2434)) by only removing duplicate tokens that are in the same position.

The [`unique` token filter](https://www.elastic.co/guide/en/elasticsearch/reference/2.2/analysis-unique-tokenfilter.html) was originally meant to remove duplicate tokens resulting from preceding filters, but appears to be overzealous with regard to explicitly repeated tokens in the search query or the source document (such as in titles or author names). Instead, use the [filter option](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/analysis-unique-tokenfilter.html) `only_on_same_position: true` (the equivalent [`remove_duplicates` token filter](https://www.elastic.co/guide/en/elasticsearch/reference/6.4/analysis-remove-duplicates-tokenfilter.html) is only available since Elasticsearch 6.4).

Before:

```json
{
  "tokens": [
    {
      "token": "liu",
      "start_offset": 1,
      "end_offset": 4,
      "type": "<ALPHANUM>",
      "position": 0
    }
  ]
}
```

After:

```json
{
  "tokens": [
    {
      "token": "liu",
      "start_offset": 1,
      "end_offset": 4,
      "type": "<ALPHANUM>",
      "position": 0
    },
    {
      "token": "liu",
      "start_offset": 6,
      "end_offset": 9,
      "type": "<ALPHANUM>",
      "position": 1
    }
  ]
}
```