### PR TITLE
Add encoding to URLDecoder.decode

### DIFF
--- a/web/app/views/api.scala.html
+++ b/web/app/views/api.scala.html
@@ -87,9 +87,9 @@ $('input.search-resources').autocomplete({
 	<p>Wöchentlich wird ein <a href="https://lobid.org/download/dumps/lobid-resources/"> Vollabzug (aka "dump") der Daten und täglich Updates auf dem Webserver zum einfachen und schnellen Download angeboten.</a> Die Daten sind im Format JSON lines.</p>
 
 	<p>Bulk-Downloads können auch über die API im Format JSON lines (Accept: application/x-jsonlines oder format=jsonl) bezogen werden:</p>
-	<p><code>curl --header "Accept: application/x-jsonlines" "https://lobid.org@java.net.URLDecoder.decode(resources.routes.Application.query("contribution.agent.label:Melville").toString)" > melville.jsonl</code></p>
+	<p><code>curl --header "Accept: application/x-jsonlines" "https://lobid.org@java.net.URLDecoder.decode(resources.routes.Application.query("contribution.agent.label:Melville").toString, "UTF-8")" > melville.jsonl</code></p>
 	<p>Für größere Anfragen kann die Antwort als gzip komprimiert werden:</p>
-	<p><code>curl --header "Accept-Encoding: gzip" "https://lobid.org@java.net.URLDecoder.decode(resources.routes.Application.query("contribution.agent.label:Melville", format="jsonl").toString)" > melville.jsonl.gz</code></p>
+	<p><code>curl --header "Accept-Encoding: gzip" "https://lobid.org@java.net.URLDecoder.decode(resources.routes.Application.query("contribution.agent.label:Melville", format="jsonl").toString, "UTF-8")" > melville.jsonl.gz</code></p>
 	<p>Siehe auch diesen Abschnitt zu <a href="https://blog.lobid.org/2018/07/02/lobid-update.html#bulk-downloads">Bulk-Downloads in unserem Blog</a>.</p>
 
 	<h2 id="auto-complete">Autovervollständigung <small><a href='#auto-complete'><span class='glyphicon glyphicon-link'></span></a></small></h2>


### PR DESCRIPTION
The build has thrown warning that URLDecoder.decode without encoding is deprecated.

This PR changes the same thing as e.g. here https://github.com/hbz/lobid-gnd/commit/d9a0ec3154bcd53df2a34e6770487e5c983121d4