### PR TITLE
Use english label as fallback for missing marc relator labels #2382

### DIFF
--- a/src/main/resources/alma/fix/contribution.fix
+++ b/src/main/resources/alma/fix/contribution.fix
@@ -351,7 +351,11 @@ do list (path: "contribution[]", "var": "$i")
   remove_field("$i.agent.@gndIdn")
 
   copy_field("$i.role.id", "$i.role.label")
-  lookup("$i.role.label","marc-relators")
+  lookup("$i.role.label","marc-relators","default":"NichtÜbersetzt" )
+  if all_equal("$i.role.label","NichtÜbersetzt") # Use english label as fallback when DNB did not provide any translation
+    copy_field("$i.role.id", "$i.role.label")
+    lookup("$i.role.label","marc-relators-english")
+  end
 
   replace_all("$i.agent.label","<<|>>","")
   uniq("$i.agent.altLabel[]")

--- a/src/main/resources/alma/fix/maps.fix
+++ b/src/main/resources/alma/fix/maps.fix
@@ -138,6 +138,8 @@ put_filemap("$[isil2opac_almaMmsId.tsv]","isil2opac_almaMmsId", sep_char:"\t")
 # dynamic map from git submodule: lookup-tables/data/marc-relators.tsv
 # generated, based on based on https://www.loc.gov/marc/relators/ loc version has no german language tags and RDA Arbeitshilfe
 put_filemap("$[marc-relators.tsv]","marc-relators", sep_char:"\t",key_column:"0",value_column:"4",expected_columns:"-1")
+put_filemap("$[marc-relators.tsv]","marc-relators-english", sep_char:"\t",key_column:"0",value_column:"3",expected_columns:"-1")
+
 
 # hbz and alma internal collection labels map
 # static map: src/main/resources/alma/maps/collectionLabels.tsv

