### PR TITLE
Use java 21 and mf with java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
       MAVEN_OPTS: "-Xmx768M"
     steps:
     - uses: actions/checkout@v7
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v6
@@ -24,13 +24,12 @@ jobs:
         cd ..
         git clone https://github.com/metafacture/metafacture-core.git
         cd metafacture-core
-        git checkout -b f2cf79da098258a2bc034da6bf7178f704fb5db4
-        git reset --hard f2cf79da098258a2bc034da6bf7178f704fb5db4
+        git checkout -b 765-raiseJavaVersionTo21
         ./gradlew publishToMavenLocal
         cd -
     - name: Build with Maven
       run: |
-        mvn install
+        mvn clean install
         mvn editorconfig:check
     - name: Install the JSON Schema CLI
       uses: sourcemeta/jsonschema@v15.11.0
@@ -52,4 +51,6 @@ jobs:
     - name: Build and Test with play
       run: |
         cd web
+        export JAVA_OPTS="--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED; --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
+        sbt clean -Djava.security.manager=allow
         sbt  --java-home $JAVA_HOME test

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <target.jdk>11</target.jdk>
+        <target.jdk>21</target.jdk>
         <junit.version>4.8.2</junit.version>
         <logback.version>1.3.14</logback.version>
     </properties>
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-io</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-files</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-json</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -40,72 +40,72 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-biblio</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formeta</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-monitoring</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-strings</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formatting</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-elasticsearch</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-csv</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-flowcontrol</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-plumbing</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph-test</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-xml</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-mangling</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafix</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>765-raiseJavaVersionTo21-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -27,9 +27,12 @@ resolvers += "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-javacOptions ++= Seq("-source", "11", "-target", "11")
+javacOptions ++= Seq("-source", "21", "-target", "21")
 javaOptions in (Test,run) += "--add-opens=java.base/java.lang=ALL-UNNAMED"
 javaOptions in (Test,run) += "--add-opens=java.base/java.util=ALL-UNNAMED"
+javaOptions in (Test,run) += "--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
+javaOptions in (Test,run) += "--add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
+
 
 import com.typesafe.sbteclipse.core.EclipsePlugin.EclipseKeys
 


### PR DESCRIPTION
@dr0i this is what i changed and I used:

Build lobid-resources:

- `git clone https://github.com/hbz/lobid-resources.git`
- `cd lobid-resources`
- `mvn clean install`

Build the web application:

- `cd web`
- `export JAVA_OPTS="--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED; --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"`
- `sbt clean -Djava.security.manager=allow`
- `sbt stage -Djava.security.manager=allow`
- `./target/universal/stage/bin/lobid-resources-web -no-version-check`

With the addition of the adding of the ` JAVA_OPTS`-step it works. See: https://github.com/metafacture/metafacture-core/issues/765#issuecomment-4989798456 and https://github.com/metafacture/metafacture-core/issues/765#issuecomment-4989308481

---
SOLVED:
~~CSS is not loading:~~
<img width="1691" height="829" alt="grafik" src="https://github.com/user-attachments/assets/ea8f1259-65a0-41b0-a852-771118f5edbc" />
