### PR TITLE
Include title keywords in DigiBib title search.

### DIFF
--- a/src/main/resources/alma/index-config.json
+++ b/src/main/resources/alma/index-config.json
@@ -639,7 +639,8 @@
           "type": "text",
           "analyzer": "german_analyzer",
           "copy_to": [
-            "q.all"
+            "q.all",
+            "q.title"
           ]
         },
         "label": {

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -136,6 +136,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "q.subject:4042570-8", /*->*/ 3 },
 			{ "q.title:der", /*->*/ 0 },
 			{ "q.title:Westfalen", /*->*/ 8 },
+			{ "q.title:Köln", /*->*/ 2 },
 			{ "q.title:Eilendorf", /*->*/ 1 },
 			{ "q.all:Federale", /*->*/ 6 },
 			{ "q.all:Fédérale", /*->*/ 6 },

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -136,7 +136,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "q.subject:4042570-8", /*->*/ 3 },
 			{ "q.title:der", /*->*/ 0 },
 			{ "q.title:Westfalen", /*->*/ 8 },
-			{ "q.title:Köln", /*->*/ 2 },
+			{ "q.title:Köln", /*->*/ 4 },
 			{ "q.title:Eilendorf", /*->*/ 1 },
 			{ "q.all:Federale", /*->*/ 6 },
 			{ "q.all:Fédérale", /*->*/ 6 },


### PR DESCRIPTION
We had a customer request for the DigiBib union catalogue (`hbz-Support-Ticket#2353753`) which would benefit from title keywords (`titleKeyword`, based on MARC `246` = Varying Form of Title) being included in the title search field (`q.title`).