--- a/src/test/resources/alma-fix/99376800349906441.json
+++ b/src/test/resources/alma-fix/99376800349906441.json
@@ -151,7 +151,7 @@
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/edd",
-      "label" : "http://id.loc.gov/vocabulary/relators/edd"
+      "label" : "Editorial director"
     },
     "type" : [ "Contribution" ]
   }, {
@@ -161,7 +161,7 @@
     },
     "role" : {
       "id" : "http://id.loc.gov/vocabulary/relators/edd",
-      "label" : "http://id.loc.gov/vocabulary/relators/edd"
+      "label" : "Editorial director"
     },
     "type" : [ "Contribution" ]
   }, {

--- a/src/test/resources/alma-fix/99376800349906441.json
+++ b/src/test/resources/alma-fix/99376800349906441.json
@@ -1,0 +1,181 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99376800349906441#!",
+  "type" : [ "BibliographicResource", "PublicationIssue", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Der Saal Löwer in der Alten Brauerei Löwer",
+  "almaMmsId" : "99376800349906441",
+  "hbzId" : "HT031447695",
+  "deprecatedUri" : "http://lobid.org/resources/HT031447695#!",
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99376800349906441",
+    "label" : "Webseite der hbz-Ressource 99376800349906441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99376800349906441",
+        "dateCreated" : "2026-04-16",
+        "dateModified" : "2026-04-17",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99376800349906441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-929#!",
+          "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-929#!",
+          "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-929#!",
+          "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "subject" : [ {
+    "notation" : "330",
+    "type" : [ "Concept" ],
+    "id" : "https://w3id.org/lobid/rpb2#n330",
+    "label" : "Geschichte",
+    "source" : {
+      "id" : "https://w3id.org/lobid/rpb2",
+      "label" : "LBZ-Notationen"
+    }
+  }, {
+    "notation" : "131",
+    "type" : [ "Concept" ],
+    "id" : "https://w3id.org/lobid/rpb2#n131",
+    "label" : "Landeskunde Pfalz",
+    "source" : {
+      "id" : "https://w3id.org/lobid/rpb2",
+      "label" : "LBZ-Notationen"
+    }
+  }, {
+    "notation" : "141",
+    "type" : [ "Concept" ],
+    "id" : "https://w3id.org/lobid/rpb2#n141",
+    "label" : "Pflichtexemplar Pfalz",
+    "source" : {
+      "id" : "https://w3id.org/lobid/rpb2",
+      "label" : "LBZ-Notationen"
+    }
+  } ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "Per. 17551/21.2024,1=148",
+    "serialNumber" : "015769606107",
+    "currentLibrary" : "PLB",
+    "currentLocation" : "PLB_INT",
+    "heldBy" : {
+      "isil" : "DE-929",
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek"
+    },
+    "seeAlso" : [ "https://lbz-rlp.digibib.net/search/katalog/record/(DE-605)HT031447695" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-929#!",
+      "label" : "Landesbibliothekszentrum Rheinland-Pfalz / Rheinische Landesbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376800349906441:DE-929:23244234540008973#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99376800349906441",
+    "label" : "Culturegraph-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT021741282#!",
+      "label" : "Der Saal Löwer in der Alten Brauerei Löwer"
+    } ],
+    "numbering" : "1",
+    "type" : [ "IsPartOfRelation" ]
+  }, {
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/ZDB-2185253-4#!",
+      "label" : "Haßlocher Heimatblätter"
+    } ],
+    "numbering" : "21,1",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "92 Seiten : Illustrationen",
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Herausgeber: Heimatmuseum Haßloch ; Redaktion: Dr. Wolfgang Hubach, Ursula Müller" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "132472988",
+      "id" : "https://d-nb.info/gnd/132472988",
+      "label" : "Hubach, Wolfgang",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1934"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edd",
+      "label" : "http://id.loc.gov/vocabulary/relators/edd"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "label" : "Müller, Ursula",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edd",
+      "label" : "http://id.loc.gov/vocabulary/relators/edd"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "10101730-3",
+      "id" : "https://d-nb.info/gnd/10101730-3",
+      "label" : "Heimatmuseum Haßloch",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Heimatmuseum Ältestes Haus Haßloch" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/edt",
+      "label" : "Herausgeber/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99376800349906441.xml
+++ b/src/test/resources/alma-fix/99376800349906441.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01052nam a2200313 cc4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">260416|2024    gw            ||| | ger c</controlfield>
+  <controlfield tag="005">20260416123614.0</controlfield>
+  <controlfield tag="001">99376800349906441</controlfield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DE-929</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-929</subfield>
+    <subfield code="d">DE-929</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DE</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">330</subfield>
+    <subfield code="2">rpb</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">131</subfield>
+    <subfield code="2">rpb</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">141</subfield>
+    <subfield code="2">rpb</subfield>
+  </datafield>
+  <datafield tag="110" ind1="2" ind2=" ">
+    <subfield code="a">Heimatmuseum Haßloch</subfield>
+    <subfield code="0">(DE-588)10101730-3</subfield>
+    <subfield code="4">edt</subfield>
+    <subfield code="0">https://d-nb.info/gnd/974491497</subfield>
+    <subfield code="0">http://viaf.org/viaf/135856626</subfield>
+    <subfield code="B">GND-974491497</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">&lt;&lt;Der&gt;&gt; Saal Löwer in der Alten Brauerei Löwer</subfield>
+    <subfield code="c">Herausgeber: Heimatmuseum Haßloch ; Redaktion: Dr. Wolfgang Hubach, Ursula Müller</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">92 Seiten</subfield>
+    <subfield code="b">Illustrationen</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Haßlocher Heimatblätter</subfield>
+    <subfield code="v">21. Jahrgang, Heft 1 (2024) = (148)</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Haßlocher Heimatblätter</subfield>
+    <subfield code="w">(DE-600)2185253-4</subfield>
+    <subfield code="v">21,1</subfield>
+    <subfield code="9">O:1</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Hubach, Wolfgang</subfield>
+    <subfield code="d">1934-</subfield>
+    <subfield code="0">(DE-588)132472988</subfield>
+    <subfield code="4">edd</subfield>
+    <subfield code="0">https://d-nb.info/gnd/132472988</subfield>
+    <subfield code="0">http://viaf.org/viaf/7975277</subfield>
+    <subfield code="B">GND-132472988</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Müller, Ursula</subfield>
+    <subfield code="4">edd</subfield>
+  </datafield>
+  <datafield tag="773" ind1="0" ind2="8">
+    <subfield code="w">(DE-605)HT021741282</subfield>
+    <subfield code="q">1</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT031447695</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT031447695</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99376800349906441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_LBZ</subfield>
+    <subfield code="i">991019940207608973</subfield>
+    <subfield code="n">Landesbibliothekszentrum RLP (LBZ)</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">49HBZ_NETWORK</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">55</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-04-17 04:10:57 Europe/Berlin</subfield>
+    <subfield code="g">99376800349906441</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">dcuraba######49HBZ_LBZ</subfield>
+    <subfield code="b">2026-04-16 12:36:14 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">PLB</subfield>
+    <subfield code="c">PLB_INT</subfield>
+    <subfield code="h">Per. 17551/21.2024,1=148</subfield>
+    <subfield code="8">22244234560008973</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2026-04-16 10:36:59</subfield>
+    <subfield code="8">22244234560008973</subfield>
+    <subfield code="b">2026-04-16 10:36:57</subfield>
+    <subfield code="M">49HBZ_LBZ</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">dcuraba</subfield>
+    <subfield code="c">dcuraba</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22244234560008973</subfield>
+    <subfield code="x">PLB_INT</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">PLB_INT</subfield>
+    <subfield code="p">S</subfield>
+    <subfield code="X">tschwarz</subfield>
+    <subfield code="Y">2026-05-27 13:09:56 Europe/Berlin</subfield>
+    <subfield code="M">49HBZ_LBZ</subfield>
+    <subfield code="s">0</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">dcuraba</subfield>
+    <subfield code="b">015769606107</subfield>
+    <subfield code="a">23244234540008973</subfield>
+    <subfield code="c">Per. 17551/21.2024,1=148</subfield>
+    <subfield code="r">LOAN</subfield>
+    <subfield code="W">2026-04-16 12:37:49 Europe/Berlin</subfield>
+    <subfield code="u">PLB</subfield>
+    <subfield code="w">PLB</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Heimatmuseum Ältestes Haus Haßloch</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-974491497</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">10101730-3</subfield>
+    <subfield code="0">http://d-nb.info/gnd/10101730-3</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-974491497</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">132472988</subfield>
+    <subfield code="0">http://d-nb.info/gnd/132472988</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-132472988</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 24 },
+			{ "title:der", /*->*/ 25 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 5 },
@@ -73,8 +73,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.location:Koln", /*->*/ 7 },
 			{ "publication.startDate:1993", /*->*/ 4 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 203 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 230 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 204 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 231 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
@acka47 this is an idea how we would have id as labels for the marc relators.

We could use the english label as fallback. Until DNB is providing labels for the relator codes.