### PR TITLE
Fix `bszId` indexing #1365

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -397,7 +397,7 @@
           "analyzer": "id_analyzer",
           "type": "text"
         },
-        "bzsId": {
+        "bszId": {
           "analyzer": "id_analyzer",
           "type": "text"
         },


### PR DESCRIPTION
`bszId`  was not indexed due to a typo in the `index-config.json`