### PR TITLE
Fix manufacture dates that break indexing #2390

### DIFF
--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -423,9 +423,13 @@ end
 # Clean manufacture
 
 do list(path: "manufacture[]","var":"$i")
+  replace_all("$i.startDate", ".*?([01]\\d{3}|20\\d{2}).*", "$1")
+  replace_all("$i.endDate", ".*-.*([01]\\d{3}|20\\d{2}).*$", "$1")
   replace_all("$i.location[].*", "^\\[(.*)\\]$", "$1")
   replace_all("$i.location[].*", "\\s?[,:;]$", "")
   replace_all("$i.manufacturedBy[].*", "^[©]|\\s?[,:;/=]?$", "")
+  call_macro("leapYearAndMonthLenghtChecker",date:"$i.startDate")
+  call_macro("leapYearAndMonthLenghtChecker",date:"$i.endDate")
   uniq("$i.location[]")
 end
 

--- a/src/test/resources/alma-fix/990034042840206441.json
+++ b/src/test/resources/alma-fix/990034042840206441.json
@@ -14,7 +14,7 @@
   "otherTitleInformation" : [ "vom Landstädtchen zur Badestadt ; 1945 - 1961" ],
   "manufacture" : [ {
     "dateStatement" : "1961[?]",
-    "startDate" : "1961?",
+    "startDate" : "1961",
     "type" : [ "Event" ],
     "location" : [ "Bielefeld" ],
     "manufacturedBy" : [ "Elbracht" ]

--- a/src/test/resources/alma-fix/990034042840206441.json
+++ b/src/test/resources/alma-fix/990034042840206441.json
@@ -1,0 +1,218 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990034042840206441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Bad Driburg",
+  "almaMmsId" : "990034042840206441",
+  "hbzId" : "HT008542783",
+  "deprecatedUri" : "http://lobid.org/resources/HT008542783#!",
+  "oclcNumber" : [ "1106901167" ],
+  "otherTitleInformation" : [ "vom Landstädtchen zur Badestadt ; 1945 - 1961" ],
+  "manufacture" : [ {
+    "dateStatement" : "1961[?]",
+    "startDate" : "1961?",
+    "type" : [ "Event" ],
+    "location" : [ "Bielefeld" ],
+    "manufacturedBy" : [ "Elbracht" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990034042840206441",
+    "label" : "Webseite der hbz-Ressource 990034042840206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990034042840206441",
+        "dateCreated" : "1998-06-15",
+        "dateModified" : "2026-08-17",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990034042840206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-385#!",
+          "label" : "Universitätsbibliothek Trier"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "ONH/g49933",
+    "inventoryNumber" : "S181-5699",
+    "serialNumber" : "0040.8722.88",
+    "currentLibrary" : "TF011",
+    "currentLocation" : "45",
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990034042840206441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990034042840206441:DE-385:23251056950006470#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "AB 11006",
+    "serialNumber" : "AB 11006",
+    "currentLibrary" : "ZB",
+    "currentLocation" : "ZB_GMAG",
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990034042840206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990034042840206441:DE-6:23475211890006449#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "SR46",
+    "inventoryNumber" : "01/19042",
+    "serialNumber" : "SR46",
+    "currentLibrary" : "P0001",
+    "currentLocation" : "03",
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr[q,any]=990034042840206441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990034042840206441:DE-466:23153363700006463#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLibrary" : "Z9030",
+    "currentLocation" : "UNASSIGNED",
+    "heldBy" : {
+      "isil" : "DE-60",
+      "id" : "http://lobid.org/organisations/DE-60#!",
+      "label" : "Stadt- und Landesbibliothek Dortmund"
+    },
+    "seeAlso" : [ "https://stlb-dortmund.digibib.net/search/katalog/record/(DE-605)HT008542783" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/BRIDGE_FIZ-7816#!",
+      "label" : "Bibliotheken ohne zentrale Katalogisierung (IZ Bridge)",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990034042840206441:DE-60:2221002320007816#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysikalischerTitel" ],
+    "currentLibrary" : "O9023",
+    "currentLocation" : "UNASSIGNED",
+    "heldBy" : {
+      "isil" : "DE-211",
+      "id" : "http://lobid.org/organisations/DE-211#!",
+      "label" : "Erzbischöfliche Akademische Bibliothek Paderborn"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/BRIDGE_FIZ-7816#!",
+      "label" : "Bibliotheken ohne zentrale Katalogisierung (IZ Bridge)",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990034042840206441:DE-211:2221002270007816#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990034042840206441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1106901167",
+    "label" : "OCLC-Ressource"
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://digitale-objekte.hbz-nrw.de/storage/2008/10/15/file_51/2582260.pdf"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "https://lobid.org/collections#nrwLastCopies",
+    "label" : "nrwLastCopies",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "59 S. : zahlr. Ill., graph. Darst.",
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "[Hrsg.: Die Stadt Bad Driburg. Bearb.: Ursula Wichert-Pollmann]" ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Wichert-Pollmann, Ursula",
+      "type" : [ "Person" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/oth",
+      "label" : "Sonstige"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "4013012-5",
+      "id" : "https://d-nb.info/gnd/4013012-5",
+      "label" : "Bad Driburg",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Driburg" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990034042840206441.xml
+++ b/src/test/resources/alma-fix/990034042840206441.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01096nam a2200289 c 4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20260816210612.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">980615|1961    gw            ||| | ger c</controlfield>
+  <controlfield tag="001">990034042840206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1106901167</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT008542783</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">HBZ/Off</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-605</subfield>
+    <subfield code="d">385</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DE</subfield>
+  </datafield>
+  <datafield tag="110" ind1="1" ind2=" ">
+    <subfield code="a">Bad Driburg</subfield>
+    <subfield code="0">(DE-588)4013012-5</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/040130126</subfield>
+    <subfield code="0">http://viaf.org/viaf/122629897</subfield>
+    <subfield code="B">GND-040130126</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Bad Driburg</subfield>
+    <subfield code="b">vom Landstädtchen zur Badestadt ; 1945 - 1961</subfield>
+    <subfield code="c">[Hrsg.: Die Stadt Bad Driburg. Bearb.: Ursula Wichert-Pollmann]</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="3">
+    <subfield code="a">Bielefeld</subfield>
+    <subfield code="b">Elbracht</subfield>
+    <subfield code="c">1961[?]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">59 S. : zahlr. Ill., graph. Darst.</subfield>
+  </datafield>
+  <datafield tag="965" ind1=" " ind2=" ">
+    <subfield code="u">https://digitale-objekte.hbz-nrw.de/storage/2008/10/15/file_51/2582260.pdf</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1106901167</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT008542783</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||27</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">m|||||||</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="m">V:DE-605;X:migimw</subfield>
+    <subfield code="q">application/pdf</subfield>
+    <subfield code="u">https://digitale-objekte.hbz-nrw.de/storage/2008/10/15/file_51/2582260.pdf</subfield>
+    <subfield code="3">Inhaltsverzeichnis</subfield>
+    <subfield code="9">O:PKN</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Wichert-Pollmann, Ursula</subfield>
+    <subfield code="4">oth</subfield>
+    <subfield code="e">Bearb.</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990034042840206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BRIDGE_FIZ</subfield>
+    <subfield code="i">9959158207816</subfield>
+    <subfield code="n">Bibliotheken ohne zentrale Katalogisierung</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="i">990011381810106470</subfield>
+    <subfield code="n">UB Trier</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="i">991038052339706449</subfield>
+    <subfield code="n">Universität Münster</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="i">990007665050106463</subfield>
+    <subfield code="n">Universitätsbibliothek Paderborn</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">OTHER</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="h">20210407170610.0</subfield>
+    <subfield code="l">53</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-08-17 04:51:57 Europe/Berlin</subfield>
+    <subfield code="g">003404284-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-06 02:42:57 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">Z9030</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">2221002320007816</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-10 12:17:17</subfield>
+    <subfield code="8">2221002320007816</subfield>
+    <subfield code="b">2023-02-10 12:17:17</subfield>
+    <subfield code="M">49HBZ_BRIDGE_FIZ</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="0" ind2=" ">
+    <subfield code="b">O9023</subfield>
+    <subfield code="c">UNASSIGNED</subfield>
+    <subfield code="8">2221002270007816</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-02-10 12:17:17</subfield>
+    <subfield code="8">2221002270007816</subfield>
+    <subfield code="b">2023-02-10 12:17:17</subfield>
+    <subfield code="M">49HBZ_BRIDGE_FIZ</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">System</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">TF011</subfield>
+    <subfield code="c">45</subfield>
+    <subfield code="h">ONH/g49933</subfield>
+    <subfield code="8">22251056960006470</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-12-10 18:26:45</subfield>
+    <subfield code="8">22251056960006470</subfield>
+    <subfield code="b">2023-08-13 13:58:30</subfield>
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22251056960006470</subfield>
+    <subfield code="x">45</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">45</subfield>
+    <subfield code="p">20</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2003-08-01 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2023-12-10 19:26:45 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">ONH/g49933</subfield>
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">0040.8722.88</subfield>
+    <subfield code="a">23251056950006470</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="c">ONH/g49933</subfield>
+    <subfield code="B">S181-5699</subfield>
+    <subfield code="D">20030801</subfield>
+    <subfield code="W">2003-08-01 02:00:00 Europe/Berlin</subfield>
+    <subfield code="u">TF011</subfield>
+    <subfield code="w">TF011</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">ZB</subfield>
+    <subfield code="c">ZB_GMAG</subfield>
+    <subfield code="h">AB 11006</subfield>
+    <subfield code="8">22475211910006449</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2022-07-11 07:42:18</subfield>
+    <subfield code="8">22475211910006449</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22475211910006449</subfield>
+    <subfield code="x">ZB_GMAG</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">ZB_GMAG</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2022-07-10 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2025-02-24 18:46:29 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">AB 11006</subfield>
+    <subfield code="a">23475211890006449</subfield>
+    <subfield code="c">AB 11006</subfield>
+    <subfield code="W">2022-07-11 09:42:18 Europe/Berlin</subfield>
+    <subfield code="u">ZB</subfield>
+    <subfield code="w">ZB</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">P0001</subfield>
+    <subfield code="c">03</subfield>
+    <subfield code="8">22153363710006463</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2022-07-14 10:48:51</subfield>
+    <subfield code="8">22153363710006463</subfield>
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22153363710006463</subfield>
+    <subfield code="x">03</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">03</subfield>
+    <subfield code="p">21</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2002-04-17 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2022-07-14 12:50:06 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">SR46</subfield>
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">SR46</subfield>
+    <subfield code="a">23153363700006463</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="R">Maintenance count: 002</subfield>
+    <subfield code="B">01/19042</subfield>
+    <subfield code="D">20020417</subfield>
+    <subfield code="W">2002-04-17 02:00:00 Europe/Berlin</subfield>
+    <subfield code="u">P0001</subfield>
+    <subfield code="w">P0001</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4013012-5</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4013012-5</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040130126</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2953525</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040130126</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Driburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040130126</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/990113148100206441.json
+++ b/src/test/resources/alma-fix/990113148100206441.json
@@ -1,0 +1,162 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990113148100206441#!",
+  "type" : [ "BibliographicResource", "Periodical" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Bericht über die Verwaltung und den Stand der Gemeindeangelegenheiten der Kreisstadt Wanzleben",
+  "almaMmsId" : "990113148100206441",
+  "oclcNumber" : [ "1368126942" ],
+  "zdbId" : "2011698-6",
+  "dnbId" : "020356471",
+  "deprecatedUri" : "http://lobid.org/resources/HT012987746#!",
+  "hbzId" : "HT012987746",
+  "alternativeTitle" : [ "Bericht über die Verwaltung und den Stand der Gemeinde-Angelegenheiten der Stadt Wanzleben ( Haupttitel 1901/1902-[?] )" ],
+  "otherTitleInformation" : [ "für die Zeit ..." ],
+  "publication" : [ {
+    "dateStatement" : "[1903?-1931?]",
+    "startDate" : "1903",
+    "endDate" : "1931",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Wanzleben" ],
+    "publishedBy" : [ "[Verlag nicht ermittelbar]" ],
+    "publicationHistory" : "1901/1902 [?]-1928/1931 [?]",
+    "frequency" : [ {
+      "id" : "http://marc21rdf.info/terms/continuingfre#u",
+      "label" : "unbekannte Erscheinungsfrequenz"
+    } ],
+    "status" : {
+      "id" : "http://id.loc.gov/vocabulary/mstatus/ceased",
+      "label" : "eingestellt"
+    }
+  } ],
+  "manufacture" : [ {
+    "type" : [ "Event" ],
+    "location" : [ "Wanzleben" ],
+    "manufacturedBy" : [ "Druck von Ludwig Wölfer" ]
+  }, {
+    "dateStatement" : "1903-1910",
+    "startDate" : "1903-1910",
+    "endDate" : "1903-1910",
+    "type" : [ "Event" ],
+    "location" : [ "Wanzleben" ],
+    "manufacturedBy" : [ "A. Colbatzky Nachf." ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990113148100206441",
+    "label" : "Webseite der hbz-Ressource 990113148100206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990113148100206441",
+        "dateCreated" : "2000-05-02",
+        "dateModified" : "2026-08-11",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990113148100206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-3#!",
+          "label" : "Universitäts- und Landesbibliothek Sachsen-Anhalt / Zentrale"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-101#!",
+          "label" : "Deutsche Nationalbibliothek"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-101#!",
+          "label" : "Deutsche Nationalbibliothek"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "natureOfContent" : [ {
+    "label" : "Zeitschrift",
+    "id" : "https://d-nb.info/gnd/4067488-5"
+  } ],
+  "subject" : [ {
+    "notation" : "340",
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "DDC-Sachgruppen der ZDB",
+      "id" : "https://zeitschriftendatenbank.de/fileadmin/user_upload/ZDB/pdf/zdbformat/5080.pdf"
+    },
+    "label" : "Recht"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "Recht",
+    "notation" : "340",
+    "version" : "sdnb"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990113148100206441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1368126942",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2011698-6",
+    "label" : "ZDB-Ressource"
+  }, {
+    "id" : "https://d-nb.info/020356471",
+    "label" : "DNB-Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/resources/HT014846970#!",
+    "label" : "Zeitschriftendatenbank (ZDB)",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "bibliographicLevel" : {
+    "label" : "Serial",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Serial"
+  },
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "4329661-0",
+      "id" : "https://d-nb.info/gnd/4329661-0",
+      "label" : "Wanzleben",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Groß-Wanzleben" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990113148100206441.json
+++ b/src/test/resources/alma-fix/990113148100206441.json
@@ -38,8 +38,8 @@
     "manufacturedBy" : [ "Druck von Ludwig Wölfer" ]
   }, {
     "dateStatement" : "1903-1910",
-    "startDate" : "1903-1910",
-    "endDate" : "1903-1910",
+    "startDate" : "1903",
+    "endDate" : "1910",
     "type" : [ "Event" ],
     "location" : [ "Wanzleben" ],
     "manufacturedBy" : [ "A. Colbatzky Nachf." ]

--- a/src/test/resources/alma-fix/990113148100206441.xml
+++ b/src/test/resources/alma-fix/990113148100206441.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01370nas a2200349#c 4500</leader>
+  <controlfield tag="005">20171201134355.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">000502d19031931xx u||p|  ||| 0||||1ger c</controlfield>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="001">990113148100206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">2011698-6</subfield>
+    <subfield code="2">DE-600</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">020356471</subfield>
+    <subfield code="2">DE-101</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)ZDB2011698-6</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1368126942</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-600)2011698-6</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-101)020356471</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">0003</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-101</subfield>
+    <subfield code="d">9999</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DXDE</subfield>
+  </datafield>
+  <datafield tag="084" ind1=" " ind2=" ">
+    <subfield code="a">340</subfield>
+    <subfield code="q">DE-600</subfield>
+    <subfield code="2">sdnb</subfield>
+  </datafield>
+  <datafield tag="110" ind1="1" ind2=" ">
+    <subfield code="a">Wanzleben</subfield>
+    <subfield code="0">(DE-588)4329661-0</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/940110466</subfield>
+    <subfield code="0">http://viaf.org/viaf/243162132</subfield>
+    <subfield code="B">GND-940110466</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Bericht über die Verwaltung und den Stand der Gemeindeangelegenheiten der Kreisstadt Wanzleben</subfield>
+    <subfield code="b">für die Zeit ...</subfield>
+  </datafield>
+  <datafield tag="247" ind1="0" ind2="0">
+    <subfield code="a">Bericht über die Verwaltung und den Stand der Gemeinde-Angelegenheiten der Stadt Wanzleben</subfield>
+    <subfield code="f">Haupttitel 1901/1902-[?]</subfield>
+    <subfield code="g">Earliest title</subfield>
+  </datafield>
+  <datafield tag="264" ind1="3" ind2="1">
+    <subfield code="a">Wanzleben</subfield>
+    <subfield code="b">[Verlag nicht ermittelbar]</subfield>
+    <subfield code="c">[1903?-1931?]</subfield>
+  </datafield>
+  <datafield tag="264" ind1="3" ind2="3">
+    <subfield code="a">Wanzleben</subfield>
+    <subfield code="b">Druck von Ludwig Wölfer</subfield>
+  </datafield>
+  <datafield tag="264" ind1="2" ind2="3">
+    <subfield code="a">Wanzleben</subfield>
+    <subfield code="b">A. Colbatzky Nachf.</subfield>
+    <subfield code="c">1903-1910</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="362" ind1="0" ind2=" ">
+    <subfield code="a">1901/1902 [?]-1928/1931 [?]</subfield>
+  </datafield>
+  <datafield tag="363" ind1="0" ind2="0">
+    <subfield code="8">1.1\x</subfield>
+    <subfield code="i">1901</subfield>
+  </datafield>
+  <datafield tag="363" ind1="1" ind2="0">
+    <subfield code="8">1.2\x</subfield>
+    <subfield code="i">1931</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Zeitschrift</subfield>
+    <subfield code="0">(DE-588)4067488-5</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990113148100206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ZDB</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="h">20171201134355.0</subfield>
+    <subfield code="l">60</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-08-11 05:36:34 Europe/Berlin</subfield>
+    <subfield code="g">011314810-HBZ01</subfield>
+    <subfield code="j">90</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 16:37:50 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4329661-0</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4329661-0</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-940110466</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2814181</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-940110466</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Groß-Wanzleben</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-940110466</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/990210511710206441.json
+++ b/src/test/resources/alma-fix/990210511710206441.json
@@ -1,0 +1,280 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990210511710206441#!",
+  "type" : [ "BibliographicResource", "Thesis", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Discursive self in microblogging",
+  "almaMmsId" : "990210511710206441",
+  "hbzId" : "HT018880143",
+  "deprecatedUri" : "http://lobid.org/resources/HT018880143#!",
+  "isbn" : [ "9789027256652", "9027256659", "9789027267528", "9027267529" ],
+  "oclcNumber" : [ "1073682687" ],
+  "bszId" : "45488110X",
+  "otherTitleInformation" : [ "speech acts, stories and self-praise" ],
+  "publication" : [ {
+    "dateStatement" : "[2016]",
+    "startDate" : "2016",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Amsterdam ; Philadelphia" ],
+    "publishedBy" : [ "John Benjamins Publishing Company" ]
+  } ],
+  "manufacture" : [ {
+    "dateStatement" : "© 2016",
+    "startDate" : "© 2016",
+    "type" : [ "Event" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990210511710206441",
+    "label" : "Webseite der hbz-Ressource 990210511710206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990210511710206441",
+        "dateCreated" : "2016-02-09",
+        "dateModified" : "2026-08-12",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990210511710206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-465#!",
+          "label" : "Universitätsbibliothek Duisburg-Essen"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-576#!",
+          "label" : "Bibliotheksservice-Zentrum Baden-Württemberg (BSZ)"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-6#!",
+          "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+        }, {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "natureOfContent" : [ {
+    "label" : "Hochschulschrift",
+    "id" : "https://d-nb.info/gnd/4113937-9"
+  } ],
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Discourse analysis / Psychological aspects"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Microblogs"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Social media"
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "401.452",
+    "notation" : "401.452"
+  }, {
+    "type" : [ "ComplexSubject" ],
+    "label" : "Weblog | Social Media | Pragmatik",
+    "componentList" : [ {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Weblog",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4678688-0",
+      "gndIdentifier" : "4678688-0",
+      "altLabel" : [ "Netztagebuch", "Blog (Web-Seite)", "Web log" ]
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Social Media",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4639271-3",
+      "gndIdentifier" : "4639271-3",
+      "altLabel" : [ "Soziale Medien" ]
+    }, {
+      "type" : [ "SubjectHeading" ],
+      "label" : "Pragmatik",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4076315-8",
+      "gndIdentifier" : "4076315-8",
+      "altLabel" : [ "Linguistische Pragmatik", "Pragmalinguistik", "Pragmatische Linguistik", "Sprachlinguistik", "Sprachpragmatik", "Sprachwirkungsforschung" ]
+    } ]
+  } ],
+  "subjectslabels" : [ "Discourse analysis / Psychological aspects", "Microblogs", "Social media", "Weblog", "Social Media", "Pragmatik" ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "2016/2435",
+    "serialNumber" : "2016/2435",
+    "currentLibrary" : "0",
+    "currentLocation" : "0-Frei1",
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma990210511710206441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990210511710206441:DE-5:23311861840006467#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "ND129.00 D276",
+    "inventoryNumber" : "16-6109",
+    "serialNumber" : "158/4459159+01",
+    "currentLibrary" : "UB_BI",
+    "currentLocation" : "155_Mono",
+    "heldBy" : {
+      "isil" : "DE-361",
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld"
+    },
+    "seeAlso" : [ "https://katalogplus.ub.uni-bielefeld.de/Search/Results?type=NZsatz&lookfor=HT018880143" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-361#!",
+      "label" : "Universitätsbibliothek Bielefeld",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990210511710206441:DE-361:23247407820006442#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "BHW1871",
+    "inventoryNumber" : "16/2543",
+    "serialNumber" : "DE00353134",
+    "currentLibrary" : "E0001",
+    "currentLocation" : "E11",
+    "heldBy" : {
+      "isil" : "DE-465",
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen"
+    },
+    "seeAlso" : [ "https://primo.uni-due.de/discovery/search?query=any,contains,990210511710206441&tab=Everything&search_scope=MyInst_and_CI_custom&vid=49HBZ_UDE:UDE&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990210511710206441:DE-465:23414105900006446#!"
+  }, {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "3K 66303",
+    "serialNumber" : "6-00457196-6",
+    "currentLibrary" : "ZB",
+    "currentLocation" : "ZB_FHM1",
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,990210511710206441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990210511710206441:DE-6:23492192690006449#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990210511710206441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1073682687",
+    "label" : "OCLC-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT001235014#!",
+      "label" : "Pragmatics & beyond. New series"
+    } ],
+    "numbering" : "260",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "tableOfContents" : [ {
+    "label" : "Inhaltsverzeichnis",
+    "id" : "https://digitale-objekte.hbz-nrw.de/storage2/2016/05/02/file_6/6730428.pdf"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
+    "label" : "Englisch"
+  } ],
+  "extent" : "vii, 247 Seiten",
+  "note" : [ "Includes bibliographical references and index" ],
+  "thesisInformation" : [ "Universität Bayreuth, Dissertation, 2014" ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Daria Dayter" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "1099124263",
+      "id" : "https://d-nb.info/gnd/1099124263",
+      "label" : "Dayter, Daria",
+      "type" : [ "Person" ],
+      "altLabel" : [ "Dayter, Dasha" ],
+      "sameAs" : [ "https://orcid.org/0000-0001-5054-5330" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990210511710206441.json
+++ b/src/test/resources/alma-fix/990210511710206441.json
@@ -23,7 +23,7 @@
   } ],
   "manufacture" : [ {
     "dateStatement" : "© 2016",
-    "startDate" : "© 2016",
+    "startDate" : "2016",
     "type" : [ "Event" ]
   } ],
   "describedBy" : {

--- a/src/test/resources/alma-fix/990210511710206441.xml
+++ b/src/test/resources/alma-fix/990210511710206441.xml
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01919nam#a2200529#cb4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20260812212139.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">160209|2016####ne ######m####|||#|#eng#c</controlfield>
+  <controlfield tag="001">990210511710206441</controlfield>
+  <datafield tag="010" ind1=" " ind2=" ">
+    <subfield code="a">2015043269</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1073682687</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9789027256652</subfield>
+    <subfield code="c">hbk</subfield>
+    <subfield code="9">978-90-272-5665-2</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9789027267528</subfield>
+    <subfield code="c">e-book</subfield>
+    <subfield code="9">978-90-272-6752-8</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT018880143</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">465</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">BSZ</subfield>
+    <subfield code="d">6</subfield>
+    <subfield code="d">DE-605</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">eng</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-NL</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">P302.8</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2=" ">
+    <subfield code="a">401.452</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Dayter, Daria</subfield>
+    <subfield code="0">(DE-588)1099124263</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/1099124263</subfield>
+    <subfield code="0">http://viaf.org/viaf/77145003809961340867</subfield>
+    <subfield code="B">GND-1099124263</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Discursive self in microblogging</subfield>
+    <subfield code="b">speech acts, stories and self-praise</subfield>
+    <subfield code="c">Daria Dayter</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Amsterdam ; Philadelphia</subfield>
+    <subfield code="b">John Benjamins Publishing Company</subfield>
+    <subfield code="c">[2016]</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="3">
+    <subfield code="c">© 2016</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">vii, 247 Seiten</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="490" ind1="1" ind2=" ">
+    <subfield code="a">Pragmatics &amp; beyond. New series</subfield>
+    <subfield code="v">Volume 260</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="0">
+    <subfield code="a">Weblog</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4678688-0</subfield>
+    <subfield code="B">GND-964066505</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="1">
+    <subfield code="a">Social Media</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4639271-3</subfield>
+    <subfield code="B">GND-961739223</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="2">
+    <subfield code="a">Pragmatik</subfield>
+    <subfield code="D">s</subfield>
+    <subfield code="0">(DE-588)4076315-8</subfield>
+    <subfield code="B">GND-040763153</subfield>
+  </datafield>
+  <datafield tag="965" ind1=" " ind2=" ">
+    <subfield code="u">https://digitale-objekte.hbz-nrw.de/storage2/2016/05/02/file_6/6730428.pdf</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1073682687</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)BSZ45488110X</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">sy||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|5zr||z|0017</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="830" ind1=" " ind2="0">
+    <subfield code="a">Pragmatics &amp; beyond. New series</subfield>
+    <subfield code="w">(DE-605)HT001235014</subfield>
+    <subfield code="v">260</subfield>
+    <subfield code="9">O:1</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="2">
+    <subfield code="m">V:DE-605;X:migimw</subfield>
+    <subfield code="q">application/pdf</subfield>
+    <subfield code="u">https://digitale-objekte.hbz-nrw.de/storage2/2016/05/02/file_6/6730428.pdf</subfield>
+    <subfield code="3">Inhaltsverzeichnis</subfield>
+    <subfield code="9">O:PKN</subfield>
+  </datafield>
+  <datafield tag="751" ind1=" " ind2=" ">
+    <subfield code="a">Bayreuth</subfield>
+    <subfield code="0">(DE-588)4005056-7</subfield>
+    <subfield code="4">uvp</subfield>
+    <subfield code="0">https://d-nb.info/gnd/040050564</subfield>
+    <subfield code="B">GND-040050564</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Discourse analysis / Psychological aspects</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Microblogs</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Social media</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Hochschulschrift</subfield>
+    <subfield code="0">(DE-588)4113937-9</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references and index</subfield>
+  </datafield>
+  <datafield tag="502" ind1=" " ind2=" ">
+    <subfield code="b">Dissertation</subfield>
+    <subfield code="c">Universität Bayreuth</subfield>
+    <subfield code="d">2014</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990210511710206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULB</subfield>
+    <subfield code="i">991030442309706467</subfield>
+    <subfield code="n">Universitaet Bonn</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_BIE</subfield>
+    <subfield code="i">991021580929706442</subfield>
+    <subfield code="n">Universität Bielefeld</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="i">990184750600206446</subfield>
+    <subfield code="n">Universität Duisburg-Essen</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="i">991017766419706449</subfield>
+    <subfield code="n">Universität Münster</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">OTHER</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="h">20210906162000.0</subfield>
+    <subfield code="l">90</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-08-12 21:21:39 Europe/Berlin</subfield>
+    <subfield code="g">021051171-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 11:44:53 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="#" ind2=" ">
+    <subfield code="b">0</subfield>
+    <subfield code="c">0-Frei1</subfield>
+    <subfield code="h">2016/2435</subfield>
+    <subfield code="8">22311861850006467</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2023-07-24 11:54:01</subfield>
+    <subfield code="8">22311861850006467</subfield>
+    <subfield code="M">49HBZ_ULB</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22311861850006467</subfield>
+    <subfield code="x">0-Frei1</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">0-Frei1</subfield>
+    <subfield code="X">AMO_TL2_FIX</subfield>
+    <subfield code="U">2023-07-23 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2023-07-25 08:01:39 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">2016/2435</subfield>
+    <subfield code="G">1</subfield>
+    <subfield code="M">49HBZ_ULB</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">#</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="L">Di</subfield>
+    <subfield code="b">2016/2435</subfield>
+    <subfield code="O">SISIS-Ausleihzähler Migrationsjahr: 0 | SISIS-Ausleihzähler Vor-Migrationsjahr: 0 | SISIS-Ausleihzähler vorletztes Migrationsjahr: 0 | SISIS-Vormerkzähler Migrationsjahr: 0 | SISIS-vorletztes Rückgabedatum: 2018-08-14 | SISIS-Buchdaten-Aufnahmedatum: 2016-05-04</subfield>
+    <subfield code="N">SISIS-ULBSystematik: 2001 | SISIS-Magazindrucker: 0 | SISIS-Fernleihkonditionen: 0 | SISIS-Medientyp: 0 | Sigel: 5 | SISIS-Entleihbarkeit: S | SISIS-Zweigstelle: 0</subfield>
+    <subfield code="a">23311861840006467</subfield>
+    <subfield code="c">2016/2435</subfield>
+    <subfield code="W">2023-07-24 13:54:01 Europe/Berlin</subfield>
+    <subfield code="u">0</subfield>
+    <subfield code="w">0</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">UB_BI</subfield>
+    <subfield code="c">155_Mono</subfield>
+    <subfield code="h">ND129.00 D276</subfield>
+    <subfield code="8">22247407830006442</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-03-15 10:48:46</subfield>
+    <subfield code="8">22247407830006442</subfield>
+    <subfield code="b">2021-04-19 04:29:48</subfield>
+    <subfield code="M">49HBZ_BIE</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="c">rdolkemeier</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22247407830006442</subfield>
+    <subfield code="x">155_Mono</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">155_Mono</subfield>
+    <subfield code="p">item_08</subfield>
+    <subfield code="X">heuer</subfield>
+    <subfield code="U">2021-04-18 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2023-03-17 15:05:59 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="M">49HBZ_BIE</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="L">Abteilung/Standort/Haushaltsstufe: 15 | SISIS-Magazindrucker: 0 | HBZ01: HT018880143 | Keine Beilagen: 1</subfield>
+    <subfield code="b">158/4459159+01</subfield>
+    <subfield code="O">SISIS-Ausleihzähler vorletztes Migrationsjahr: 0 | SISIS-Vormerkzähler Migrationsjahr: 0 | SISIS-Buchdaten-Aufnahmedatum: 2016-09-12</subfield>
+    <subfield code="N">Fernleihkonditionen: 0 | Sigel: 361 | Klassifikation: 155_Mono | Altersbegrenzung: 0 | SISIS-Ausleihzähler Migrationsjahr: 0 | SISIS-Ausleihzähler Vor-Migrationsjahr: 1</subfield>
+    <subfield code="a">23247407820006442</subfield>
+    <subfield code="c">ND129.00 D276</subfield>
+    <subfield code="B">16-6109</subfield>
+    <subfield code="W">2021-04-19 06:29:48 Europe/Berlin</subfield>
+    <subfield code="u">UB_BI</subfield>
+    <subfield code="w">UB_BI</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">E0001</subfield>
+    <subfield code="c">E11</subfield>
+    <subfield code="h">  BHW1871  </subfield>
+    <subfield code="8">22414105910006446</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2024-05-10 10:52:08</subfield>
+    <subfield code="8">22414105910006446</subfield>
+    <subfield code="b">2021-04-15 18:18:45</subfield>
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22414105910006446</subfield>
+    <subfield code="x">E11</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">E11</subfield>
+    <subfield code="X">5502497100006446</subfield>
+    <subfield code="U">2016-02-09 11:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2024-09-14 16:01:17 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">BHW1871</subfield>
+    <subfield code="P">29</subfield>
+    <subfield code="Q">SL</subfield>
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">DE00353134</subfield>
+    <subfield code="a">23414105900006446</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="c">BHW1871</subfield>
+    <subfield code="S">MB16-974</subfield>
+    <subfield code="B">16/2543</subfield>
+    <subfield code="D">20160404</subfield>
+    <subfield code="W">2016-02-09 01:00:00 Europe/Berlin</subfield>
+    <subfield code="u">E0001</subfield>
+    <subfield code="w">E0001</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">ZB</subfield>
+    <subfield code="c">ZB_FHM1</subfield>
+    <subfield code="h">3K 66303</subfield>
+    <subfield code="8">22492192700006449</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="b">2022-07-11 08:26:21</subfield>
+    <subfield code="8">22492192700006449</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22492192700006449</subfield>
+    <subfield code="x">ZB_FHM1</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">ZB_FHM1</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2022-07-10 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2025-02-24 22:06:52 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">6-00457196-6</subfield>
+    <subfield code="a">23492192690006449</subfield>
+    <subfield code="c">3K 66303</subfield>
+    <subfield code="W">2022-07-11 10:26:21 Europe/Berlin</subfield>
+    <subfield code="u">ZB</subfield>
+    <subfield code="w">ZB</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Linguistische Pragmatik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Pragmalinguistik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Pragmatische Linguistik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Sprachlinguistik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Sprachpragmatik</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Sprachwirkungsforschung</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4076315-8</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4076315-8</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040763153</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Soziale Medien</subfield>
+    <subfield code="9">v:Gabler (online)</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-961739223</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4639271-3</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4639271-3</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-961739223</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Netztagebuch</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-964066505</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Blog</subfield>
+    <subfield code="g">Web-Seite</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-964066505</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GST" ind1=" " ind2=" ">
+    <subfield code="a">Web log</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-964066505</subfield>
+    <subfield code="C">450</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4678688-0</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4678688-0</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-964066505</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4005056-7</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4005056-7</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2951825</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Baireuth</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Stadt Bayreuth</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Kreishauptstadt Bayreuth</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Baruthum</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Byruthi</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Bareut</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Baruthi</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Byruthum</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Burythum</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Byrrhuthum</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040050564</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Dayter, Dasha</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1099124263</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">1099124263</subfield>
+    <subfield code="0">http://d-nb.info/gnd/1099124263</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1099124263</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0000-0001-5054-5330</subfield>
+    <subfield code="9">v:Herkunft: base</subfield>
+    <subfield code="2">orcid</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-1099124263</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/99377014341006441.json
+++ b/src/test/resources/alma-fix/99377014341006441.json
@@ -1,0 +1,224 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99377014341006441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Vocabularius breuiloquus cum arte diphth[o]nga[n]di. punctandi et accentuandi",
+  "almaMmsId" : "99377014341006441",
+  "urn" : [ "urn:nbn:de:bvb:12-bsb00038353-7" ],
+  "hbzId" : "HT031491789",
+  "deprecatedUri" : "http://lobid.org/resources/HT031491789#!",
+  "oclcNumber" : [ "645637098" ],
+  "bvbId" : "BV035425752",
+  "alternativeTitle" : [ "Vocabularius breviloquus cum arte diphthongandi punctandi et accentuandi" ],
+  "otherTitleInformation" : [ "Ars diphthongandi", "Dialogus de arte punctandi", "Tractatus de accentu" ],
+  "manufacture" : [ {
+    "dateStatement" : "Anno d[om]ni. M.cccc.lxxxix. Finitus in die sancti Leonardi. [1489.11.06.]",
+    "startDate" : "Anno domni. M..lxxxix. Finitus in die santi Leonardi. 1489.11.06.",
+    "type" : [ "Event" ],
+    "location" : [ "Argentine" ],
+    "manufacturedBy" : [ "[Drucker des Jordanus, das ist Georg Husner]" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99377014341006441",
+    "label" : "Webseite der hbz-Ressource 99377014341006441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99377014341006441",
+        "dateCreated" : "2026-06-02",
+        "dateModified" : "2026-08-17",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99377014341006441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-38#!",
+          "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-38#!",
+          "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-38#!",
+          "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "natureOfContent" : [ {
+    "label" : "Inkunabel",
+    "id" : "https://d-nb.info/gnd/4027041-5"
+  } ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "GBII+A283+I",
+    "serialNumber" : "GBII+A283+I",
+    "currentLibrary" : "38-HLS",
+    "currentLocation" : "38-HLS-MAG",
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=99377014341006441&fdb=uni" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99377014341006441:DE-38:23398039370006476#!",
+    "custodialHistory" : [ {
+      "type" : [ "Event" ],
+      "contribution" : [ {
+        "agent" : {
+          "label" : "Kölner Kartause",
+          "id" : "https://d-nb.info/gnd/4275651-0"
+        },
+        "role" : {
+          "id" : "http://id.loc.gov/vocabulary/relators/own",
+          "label" : "Eigentümer/in"
+        }
+      } ],
+      "typeOfOwnership" : [ {
+        "label" : "Vorbesitz"
+      } ],
+      "note" : [ "Details: hs. Besitzvermerk \"P[er]tinet Carthus in Colonia\"" ]
+    }, {
+      "type" : [ "Event" ],
+      "contribution" : [ {
+        "agent" : {
+          "label" : "Korbeck, Fridel <<von>>"
+        },
+        "role" : {
+          "id" : "http://id.loc.gov/vocabulary/relators/own",
+          "label" : "Eigentümer/in"
+        }
+      } ],
+      "typeOfOwnership" : [ {
+        "label" : "Vorbesitz"
+      } ],
+      "note" : [ "Details: hs. Besitzvermerk: \"Ex testame[n]to ven[erab]ilo d[omi]ni ffridelli de korbeck decretoru[m] doctoris q m[u]ltos libros nob[is] donauit cuius a[l]ia[m] requiescat in pace sempitina. Ame[n].\"" ]
+    } ]
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99377014341006441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/645637098",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb00038353-7",
+    "label" : "URN-Link"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb00038353-7",
+    "label" : "URN-Link"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "exampleOfWork" : {
+    "label" : "Vocabularius breviloquus",
+    "id" : "https://d-nb.info/gnd/7695838-3",
+    "type" : [ "Work" ]
+  },
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/lat",
+    "label" : "Latein"
+  } ],
+  "extent" : "644 ungezählte Seiten ; 2°",
+  "note" : [ "Mit Vorrede an den Leser", "Bibliogr. Nachweis: Copinger 2819 = Copinger/Reichling 6294. Benzing, Reuchlin 14. Ritter, Inc. alsac. II, 600. Pell-Pol 9898. Pol 3344. IGI 8337. BMC I, 139 (IB. 2021). Goff R 167. IBP 4744. CIH 2941" ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "118744658",
+      "id" : "https://d-nb.info/gnd/118744658",
+      "label" : "Reuchlin, Johannes",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1455",
+      "dateOfDeath" : "1522",
+      "altLabel" : [ "John, Reuchlin", "Giovanni, Reuchlin", "John, Capnion", "Johann, Reuchlin", "Reuchlin", "Johannes, Capnion", "Capnio", "Kapnion", "Johannes, Reuchlin", "Iōannēs, Kapniōn", "Johannes", "Johann", "Reuchlin, Joānes", "Capnio, Johann", "Capnion, Johannes", "Roechlin, Johannes", "Reuchlin, Johann", "Connibertus, Alexander", "Kapnion, Johannes", "Reuchlin, Joannes", "Reuchlinus, Joannes", "Reuchlinus, Johannes", "Capnio, Johannes" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "11869877X",
+      "id" : "https://d-nb.info/gnd/11869877X",
+      "label" : "Guarinus, Veronensis",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1374",
+      "dateOfDeath" : "1460",
+      "altLabel" : [ "Guarino, de Vérone", "Guarino, Veronensis", "Guarinus, de Verona", "Guarinus, aus Verona", "Guarino, von Verona", "Guarinus, von Verona", "Guarino, Veronese", "Guarini, da Verona", "Varius, Veronensis", "Guarino, di Verona", "Guarini, Veronese", "Guarino, da Verona", "Guarino, Guarini", "Guarino Veronese", "Guarinus, Veronese", "Varinus, Veronensis", "Guarini, Guarino, Veronese", "Guarini, Guarino", "Guarini, Guarino, Veronensis", "Guarini, Baptista", "Guarinus, Baptista" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/wat",
+      "label" : "Zusätzlicher Text"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "119011700",
+      "id" : "https://d-nb.info/gnd/119011700",
+      "label" : "Heynlin, Johannes",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1430",
+      "dateOfDeath" : "1496",
+      "altLabel" : [ "Johannes, a Lapide", "Jean, de Stein", "Johann, Heynlin", "Johannes, Heynlin", "Ioannes, de Lapide", "Johannes, von Stein", "Jean, Heynlin", "Johannes, Lapidarius", "Johannes, Lapideus", "Johannes, Heynlin von Stein", "Jean, de la Pierre", "Johannes, de Lapide", "Stein, Johannes von", "Heynlin, Johann", "Heynlin von Stein, Johannes", "Stein, Johann von", "Stein, Johannes vom", "Heynlin de Lapide, Johannes", "Lapide, Johannes de", "Stein, Johann vom" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/wat",
+      "label" : "Zusätzlicher Text"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "136216064",
+      "id" : "https://d-nb.info/gnd/136216064",
+      "label" : "Husner, Georg",
+      "type" : [ "Person" ],
+      "dateOfDeath" : "1505",
+      "altLabel" : [ "Georg, Husner", "Georg, Hußner", "Drucker der Casus breves", "Drucker des Jordanus", "Drucker des Jordanus von Quedlinburg", "Drucker des Iordanus", "Drucker des Iordanus von Quedlinburg", "Hussner, Georg", "Husner, Georgius", "Husner, Ieorius", "Strosack, Johannes" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/prt",
+      "label" : "Druck"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99377014341006441.json
+++ b/src/test/resources/alma-fix/99377014341006441.json
@@ -17,7 +17,7 @@
   "otherTitleInformation" : [ "Ars diphthongandi", "Dialogus de arte punctandi", "Tractatus de accentu" ],
   "manufacture" : [ {
     "dateStatement" : "Anno d[om]ni. M.cccc.lxxxix. Finitus in die sancti Leonardi. [1489.11.06.]",
-    "startDate" : "Anno domni. M..lxxxix. Finitus in die santi Leonardi. 1489.11.06.",
+    "startDate" : "1489",
     "type" : [ "Event" ],
     "location" : [ "Argentine" ],
     "manufacturedBy" : [ "[Drucker des Jordanus, das ist Georg Husner]" ]

--- a/src/test/resources/alma-fix/99377014341006441.xml
+++ b/src/test/resources/alma-fix/99377014341006441.xml
@@ -1,0 +1,952 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>02573cam a2200481 c 4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20260708160643.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">260602s1489    fr       |||| 00||| lat c</controlfield>
+  <controlfield tag="001">99377014341006441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">645637098</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT031491789</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">DE-38</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-38</subfield>
+    <subfield code="d">DE-38</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">lat</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-FR</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlin, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="0">(DE-588)118744658</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/118744658</subfield>
+    <subfield code="0">http://viaf.org/viaf/66542815</subfield>
+    <subfield code="B">GND-118744658</subfield>
+  </datafield>
+  <datafield tag="240" ind1="1" ind2="0">
+    <subfield code="a">Vocabularius breviloquus</subfield>
+    <subfield code="0">(DE-588)7695838-3</subfield>
+    <subfield code="B">GND-100104519X</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Vocabularius breuiloquus cum arte diphth[o]nga[n]di. punctandi et accentuandi</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2=" ">
+    <subfield code="a">Vocabularius breviloquus cum arte diphthongandi punctandi et accentuandi</subfield>
+  </datafield>
+  <datafield tag="249" ind1=" " ind2=" ">
+    <subfield code="a">Ars diphthongandi</subfield>
+    <subfield code="v">Guarinus Veronensis</subfield>
+    <subfield code="a">Dialogus de arte punctandi</subfield>
+    <subfield code="v">Johannes de Lapide</subfield>
+    <subfield code="a">Tractatus de accentu</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="3">
+    <subfield code="a">Argentine</subfield>
+    <subfield code="b">[Drucker des Jordanus, das ist Georg Husner]</subfield>
+    <subfield code="c">Anno d[om]ni. M.cccc.lxxxix. Finitus in die sancti Leonardi. [1489.11.06.]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">644 ungezählte Seiten</subfield>
+    <subfield code="c">2°</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="b">txt</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="b">n</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="b">nc</subfield>
+  </datafield>
+  <datafield tag="361" ind1="1" ind2=" ">
+    <subfield code="5">DE-38</subfield>
+    <subfield code="s">GBII+A283+I</subfield>
+    <subfield code="o">Vorbesitz</subfield>
+    <subfield code="a">Kölner Kartause</subfield>
+    <subfield code="0">(DE-588)4275651-0</subfield>
+    <subfield code="z">Details: hs. Besitzvermerk "P[er]tinet Carthus in Colonia"</subfield>
+  </datafield>
+  <datafield tag="361" ind1="1" ind2=" ">
+    <subfield code="5">DE-38</subfield>
+    <subfield code="s">GBII+A283+I</subfield>
+    <subfield code="o">Vorbesitz</subfield>
+    <subfield code="a">Korbeck, Fridel &lt;&lt;von&gt;&gt;</subfield>
+    <subfield code="z">Details: hs. Besitzvermerk: "Ex testame[n]to ven[erab]ilo d[omi]ni ffridelli de korbeck decretoru[m] doctoris q m[u]ltos libros nob[is] donauit cuius a[l]ia[m] requiescat in pace sempitina. Ame[n]."</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)645637098</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)BVBBV035425752</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-604)BV035425752</subfield>
+  </datafield>
+  <datafield tag="856" ind1="4" ind2="1">
+    <subfield code="u">http://mdz-nbn-resolving.de/urn:nbn:de:bvb:12-bsb00038353-7</subfield>
+    <subfield code="x">Resolving-System</subfield>
+    <subfield code="z">kostenfrei</subfield>
+    <subfield code="3">Volltext // Exemplar mit der Signatur: München, Bayerische Staatsbibliothek -- 2 Inc.c.a. 2338 n</subfield>
+  </datafield>
+  <datafield tag="700" ind1="0" ind2=" ">
+    <subfield code="a">Guarinus</subfield>
+    <subfield code="c">Veronensis</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="0">(DE-588)11869877X</subfield>
+    <subfield code="4">wat</subfield>
+    <subfield code="0">https://d-nb.info/gnd/11869877X</subfield>
+    <subfield code="0">http://viaf.org/viaf/78782481</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Heynlin, Johannes</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="0">(DE-588)119011700</subfield>
+    <subfield code="4">wat</subfield>
+    <subfield code="0">https://d-nb.info/gnd/119011700</subfield>
+    <subfield code="0">http://viaf.org/viaf/106970261</subfield>
+    <subfield code="B">GND-119011700</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Husner, Georg</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="0">(DE-588)136216064</subfield>
+    <subfield code="4">prt</subfield>
+    <subfield code="0">https://d-nb.info/gnd/136216064</subfield>
+    <subfield code="0">http://viaf.org/viaf/85069603</subfield>
+    <subfield code="B">GND-136216064</subfield>
+  </datafield>
+  <datafield tag="751" ind1=" " ind2=" ">
+    <subfield code="a">Straßburg</subfield>
+    <subfield code="0">(DE-588)4057878-1</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="4">mfp</subfield>
+    <subfield code="0">https://d-nb.info/gnd/04057878X</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="i">Elektronische Reproduktion</subfield>
+    <subfield code="d">München : Bayerische Staatsbibliothek, 2009</subfield>
+    <subfield code="o">urn:nbn:de:bvb:12-bsb00038353-7</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Inkunabel</subfield>
+    <subfield code="0">(DE-588)4027041-5</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Mit Vorrede an den Leser</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Bibliogr. Nachweis: Copinger 2819 = Copinger/Reichling 6294. Benzing, Reuchlin 14. Ritter, Inc. alsac. II, 600. Pell-Pol 9898. Pol 3344. IGI 8337. BMC I, 139 (IB. 2021). Goff R 167. IBP 4744. CIH 2941</subfield>
+  </datafield>
+  <datafield tag="510" ind1="4" ind2=" ">
+    <subfield code="a">BSB-Ink R-153</subfield>
+  </datafield>
+  <datafield tag="510" ind1="4" ind2=" ">
+    <subfield code="a">GW M37936</subfield>
+  </datafield>
+  <datafield tag="510" ind1="4" ind2=" ">
+    <subfield code="a">ISTC ir00167000</subfield>
+  </datafield>
+  <datafield tag="510" ind1="4" ind2=" ">
+    <subfield code="a">CR 6294</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99377014341006441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="i">991055898747606476</subfield>
+    <subfield code="n">Universität Köln</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">OTHER</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="h">20260708160643.0</subfield>
+    <subfield code="l">59</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-08-17 04:45:29 Europe/Berlin</subfield>
+    <subfield code="g">99377014341006441</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">38beckers######49HBZ_UBK</subfield>
+    <subfield code="b">2026-06-02 16:37:46 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">38-HLS</subfield>
+    <subfield code="c">38-HLS-MAG</subfield>
+    <subfield code="8">22398039390006476</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2026-06-02 14:47:22</subfield>
+    <subfield code="8">22398039390006476</subfield>
+    <subfield code="b">2026-06-02 14:47:17</subfield>
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">38beckers</subfield>
+    <subfield code="c">38beckers</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22398039390006476</subfield>
+    <subfield code="x">38-HLS-MAG</subfield>
+    <subfield code="f">RARE</subfield>
+    <subfield code="v">38-HLS-MAG</subfield>
+    <subfield code="p">L</subfield>
+    <subfield code="X">38beckers</subfield>
+    <subfield code="Y">2026-06-02 16:48:15 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">GBII+A283+I</subfield>
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">38beckers</subfield>
+    <subfield code="b">GBII+A283+I</subfield>
+    <subfield code="a">23398039370006476</subfield>
+    <subfield code="K">Panzerschrank</subfield>
+    <subfield code="W">2026-06-02 16:47:56 Europe/Berlin</subfield>
+    <subfield code="u">38-HLS</subfield>
+    <subfield code="w">38-HLS</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">a Lapide</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Jean</subfield>
+    <subfield code="c">de Stein</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johann</subfield>
+    <subfield code="c">Heynlin</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">Heynlin</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Stein, Johannes &lt;&lt;von&gt;&gt;</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Ioannes</subfield>
+    <subfield code="c">de Lapide</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Heynlin, Johann</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">von Stein</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Jean</subfield>
+    <subfield code="c">Heynlin</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Heynlin von Stein, Johannes</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">Lapidarius</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">Lapideus</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Stein, Johann &lt;&lt;von&gt;&gt;</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Stein, Johannes &lt;&lt;vom&gt;&gt;</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">Heynlin von Stein</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Jean</subfield>
+    <subfield code="c">de la Pierre</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Heynlin de Lapide, Johannes</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">de Lapide</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Lapide, Johannes &lt;&lt;de&gt;&gt;</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Stein, Johann &lt;&lt;vom&gt;&gt;</subfield>
+    <subfield code="d">1430-1496</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">119011700</subfield>
+    <subfield code="0">http://d-nb.info/gnd/119011700</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119011700</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">John</subfield>
+    <subfield code="c">Reuchlin</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Giovanni</subfield>
+    <subfield code="c">Reuchlin</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">John</subfield>
+    <subfield code="c">Capnion</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johann</subfield>
+    <subfield code="c">Reuchlin</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlin, Joānes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Capnio, Johann</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Reuchlin</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">Capnion</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Capnion, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Roechlin, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Capnio</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlin, Johann</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Kapnion</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="c">Reuchlin</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Iōannēs</subfield>
+    <subfield code="c">Kapniōn</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Connibertus, Alexander</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Kapnion, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlin, Joannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlinus, Joannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlinus, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Capnio, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Johann</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Capnio, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="5">DE-18</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Kapnion, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="5">DE-18</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">118744658</subfield>
+    <subfield code="0">http://d-nb.info/gnd/118744658</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118744658</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4057878-1</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4057878-1</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2973783</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strassburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Straßbourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strasbourg</subfield>
+    <subfield code="9">v:franz.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Argentoratum</subfield>
+    <subfield code="9">v:lat.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Argentorate</subfield>
+    <subfield code="9">v:lat.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strateburgum</subfield>
+    <subfield code="9">v:seit 6. Jh. bezeugt</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Stratisburgo</subfield>
+    <subfield code="9">v:M; 6. Jh.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strossburi</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Ville de Strasbourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Estrasburgo</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strasburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Straßburg/Elsaß</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strassburg i. E.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hussner, Georg</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Georg</subfield>
+    <subfield code="c">Husner</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Georg</subfield>
+    <subfield code="c">Hußner</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Husner, Georgius</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Husner, Ieorius</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Strosack, Johannes</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Drucker der Casus breves</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Drucker des Jordanus</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Drucker des Jordanus von Quedlinburg</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Drucker des Iordanus</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Drucker des Iordanus von Quedlinburg</subfield>
+    <subfield code="d">14XX-1505</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">136216064</subfield>
+    <subfield code="0">http://d-nb.info/gnd/136216064</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-136216064</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">de Vérone</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">Veronensis</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Guarini, Guarino</subfield>
+    <subfield code="c">Veronese</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarinus</subfield>
+    <subfield code="c">de Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Guarini, Guarino</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Guarini, Guarino</subfield>
+    <subfield code="c">Veronensis</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarinus</subfield>
+    <subfield code="c">aus Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">von Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarinus</subfield>
+    <subfield code="c">von Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">Veronese</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarini</subfield>
+    <subfield code="c">da Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Varius</subfield>
+    <subfield code="c">Veronensis</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">di Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarini</subfield>
+    <subfield code="c">Veronese</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Guarini, Baptista</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">da Verona</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino</subfield>
+    <subfield code="c">Guarini</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarino Veronese</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Guarinus</subfield>
+    <subfield code="c">Veronese</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Varinus</subfield>
+    <subfield code="c">Veronensis</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Guarinus, Baptista</subfield>
+    <subfield code="d">1374-1460</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">11869877X</subfield>
+    <subfield code="0">http://d-nb.info/gnd/11869877X</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-11869877X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Reuchlin, Johannes</subfield>
+    <subfield code="d">1455-1522</subfield>
+    <subfield code="t">Vocabularius brevilogus</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-100104519X</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">7695838-3</subfield>
+    <subfield code="0">http://d-nb.info/gnd/7695838-3</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-100104519X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 25 },
+			{ "title:der", /*->*/ 26 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 5 },
@@ -73,8 +73,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.location:Koln", /*->*/ 7 },
 			{ "publication.startDate:1993", /*->*/ 4 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 208 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 235 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 212 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 239 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },
@@ -105,7 +105,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "describedBy.resultOf.object.dateCreated:\"2023-03-22\"", /*->*/ 1},
 			{ "describedBy.resultOf.object.dateModified:\"2023-07-30\"", /*->*/ 3},
 			{ "describedBy.resultOf.object.sourceOrganization.id:\"http\\://lobid.org/organisations/DE-5#\\!\"", /*->*/ 8},
-			{ "describedBy.resultOf.object.modifiedBy.id:\"http\\://lobid.org/organisations/DE-6#\\!\"", /*->*/ 24 },
+			{ "describedBy.resultOf.object.modifiedBy.id:\"http\\://lobid.org/organisations/DE-6#\\!\"", /*->*/ 25 },
 			{ "\"Reader-friendly\"", /*->*/ 1},
 			{ "\"Reader friendly\"", /*->*/ 1},
 			// all q tests are related to DigiBib


### PR DESCRIPTION
The mentioned issue with `manufacture` dates that breaks the index should be solved with this:
https://github.com/hbz/lobid-resources/issues/2390#issuecomment-5327245714

Related  #2390