### PR TITLE
Add new verbund ids to index #2365

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -393,6 +393,30 @@
             "q.all"
           ]
         },
+        "bvbId": {
+          "analyzer": "id_analyzer",
+          "type": "text"
+        },
+        "bzsId": {
+          "analyzer": "id_analyzer",
+          "type": "text"
+        },
+        "gbvId": {
+          "analyzer": "id_analyzer",
+          "type": "text"
+        },
+        "k10PlusId": {
+          "analyzer": "id_analyzer",
+          "type": "text"
+        },
+        "kobvId": {
+          "analyzer": "id_analyzer",
+          "type": "text"
+        },
+        "obvId": {
+          "analyzer": "id_analyzer",
+          "type": "text"
+        },
         "rpbId": {
           "analyzer": "id_analyzer",
           "type": "text"


### PR DESCRIPTION
@dr0i we need these ids for https://github.com/hbz/schlagwortfolgen-harvester/issues/1 
`hebisId` was already indexed, since it was introduced by @fsteeg in context of rpb.