### PR TITLE
Show holdings also for eResources and resources with superordination #1865

### DIFF
--- a/web/app/views/details.scala.html
+++ b/web/app/views/details.scala.html
@@ -70,7 +70,7 @@
             </table>
             </dd>
             }
-            @if(!superordination && !items.isEmpty && !doc.toString.contains("fulltextOnline")){
+            @if(!items.isEmpty){
              @defining(items.size){num =>
              <dt>Bestand in @num Bibliothek@if(num>1){en}:</dt>
              }


### PR DESCRIPTION
Resolves #1865

This often helps with debugging, since it shows that there are items connected to the records.

In order to highlight the Free link, we could Improve the GUI label from "Freie Online-Ressource:"

http://lobid.org/resources/990134555090206441

Without the change:
<img width="1217" height="516" alt="grafik" src="https://github.com/user-attachments/assets/cbe03a5f-1df0-4e8d-9895-40999cff8ad1" />

With the change of this PR:
http://quaoar13.hbz-nrw.de:7508/resources/990134555090206441
<img width="1257" height="591" alt="grafik" src="https://github.com/user-attachments/assets/26bd6e67-151b-4376-8528-a4c5bec6573c" />



http://lobid.org/resources/990368617770206441

Without the change:
<img width="1245" height="460" alt="grafik" src="https://github.com/user-attachments/assets/79deef52-7d13-4dd7-9944-befb63edab3f" />

With the change of this PR:

http://quaoar13.hbz-nrw.de:7508/resources/990368617770206441
<img width="1226" height="457" alt="grafik" src="https://github.com/user-attachments/assets/ebad8b17-2289-4829-a7ae-cbb2cb44365d" />
