### PR TITLE
Skip startDates with 0000

### DIFF
--- a/src/main/resources/alma/fix/macros.fix
+++ b/src/main/resources/alma/fix/macros.fix
@@ -547,14 +547,18 @@ do put_macro("publicationDateCleaner")
 end
 
 do put_macro("publicationStartDate")
-  if any_match("$[date]","[^-]*?([01]\\d{3}|20\\d{2}).*")
-    paste("$[dateTarget]", "$[date]")
+  unless any_match("$[date]","0000")
+    if any_match("$[date]","[^-]*?([01]\\d{3}|20\\d{2}).*")
+      paste("$[dateTarget]", "$[date]")
+    end
   end
 end
 
 do put_macro("publicationEndDate")
-  if any_match("$[date]",".*-.*([01]\\d{3}|20\\d{2}).*$")
-    paste("$[dateTarget]", "$[date]")
+  unless any_match("$[date]","0000")
+    if any_match("$[date]",".*-.*([01]\\d{3}|20\\d{2}).*$")
+      paste("$[dateTarget]", "$[date]")
+    end
   end
 end
 

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -280,11 +280,13 @@ if exists("publication[].$first")
   unless exists("publication[].$first.startDate")
     unless is_array("008")
       if any_match("008","^.{6}[\\|bresticdkmu](\\d{4}).*$")
-        copy_field("008","@008startDate")
-        replace_all("@008startDate","^.{7}(\\d{4}).*$","$1")
-        if any_match("@008startDate",".*?([01]\\d{3}|20\\d{2}).*")
-          copy_field("@008startDate","publication[].$first.startDate")
-        end
+          copy_field("008","@008startDate")
+          replace_all("@008startDate","^.{7}(\\d{4}).*$","$1")
+          unless any_equal("@008startDate","0000")
+            if any_match("@008startDate",".*?([01]\\d{3}|20\\d{2}).*")
+              copy_field("@008startDate","publication[].$first.startDate")
+            end
+          end
       end
     end
   end
@@ -293,7 +295,7 @@ if exists("publication[].$first")
       if any_match("008","^.{6}[cdkmu]\\d{4}(\\d{4}).*$")
         copy_field("008","@008endDate")
         replace_all("@008endDate","^.{11}(\\d{4}).*$","$1")
-        unless any_equal("@008endDate","9999")
+        unless any_match("@008endDate","0000|9999")
           copy_field("@008endDate","publication[].$first.endDate")
         end
       end
@@ -390,10 +392,12 @@ if greater_than("publication[].1.startDate","$[todaysYear]")
   unless is_array("008")
     copy_field("008","@008startDateTest")
     replace_all("@008startDateTest","^.{7}(\\d{4}).*$","$1")
-    if less_than("@008startDateTest","$[todaysYear]")
-      copy_field("@008startDateTest","publication[].1.startDate")
-    elsif any_equal("@008startDateTest","$[todaysYear]")
-      copy_field("@008startDateTest","publication[].1.startDate")
+    unless any_equal ("@008startDateTest","0000")
+      if less_than("@008startDateTest","$[todaysYear]")
+        copy_field("@008startDateTest","publication[].1.startDate")
+      elsif any_equal("@008startDateTest","$[todaysYear]")
+        copy_field("@008startDateTest","publication[].1.startDate")
+      end
     end
   end
 end
@@ -401,10 +405,12 @@ if greater_than("publication[].1.endDate","$[todaysYear]")
   unless is_array("008")
     copy_field("008","@008endDateTest")
     replace_all("@008endDateTest","^.{11}(\\d{4}).*$","$1")
-    if less_than("@008endDateTest","$[todaysYear]")
-      copy_field("@008endDateTest","publication[].1.endDate")
-    elsif any_equal("@008endDateTest","$[todaysYear]")
-      copy_field("@008endDateTest","publication[].1.endDate")
+    unless any_match ("@008endDateTest","0000|9999")
+      if less_than("@008endDateTest","$[todaysYear]")
+        copy_field("@008endDateTest","publication[].1.endDate")
+      elsif any_equal("@008endDateTest","$[todaysYear]")
+        copy_field("@008endDateTest","publication[].1.endDate")
+      end
     end
   end
 end

--- a/src/main/resources/alma/fix/titleRelatedFields.fix
+++ b/src/main/resources/alma/fix/titleRelatedFields.fix
@@ -411,11 +411,13 @@ end
 
 # Fallback for non-gregorian startDates
 unless greater_than("@standardPubDate","$[todaysYear]")
-  if any_match("leader","^(.{7})[abdm].*")
-    if less_than("publication[].1.startDate","$[standardPubDateMinus4]")
-      copy_field("@standardPubDate","publication[].1.startDate")
-    elsif greater_than("publication[].1.startDate","$[standardPubDatePlus4]")
-      copy_field("@standardPubDate","publication[].1.startDate")
+  unless any_equal ("@standardPubDate","0000")
+    if any_match("leader","^(.{7})[abdm].*")
+      if less_than("publication[].1.startDate","$[standardPubDateMinus4]")
+        copy_field("@standardPubDate","publication[].1.startDate")
+      elsif greater_than("publication[].1.startDate","$[standardPubDatePlus4]")
+        copy_field("@standardPubDate","publication[].1.startDate")
+      end
     end
   end
 end

--- a/src/test/resources/alma-fix/990032141440206441.json
+++ b/src/test/resources/alma-fix/990032141440206441.json
@@ -16,8 +16,7 @@
     "dateStatement" : "19-?",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Porto" ],
-    "publishedBy" : [ "Lello & Irmao" ],
-    "startDate" : "0000"
+    "publishedBy" : [ "Lello & Irmao" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990032141440206441",

--- a/src/test/resources/alma-fix/990032141440206441.json
+++ b/src/test/resources/alma-fix/990032141440206441.json
@@ -1,0 +1,94 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990032141440206441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "A freira no subterrâneo",
+  "almaMmsId" : "990032141440206441",
+  "hbzId" : "HT008145754",
+  "deprecatedUri" : "http://lobid.org/resources/HT008145754#!",
+  "otherTitleInformation" : [ "romance histórico" ],
+  "edition" : [ "9. ed" ],
+  "publication" : [ {
+    "dateStatement" : "19-?",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Porto" ],
+    "publishedBy" : [ "Lello & Irmao" ],
+    "startDate" : "0000"
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990032141440206441",
+    "label" : "Webseite der hbz-Ressource 990032141440206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990032141440206441",
+        "dateCreated" : "1998-02-05",
+        "dateModified" : "2026-07-11",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990032141440206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-605#!",
+          "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990032141440206441",
+    "label" : "Culturegraph-Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "extent" : "262 S.",
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "trad. por Camilo Castelo Branco. Com um estudo do pranteado escritor Manuel Laranjeira sobre Camilo" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "118668757",
+      "id" : "https://d-nb.info/gnd/118668757",
+      "label" : "Castelo Branco, Camilo",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1825",
+      "dateOfDeath" : "1890",
+      "altLabel" : [ "Branco, Camilo Castelo", "Branco, Camilo C.", "Castelo-Branco, Camilo", "Castello-Branco, Camillo", "Castello Branco, Camillo", "Castello Branco, C.", "Branco, Camillo Castello", "Botelho, Camillo Castello Branco", "Botelho, Vde de Corrêá", "Correia Botelho, Camillo Castello Branco", "Corrêa Botelho, Camillo Ferreira Botelho Castello Branco", "Corrêá Botelho, Vcde de", "Ferreira Botelho Castello Branco Correira Botelho, Camillo", "Fereira Botelho Castelo Branco Correira Botelho, Camilo", "Camilo", "Camilo Castelo Branco" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990032141440206441.xml
+++ b/src/test/resources/alma-fix/990032141440206441.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>00739nam#a2200241#c#4500</leader>
+  <controlfield tag="005">20230210052304.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">980205|0000####po############|||#|#####c</controlfield>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="001">990032141440206441</controlfield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT008145754</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">HBZ/Off</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-PT</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Castelo Branco, Camilo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="0">(DE-588)118668757</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="0">https://d-nb.info/gnd/118668757</subfield>
+    <subfield code="0">http://viaf.org/viaf/7399630</subfield>
+    <subfield code="B">GND-118668757</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">&lt;&lt;A&gt;&gt; freira no subterrâneo</subfield>
+    <subfield code="b">romance histórico</subfield>
+    <subfield code="c">trad. por Camilo Castelo Branco. Com um estudo do pranteado escritor Manuel Laranjeira sobre Camilo</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">9. ed.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Porto</subfield>
+    <subfield code="b">Lello &amp; Irmao</subfield>
+    <subfield code="c">19-?</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">262 S.</subfield>
+  </datafield>
+  <datafield tag="960" ind1="1" ind2=" ">
+    <subfield code="b">roj</subfield>
+  </datafield>
+  <datafield tag="960" ind1="1" ind2=" ">
+    <subfield code="o">retro</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">e|1uc||||||17</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">m|||||||</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990032141440206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">55</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-07-11 04:33:05 Europe/Berlin</subfield>
+    <subfield code="g">003214144-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 08:40:11 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Branco, Camilo Castelo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Branco, Camilo C.</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Castelo-Branco, Camilo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Castello-Branco, Camillo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Castello Branco, Camillo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Castello Branco, C.</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Branco, Camillo Castello</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Branco, Camilo Castelo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Camilo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="9">v:Vorlage</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Camilo Castelo Branco</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Botelho, Camillo Castello Branco</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Botelho, Vde de Corrêá</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Correia Botelho, Camillo Castello Branco</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Corrêa Botelho, Camillo Ferreira Botelho Castello Branco</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Corrêá Botelho, Vcde de</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Ferreira Botelho Castello Branco Correira Botelho, Camillo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Fereira Botelho Castelo Branco Correira Botelho, Camilo</subfield>
+    <subfield code="d">1825-1890</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">118668757</subfield>
+    <subfield code="0">http://d-nb.info/gnd/118668757</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">Q365423</subfield>
+    <subfield code="9">v:Herkunft: musicb002</subfield>
+    <subfield code="2">wikidata</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0000 0001 2095 5267</subfield>
+    <subfield code="9">v:Herkunft: musicb002</subfield>
+    <subfield code="2">isni</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">artist/dad431f3-d646-44c8-988f-58fc770b6b94</subfield>
+    <subfield code="9">v:Herkunft: musicb002</subfield>
+    <subfield code="2">musicb</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118668757</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/990110321460206441.json
+++ b/src/test/resources/alma-fix/990110321460206441.json
@@ -1,0 +1,131 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990110321460206441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Hyperion oder der Eremit in Griechenland, 1",
+  "almaMmsId" : "990110321460206441",
+  "hbzId" : "HT012881423",
+  "deprecatedUri" : "http://lobid.org/resources/HT012881423#!",
+  "isbn" : [ "3458320652", "9783458320654" ],
+  "oclcNumber" : [ "1072886704" ],
+  "edition" : [ "1. Aufl., [Nachdr.]" ],
+  "publication" : [ {
+    "dateStatement" : "[19]83",
+    "startDate" : "0000",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Frankfurt am Main" ],
+    "publishedBy" : [ "Insel-Verl." ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990110321460206441",
+    "label" : "Webseite der hbz-Ressource 990110321460206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990110321460206441",
+        "dateCreated" : "2000-12-15",
+        "dateModified" : "2026-07-11",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990110321460206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-465#!",
+          "label" : "Universitätsbibliothek Duisburg-Essen"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "CNKE1003-1",
+    "inventoryNumber" : "G00/1842",
+    "serialNumber" : "CNKE1003-1",
+    "currentLibrary" : "E0001",
+    "currentLocation" : "E11",
+    "heldBy" : {
+      "isil" : "DE-465",
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen"
+    },
+    "seeAlso" : [ "https://primo.uni-due.de/discovery/search?query=any,contains,990110321460206441&tab=Everything&search_scope=MyInst_and_CI_custom&vid=49HBZ_UDE:UDE&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990110321460206441:DE-465:23409197690006446#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990110321460206441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1072886704",
+    "label" : "OCLC-Ressource"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "id" : "http://lobid.org/resources/HT012881420#!",
+      "label" : "Hyperion oder der Eremit in Griechenland"
+    } ],
+    "numbering" : "1",
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/ger",
+    "label" : "Deutsch"
+  } ],
+  "extent" : "228 S.",
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Friedrich Hölderlin" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "118551981",
+      "id" : "https://d-nb.info/gnd/118551981",
+      "label" : "Hölderlin, Friedrich",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1770",
+      "dateOfDeath" : "1843",
+      "altLabel" : [ "Hölderlin, Friedr.", "Hölderlin, F.", "Hoelderlin, Joannes Christianus Fridericus", "Hoelderlin, Christian Johann Friedrich", "Hoelderlin, Christianus Johannes Fridericus", "Hölderlin, J. Ch. Friedrich", "Holderlin, Friedrich", "Chailnterlin, Phrēntrich", "Chelderlin, Fridrich", "Chelnterlin, Phrēntrich", "Chʹolderlin, Fridrich", "Gelʹderlin, Fridrich", "Gelʹderlin, Friedrich", "Gelʹderlin, I. Ch. F.", "Gëlʹderlin, Iogann Kristian Fridrich", "Helderlîn, Frîdrîk", "Herudârîn, Furîdorihhi", "Hoelderlin, Friedrich", "Hoelderlin, Frédéric", "Gelʹderlin, Fridrikh", "Kholʹderlin, Fridrikh", "Holderlin, Frederich", "Hūldarlīn, Frīdrīš", "Hölderling, Friedrich", "Hölderlin, Friedrich Johann Christian", "Hölderlin, Fryderyk", "Hölderlin, Johann", "Hölderlin, J. Ch. F.", "Chailnterlin, Phrēntrix", "Helderlin, Fridrih", "Hëlʹdėrlin, Frydrych", "Hölderlin, Johann C.", "Ch'olderlin, Fridrich", "Gel'derlin, Fridrich", "Hölderlin, Johannes Christian Friedrich", "Gëlderlin, Fridrich", "Gëlʹdėrlin, Frydrych", "Helderlin, Fridrikh", "Chiolderlin, Fridrich", "Hoelderlin, Johann Christian Friedrich", "Helderlin, Fridrik", "Hölderlin, Johann Christian Friedrich", "Hoel deol lin, Peu li deu li hi", "荷尔德林, 弗里德里希", "Гёльдэрлін, Фрыдрых", "Гёльдерлин, Фридрих", "Hölderlin", "Hillmar", "Chainterlin", "Gelʹderlin", "Herudārin", "Hildarlin", "Hoelderlin", "Holḍālina", "Holderlin", "He er de lin", "Heerdelin", "Hoeldeollin", "Scardanelli", "He'erdelin", "Holterling", "Peu li deu li hi Hoel deol lin", "프리드리히 횔덜린", "횔덜린 프리드리히", "弗里德里希·荷尔德林", "ヘルダーリン" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990110321460206441.json
+++ b/src/test/resources/alma-fix/990110321460206441.json
@@ -15,7 +15,7 @@
   "edition" : [ "1. Aufl., [Nachdr.]" ],
   "publication" : [ {
     "dateStatement" : "[19]83",
-    "startDate" : "0000",
+    "startDate" : "1983",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Frankfurt am Main" ],
     "publishedBy" : [ "Insel-Verl." ]

--- a/src/test/resources/alma-fix/990110321460206441.xml
+++ b/src/test/resources/alma-fix/990110321460206441.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>00816nam#a2200277#cc4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20250410185147.0</controlfield>
+  <controlfield tag="007">tu</controlfield>
+  <controlfield tag="008">001215|0000####gw ###########|||#|#ger#c</controlfield>
+  <controlfield tag="001">990110321460206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1072886704</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">3458320652</subfield>
+    <subfield code="9">3-458-32065-2</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT012881423</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">465</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DE</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="0">(DE-588)118551981</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="9">O:H</subfield>
+    <subfield code="0">https://d-nb.info/gnd/118551981</subfield>
+    <subfield code="0">http://viaf.org/viaf/95147974</subfield>
+    <subfield code="B">GND-118551981</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Hyperion oder der Eremit in Griechenland</subfield>
+    <subfield code="n">1</subfield>
+    <subfield code="c">Friedrich Hölderlin</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">1. Aufl., [Nachdr.]</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Frankfurt am Main</subfield>
+    <subfield code="b">Insel-Verl.</subfield>
+    <subfield code="c">[19]83</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">228 S.</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1072886704</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT012881423</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="773" ind1="0" ind2="8">
+    <subfield code="w">(DE-605)HT012881420</subfield>
+    <subfield code="q">1</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990110321460206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="i">990008408770206446</subfield>
+    <subfield code="n">Universität Duisburg-Essen</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">66</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-07-11 04:46:10 Europe/Berlin</subfield>
+    <subfield code="g">011032146-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 20:08:52 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">E0001</subfield>
+    <subfield code="c">E11</subfield>
+    <subfield code="h">  CNKE1003-1  </subfield>
+    <subfield code="8">22409197700006446</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2024-05-10 14:47:29</subfield>
+    <subfield code="8">22409197700006446</subfield>
+    <subfield code="b">2021-04-15 18:01:14</subfield>
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22409197700006446</subfield>
+    <subfield code="x">E11</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="v">E11</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2000-12-15 11:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2024-05-10 16:47:39 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">CNKE1003-1</subfield>
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">CNKE1003-1</subfield>
+    <subfield code="a">23409197690006446</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="c">CNKE1003-1</subfield>
+    <subfield code="B">G00/1842</subfield>
+    <subfield code="D">20001215</subfield>
+    <subfield code="W">2000-12-15 01:00:00 Europe/Berlin</subfield>
+    <subfield code="u">E0001</subfield>
+    <subfield code="w">E0001</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Friedr.</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, F.</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoelderlin, Joannes Christianus Fridericus</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoelderlin, Christian Johann Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoelderlin, Christianus Johannes Fridericus</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, J. Ch. Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Holderlin, Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Hölderlin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Hillmar</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="4">pseu</subfield>
+    <subfield code="i">Pseudonym</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Chailnterlin, Phrēntrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Chainterlin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Chelderlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Chelnterlin, Phrēntrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Chʹolderlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gelʹderlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gelʹderlin, Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gelʹderlin, I. Ch. F.</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Gelʹderlin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gëlʹderlin, Iogann Kristian Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Helderlîn, Frîdrîk</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Herudārin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Herudârîn, Furîdorihhi</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Hildarlin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoelderlin, Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Hoelderlin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoelderlin, Frédéric</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Holḍālina</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Holderlin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gelʹderlin, Fridrikh</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Kholʹderlin, Fridrikh</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Holderlin, Frederich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hūldarlīn, Frīdrīš</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderling, Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="9">v:falsche Namensform</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">He er de lin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Heerdelin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Hoeldeollin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Friedrich Johann Christian</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Fryderyk</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Johann</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, J. Ch. F.</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Scardanelli</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="4">pseu</subfield>
+    <subfield code="i">Pseudonym</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Chailnterlin, Phrēntrix</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">He'erdelin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Helderlin, Fridrih</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hëlʹdėrlin, Frydrych</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Johann C.</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Ch'olderlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gel'derlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Johannes Christian Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gëlderlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gëlʹdėrlin, Frydrych</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Helderlin, Fridrikh</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Chiolderlin, Fridrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="9">v:bulg. Namensform</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoelderlin, Johann Christian Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Helderlin, Fridrik</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Holterling</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hölderlin, Johann Christian Friedrich</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Peu li deu li hi Hoel deol lin</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hoel deol lin, Peu li deu li hi</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">프리드리히 횔덜린</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="9">U:Hang</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">횔덜린 프리드리히</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="9">U:Hang</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">弗里德里希·荷尔德林</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="5">DE-576</subfield>
+    <subfield code="9">U:Hans</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">荷尔德林, 弗里德里希</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="5">DE-576</subfield>
+    <subfield code="9">U:Hans</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">ヘルダーリン</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="5">DE-576</subfield>
+    <subfield code="9">U:Jpan</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Гёльдэрлін, Фрыдрых</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="9">U:Cyrl</subfield>
+    <subfield code="9">L:bel</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Гёльдерлин, Фридрих</subfield>
+    <subfield code="d">1770-1843</subfield>
+    <subfield code="9">U:Cyrl</subfield>
+    <subfield code="9">L:rus</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">118551981</subfield>
+    <subfield code="0">http://d-nb.info/gnd/118551981</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0000 0001 2103 1808</subfield>
+    <subfield code="2">isni</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">Q75889</subfield>
+    <subfield code="2">wikidata</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118551981</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/990178504050206441.json
+++ b/src/test/resources/alma-fix/990178504050206441.json
@@ -17,8 +17,7 @@
     "dateStatement" : "19XX",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Frankfurt/Main [u.a.]" ],
-    "publishedBy" : [ "Peters" ],
-    "startDate" : "0000"
+    "publishedBy" : [ "Peters" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990178504050206441",

--- a/src/test/resources/alma-fix/990178504050206441.json
+++ b/src/test/resources/alma-fix/990178504050206441.json
@@ -1,0 +1,117 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990178504050206441#!",
+  "type" : [ "BibliographicResource", "MultiVolumeBook", "PublishedScore", "Book" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "12 Etüden für Violoncello opus 72",
+  "almaMmsId" : "990178504050206441",
+  "hbzId" : "HT016233849",
+  "deprecatedUri" : "http://lobid.org/resources/HT016233849#!",
+  "oclcNumber" : [ "1073339731" ],
+  "otherTitleInformation" : [ "(mit Begleitung eines zweiten Violoncellos ad libitum)" ],
+  "edition" : [ "Stimmen" ],
+  "publication" : [ {
+    "dateStatement" : "19XX",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Frankfurt/Main [u.a.]" ],
+    "publishedBy" : [ "Peters" ],
+    "startDate" : "0000"
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990178504050206441",
+    "label" : "Webseite der hbz-Ressource 990178504050206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990178504050206441",
+        "dateCreated" : "2010-02-11",
+        "dateModified" : "2026-07-24",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990178504050206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-575#!",
+          "label" : "Hochschule für Musik Detmold, Bibliothek"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "NurTitel" ],
+    "seeAlso" : [ "https://det.digibib.net/search/katalog/record/(DE-605)HT016233849" ],
+    "heldBy" : {
+      "isil" : "DE-51",
+      "id" : "http://lobid.org/organisations/DE-51#!",
+      "label" : "Lippische Landesbibliothek - Theologische Bibliothek und Mediothek"
+    },
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-51#!",
+      "label" : "Lippische Landesbibliothek - Theologische Bibliothek und Mediothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990178504050206441:DE-51:991006266399706480#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990178504050206441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1073339731",
+    "label" : "OCLC-Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "exampleOfWork" : {
+    "label" : "Etüden, Vc, op. 72",
+    "type" : [ "Work" ]
+  },
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Friedrich Grützmacher" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "118698508",
+      "id" : "https://d-nb.info/gnd/118698508",
+      "label" : "Grützmacher, Friedrich",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1832",
+      "dateOfDeath" : "1903",
+      "altLabel" : [ "Grützmacher, Friedrich, der Ältere", "Grützmacher, F.", "Grützmacher, Fr.", "Gruetzmacher, Friedrich", "Grützmacher, Frédéric", "Grützmacher, Friedrich Wilhelm Ludwig", "Gritzmacher, F.", "Ku-lu-tzu-ma-ha" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/cmp",
+      "label" : "Komposition"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990178504050206441.xml
+++ b/src/test/resources/alma-fix/990178504050206441.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>00836ncm#a2200253#ca4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20210409041557.0</controlfield>
+  <controlfield tag="007">qu</controlfield>
+  <controlfield tag="008">100211|0000####gw uu|##################c</controlfield>
+  <controlfield tag="001">990178504050206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1073339731</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT016233849</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">575</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-DE</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, Friedrich</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="0">(DE-588)118698508</subfield>
+    <subfield code="4">cmp</subfield>
+    <subfield code="0">https://d-nb.info/gnd/118698508</subfield>
+    <subfield code="0">http://viaf.org/viaf/76581551</subfield>
+    <subfield code="B">GND-118698508</subfield>
+  </datafield>
+  <datafield tag="240" ind1="1" ind2="0">
+    <subfield code="a">Etüden, Vc, op. 72</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">&lt;&lt;12&gt;&gt; Etüden für Violoncello opus 72</subfield>
+    <subfield code="h">Musikdruck</subfield>
+    <subfield code="b">(mit Begleitung eines zweiten Violoncellos ad libitum)</subfield>
+    <subfield code="c">Friedrich Grützmacher</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">Stimmen</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Frankfurt/Main [u.a.]</subfield>
+    <subfield code="b">Peters</subfield>
+    <subfield code="c">19XX</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1073339731</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT016233849</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||14</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">a|||||||||||||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">nm||||||</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990178504050206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_DET</subfield>
+    <subfield code="i">991006266399706480</subfield>
+    <subfield code="n">Hochschule für Musik Detmold / Lippische Landesbibliothek</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">56</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-07-24 04:11:02 Europe/Berlin</subfield>
+    <subfield code="g">017850405-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 20:47:13 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, Friedrich</subfield>
+    <subfield code="c">der Ältere</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, F.</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, Fr.</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gruetzmacher, Friedrich</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, Frédéric</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, Friedrich Wilhelm Ludwig</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="4">navo</subfield>
+    <subfield code="i">Vollstaendiger Name</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Gritzmacher, F.</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Ku-lu-tzu-ma-ha</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Grützmacher, Friedrich Wilhelm Ludwig</subfield>
+    <subfield code="d">1832-1903</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">118698508</subfield>
+    <subfield code="0">http://d-nb.info/gnd/118698508</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">Q66891</subfield>
+    <subfield code="9">v:Herkunft: musicb002</subfield>
+    <subfield code="2">wikidata</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">0000 0001 0917 9316</subfield>
+    <subfield code="9">v:Herkunft: musicb002</subfield>
+    <subfield code="2">isni</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">artist/e5111424-1676-4b3c-924c-2dc2d354bb2c</subfield>
+    <subfield code="9">v:Herkunft: musicb002</subfield>
+    <subfield code="2">musicb</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-118698508</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/990191585910206441.json
+++ b/src/test/resources/alma-fix/990191585910206441.json
@@ -1,0 +1,163 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/990191585910206441#!",
+  "type" : [ "BibliographicResource", "Map" ],
+  "medium" : [ {
+    "label" : "Print",
+    "id" : "http://rdaregistry.info/termList/RDAproductionMethod/1010"
+  } ],
+  "title" : "Lotharingia, Vastvm Regnvm",
+  "almaMmsId" : "990191585910206441",
+  "hbzId" : "HT017250243",
+  "deprecatedUri" : "http://lobid.org/resources/HT017250243#!",
+  "oclcNumber" : [ "1075833123" ],
+  "alternativeTitle" : [ "Lotharingia, Vastum Regnum" ],
+  "edition" : [ "[Nachdr. der Ausg.] Argentin., 1513" ],
+  "publication" : [ {
+    "dateStatement" : "[s.a.]",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Sarreguimines" ],
+    "publishedBy" : [ "Imp. Sarregueminoise" ],
+    "startDate" : "0000"
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/990191585910206441",
+    "label" : "Webseite der hbz-Ressource 990191585910206441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/990191585910206441",
+        "dateCreated" : "2012-06-08",
+        "dateModified" : "2026-07-17",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 990191585910206441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-385#!",
+          "label" : "Universitätsbibliothek Trier"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-385#!",
+          "label" : "Universitätsbibliothek Trier"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "natureOfContent" : [ {
+    "label" : "Altkarte",
+    "id" : "https://d-nb.info/gnd/4611904-8"
+  } ],
+  "subject" : [ {
+    "type" : [ "ComplexSubject" ],
+    "label" : "Lothringen",
+    "componentList" : [ {
+      "type" : [ "PlaceOrGeographicName" ],
+      "label" : "Lothringen",
+      "source" : {
+        "label" : "Gemeinsame Normdatei (GND)",
+        "id" : "https://d-nb.info/gnd/7749153-1"
+      },
+      "id" : "https://d-nb.info/gnd/4036377-6",
+      "gndIdentifier" : "4036377-6",
+      "altLabel" : [ "Lorraine", "Lotharingien", "Herzogtum Lothringen", "Duché de Lorraine", "Province de Lorraine", "Staat Lothringen" ]
+    } ]
+  } ],
+  "subjectslabels" : [ "Lothringen" ],
+  "hasItem" : [ {
+    "label" : "lobid Bestandsressource",
+    "type" : [ "Item", "PhysicalObject" ],
+    "callNumber" : "RL/gk245",
+    "inventoryNumber" : "S191-212",
+    "serialNumber" : "0082.5924.51",
+    "currentLibrary" : "TF011",
+    "currentLocation" : "44",
+    "heldBy" : {
+      "isil" : "DE-385",
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier"
+    },
+    "seeAlso" : [ "https://tricat.uni-trier.de/permalink/49HBZ_UBT/1hikhph/alma990191585910206441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-385#!",
+      "label" : "Universitätsbibliothek Trier",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/990191585910206441:DE-385:23281420520006470#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)990191585910206441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1075833123",
+    "label" : "OCLC-Ressource"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/organisations/DE-655#!",
+    "label" : "hbz - Hochschulbibliothekszentrum des Landes Nordrhein-Westfalen, Netzwerkzone",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/lat",
+    "label" : "Latein"
+  } ],
+  "extent" : "1 Kt. : mehrfarb. ; 26 x 36 cm",
+  "note" : [ "Sachtitel im Kt.-Bild", "Kartograph. ermittelt", "S oben. - Maßstab in graph. Form (Scala miliar.). - 2 Wappen oben, 17 Wappen im Kartenrahmen rechts und unten" ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Iohannis Schotti" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "119353717",
+      "id" : "https://d-nb.info/gnd/119353717",
+      "label" : "Waldseemüller, Martin",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1470",
+      "dateOfDeath" : "1520",
+      "altLabel" : [ "Waltzemuller, Martin Hylacomylus", "Hylocomylus, Martin", "Waltzemüller, Martin", "Ylacomilus, Martinus", "Walseemuller, Martin", "Waltzenmüller, Martin", "Hilacomylus, Martinus", "Ilacomylus, Martinus", "Hylacomylus, Martinus", "Hilacomilus, Martinus", "Hylacomilus, Martinus", "Ilacomilus, Martinus", "Hylacomylus, Martin", "Ilacomilus" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/ctg",
+      "label" : "Kartografie"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "124577008",
+      "id" : "https://d-nb.info/gnd/124577008",
+      "label" : "Schott, Johann",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1477",
+      "dateOfDeath" : "1548",
+      "altLabel" : [ "Schottus, Joannes", "Scotus, Joannes", "Scotus, Johannes", "Scotus, Johann", "Schott, Hans", "Schottus, Ioannes", "Schottus, Johannes", "Scotus, Johannes aus Straßburg", "Schott, Johannes", "Schott, Jean", "Schött, Johann", "Schött, Johannes", "Schotus, Johannes", "Scotus, Johannes, aus Strassburg", "J.S." ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/oth",
+      "label" : "Sonstige"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/990191585910206441.json
+++ b/src/test/resources/alma-fix/990191585910206441.json
@@ -17,8 +17,7 @@
     "dateStatement" : "[s.a.]",
     "type" : [ "PublicationEvent" ],
     "location" : [ "Sarreguimines" ],
-    "publishedBy" : [ "Imp. Sarregueminoise" ],
-    "startDate" : "0000"
+    "publishedBy" : [ "Imp. Sarregueminoise" ]
   } ],
   "describedBy" : {
     "id" : "http://lobid.org/resources/990191585910206441",

--- a/src/test/resources/alma-fix/990191585910206441.xml
+++ b/src/test/resources/alma-fix/990191585910206441.xml
@@ -1,0 +1,549 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>01393nem#a2200385#c#4500</leader>
+  <controlfield tag="003">DE-605</controlfield>
+  <controlfield tag="005">20210409051755.0</controlfield>
+  <controlfield tag="007">au#|||||</controlfield>
+  <controlfield tag="008">120608|0000####fr #######|###|#|###lat#c</controlfield>
+  <controlfield tag="001">990191585910206441</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="a">1075833123</subfield>
+    <subfield code="2">OCoLC</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-605)HT017250243</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">385</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="d">385</subfield>
+    <subfield code="e">rakwb</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">lat</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-FR</subfield>
+  </datafield>
+  <datafield tag="245" ind1="0" ind2="0">
+    <subfield code="a">Lotharingia, Vastvm Regnvm</subfield>
+    <subfield code="c">Iohannis Schotti</subfield>
+  </datafield>
+  <datafield tag="246" ind1="3" ind2=" ">
+    <subfield code="a">Lotharingia, Vastum Regnum</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">[Nachdr. der Ausg.] Argentin., 1513</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">[Sarreguimines]</subfield>
+    <subfield code="b">Imp. Sarregueminoise</subfield>
+    <subfield code="c">[s.a.]</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 Kt. : mehrfarb. ; 26 x 36 cm</subfield>
+  </datafield>
+  <datafield tag="689" ind1="0" ind2="0">
+    <subfield code="a">Lothringen</subfield>
+    <subfield code="D">g</subfield>
+    <subfield code="0">(DE-588)4036377-6</subfield>
+    <subfield code="B">GND-040363775</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1075833123</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)HBZHT017250243</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">030</subfield>
+    <subfield code="A">a|1uc||||||35</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">050</subfield>
+    <subfield code="A">||||||||||a|||</subfield>
+  </datafield>
+  <datafield tag="964" ind1="0" ind2="s">
+    <subfield code="F">051</subfield>
+    <subfield code="A">m|||||||</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Waldseemüller, Martin</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="0">(DE-588)119353717</subfield>
+    <subfield code="4">ctg</subfield>
+    <subfield code="0">https://d-nb.info/gnd/119353717</subfield>
+    <subfield code="0">http://viaf.org/viaf/27366067</subfield>
+    <subfield code="B">GND-119353717</subfield>
+  </datafield>
+  <datafield tag="700" ind1="1" ind2=" ">
+    <subfield code="a">Schott, Johann</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="0">(DE-588)124577008</subfield>
+    <subfield code="4">oth</subfield>
+    <subfield code="0">https://d-nb.info/gnd/124577008</subfield>
+    <subfield code="0">http://viaf.org/viaf/12610021</subfield>
+    <subfield code="B">GND-124577008</subfield>
+  </datafield>
+  <datafield tag="751" ind1=" " ind2=" ">
+    <subfield code="a">Straßburg</subfield>
+    <subfield code="0">(DE-588)4057878-1</subfield>
+    <subfield code="4">pup</subfield>
+    <subfield code="0">https://d-nb.info/gnd/04057878X</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+  </datafield>
+  <datafield tag="772" ind1="0" ind2="8">
+    <subfield code="i">Orig. ersch. in</subfield>
+    <subfield code="t">Ptolemaeus, Claudius: Geographia</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="a">Altkarte</subfield>
+    <subfield code="0">(DE-588)4611904-8</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Sachtitel im Kt.-Bild</subfield>
+    <subfield code="9">F:507</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Kartograph. ermittelt</subfield>
+    <subfield code="9">F:509</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">S oben. - Maßstab in graph. Form (Scala miliar.). - 2 Wappen oben, 17 Wappen im Kartenrahmen rechts und unten</subfield>
+    <subfield code="9">F:517</subfield>
+  </datafield>
+  <datafield tag="534" ind1=" " ind2=" ">
+    <subfield code="c">1513</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">990191585910206441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="i">990019447310106470</subfield>
+    <subfield code="n">UB Trier</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">System</subfield>
+    <subfield code="f">ILS</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">59</subfield>
+    <subfield code="k">01</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-07-17 04:13:31 Europe/Berlin</subfield>
+    <subfield code="g">019158591-HBZ01</subfield>
+    <subfield code="j">60</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="b">2021-04-05 11:42:39 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="H52" ind1="8" ind2=" ">
+    <subfield code="b">TF011</subfield>
+    <subfield code="c">44</subfield>
+    <subfield code="h">RL/gk245</subfield>
+    <subfield code="8">22281420530006470</subfield>
+  </datafield>
+  <datafield tag="HOL" ind1=" " ind2=" ">
+    <subfield code="d">2023-12-11 05:28:55</subfield>
+    <subfield code="8">22281420530006470</subfield>
+    <subfield code="b">2023-08-13 16:30:12</subfield>
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="g">false</subfield>
+    <subfield code="a">import</subfield>
+    <subfield code="c">System</subfield>
+  </datafield>
+  <datafield tag="ITM" ind1=" " ind2=" ">
+    <subfield code="H">22281420530006470</subfield>
+    <subfield code="x">44</subfield>
+    <subfield code="f">MAP</subfield>
+    <subfield code="v">44</subfield>
+    <subfield code="p">44</subfield>
+    <subfield code="X">System</subfield>
+    <subfield code="U">2012-06-12 12:59:00 Europe/Berlin</subfield>
+    <subfield code="Y">2023-12-11 06:28:55 Europe/Berlin</subfield>
+    <subfield code="h">false</subfield>
+    <subfield code="n">RL/gk245</subfield>
+    <subfield code="P">86/a/r/</subfield>
+    <subfield code="M">49HBZ_UBT</subfield>
+    <subfield code="s">1</subfield>
+    <subfield code="d">8</subfield>
+    <subfield code="V">import</subfield>
+    <subfield code="b">0082.5924.51</subfield>
+    <subfield code="N">Z30-PRICE: 0.00</subfield>
+    <subfield code="a">23281420520006470</subfield>
+    <subfield code="t">8</subfield>
+    <subfield code="c">RL/gk245</subfield>
+    <subfield code="S">BE12-7235</subfield>
+    <subfield code="B">S191-212</subfield>
+    <subfield code="D">20120612</subfield>
+    <subfield code="W">2012-06-12 02:00:00 Europe/Berlin</subfield>
+    <subfield code="u">TF011</subfield>
+    <subfield code="w">TF011</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4036377-6</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4036377-6</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Lorraine</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Lotharingien</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Herzogtum Lothringen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Duché de Lorraine</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Province de Lorraine</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Staat Lothringen</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-040363775</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schottus, Joannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Scotus, Joannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Scotus, Johannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Scotus, Johann</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schott, Hans</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schottus, Ioannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schottus, Johannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">J.S.</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Scotus, Johannes aus Straßburg</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schott, Johannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schott, Jean</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schött, Johann</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schött, Johannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Schotus, Johannes</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Scotus, Johannes</subfield>
+    <subfield code="c">aus Strassburg</subfield>
+    <subfield code="d">1477-1548</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">124577008</subfield>
+    <subfield code="0">http://d-nb.info/gnd/124577008</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-124577008</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Waltzemuller, Martin Hylacomylus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hylocomylus, Martin</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Waltzemüller, Martin</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="0" ind2=" ">
+    <subfield code="a">Ilacomilus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="4">pseu</subfield>
+    <subfield code="i">Pseudonym</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Ylacomilus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Walseemuller, Martin</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Waltzenmüller, Martin</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hilacomylus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Ilacomylus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hylacomylus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hilacomilus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hylacomilus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Ilacomilus, Martinus</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GPN" ind1="1" ind2=" ">
+    <subfield code="a">Hylacomylus, Martin</subfield>
+    <subfield code="d">1470-1520</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">400</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">119353717</subfield>
+    <subfield code="0">http://d-nb.info/gnd/119353717</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-119353717</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">4057878-1</subfield>
+    <subfield code="0">http://d-nb.info/gnd/4057878-1</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">2973783</subfield>
+    <subfield code="2">geonames</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strassburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Straßbourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strasbourg</subfield>
+    <subfield code="9">v:franz.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Argentoratum</subfield>
+    <subfield code="9">v:lat.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Argentorate</subfield>
+    <subfield code="9">v:lat.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strateburgum</subfield>
+    <subfield code="9">v:seit 6. Jh. bezeugt</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Stratisburgo</subfield>
+    <subfield code="9">v:M; 6. Jh.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strossburi</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Ville de Strasbourg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Estrasburgo</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strasburg</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Straßburg/Elsaß</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+  <datafield tag="GGN" ind1=" " ind2=" ">
+    <subfield code="a">Strassburg i. E.</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-04057878X</subfield>
+    <subfield code="C">451</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/99370687546706441.json
+++ b/src/test/resources/alma-fix/99370687546706441.json
@@ -1,0 +1,348 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99370687546706441#!",
+  "type" : [ "BibliographicResource", "Periodical", "Proceedings" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Seminaria Niedzickie",
+  "almaMmsId" : "99370687546706441",
+  "urn" : [ "urn:nbn:de:bsz:16-diglit-415873" ],
+  "dnbId" : "1165908344",
+  "zdbId" : "2941183-X",
+  "alternativeTitle" : [ "Seminaria Niedzickie" ],
+  "otherTitleInformation" : [ "zwia̧zki artystyczne polsko-czesko-slowacko-wegierskie = Niedzica Seminars : Polish-Czech-Slovak-Hungarian artistic connections" ],
+  "publication" : [ {
+    "dateStatement" : "0000",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Heidelberg" ],
+    "publishedBy" : [ "Universitätsbibliothek Heidelberg" ],
+    "publicationHistory" : "1.1981 - 7.1991(1992)",
+    "frequency" : [ {
+      "id" : "http://marc21rdf.info/terms/continuingfre#u",
+      "label" : "unbekannte Erscheinungsfrequenz"
+    } ],
+    "endDate" : "0000",
+    "status" : {
+      "id" : "http://id.loc.gov/vocabulary/mstatus/ceased",
+      "label" : "eingestellt"
+    }
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99370687546706441",
+    "label" : "Webseite der hbz-Ressource 99370687546706441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99370687546706441",
+        "dateCreated" : "2018-08-31",
+        "dateModified" : "2026-02-19",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99370687546706441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/DE-16-77#!",
+          "label" : "Centre for Asian and Transcultural Studies (CATS), Abteilung Südasien"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/DE-101#!",
+          "label" : "Deutsche Nationalbibliothek"
+        },
+        "modifiedBy" : [ {
+          "id" : "http://lobid.org/organisations/DE-16-77#!",
+          "label" : "Centre for Asian and Transcultural Studies (CATS), Abteilung Südasien"
+        } ]
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "natureOfContent" : [ {
+    "label" : "Zeitschrift",
+    "id" : "https://d-nb.info/gnd/4067488-5"
+  } ],
+  "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ZBS/openurl?u.ignore_date_coverage=true&portfolio_pid=5329464520006478&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ZBS/openurl?u.ignore_date_coverage=true&rft.mms_id=998475354406478",
+    "heldBy" : {
+      "isil" : "DE-Kn41",
+      "id" : "http://lobid.org/organisations/DE-Kn41#!",
+      "label" : "Zentralbibliothek der Sportwissenschaften der Deutschen Sporthochschule Köln"
+    },
+    "seeAlso" : [ "https://primo.zbsport.dshs-koeln.de/permalink/49HBZ_ZBS/18h80sa/alma99370687546706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Kn41#!",
+      "label" : "Zentralbibliothek der Sportwissenschaften der Deutschen Sporthochschule Köln",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-Kn41:5329464520006478#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&portfolio_pid=53139658110006464&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_FUH/openurl?u.ignore_date_coverage=true&rft.mms_id=99381836020606464",
+    "heldBy" : {
+      "isil" : "DE-708",
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität"
+    },
+    "seeAlso" : [ "https://fub-hagen.digibib.net/search/katalog/record/(DE-600)2941183-X" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-708#!",
+      "label" : "Universitätsbibliothek der Fernuniversität",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-708:53139658110006464#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_RTU/openurl?u.ignore_date_coverage=true&portfolio_pid=53117704320007476&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_RTU/openurl?u.ignore_date_coverage=true&rft.mms_id=992022037882807476",
+    "heldBy" : {
+      "isil" : "DE-386",
+      "id" : "http://lobid.org/organisations/DE-386#!",
+      "label" : "Universitätsbibliothek der RPTU in Kaiserslautern"
+    },
+    "seeAlso" : [ "https://hbz-rptu.primo.exlibrisgroup.com/permalink/49HBZ_RTU/11q51gp/alma99370687546706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-386#!",
+      "label" : "Universitätsbibliothek der RPTU in Kaiserslautern",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-386:53117704320007476#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_TGA/openurl?u.ignore_date_coverage=true&portfolio_pid=5314856200006469&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_TGA/openurl?u.ignore_date_coverage=true&rft.mms_id=991000714195606469",
+    "heldBy" : {
+      "isil" : "DE-Bm1",
+      "id" : "http://lobid.org/organisations/DE-Bm1#!",
+      "label" : "Technische Hochschule Georg Agricola, Hochschulbibliothek"
+    },
+    "seeAlso" : [ "https://thga.digibib.net/search/katalog/record/(DE-600)2941183-X" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Bm1#!",
+      "label" : "Technische Hochschule Georg Agricola, Hochschulbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-Bm1:5314856200006469#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&portfolio_pid=53345676760006467&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULB/openurl?u.ignore_date_coverage=true&rft.mms_id=991045253632906467",
+    "heldBy" : {
+      "isil" : "DE-5",
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn"
+    },
+    "seeAlso" : [ "https://bonnus.ulb.uni-bonn.de/permalink/49HBZ_ULB/idtnkp/alma99370687546706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-5#!",
+      "label" : "Universitäts- und Landesbibliothek Bonn",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-5:53345676760006467#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UDE/openurl?u.ignore_date_coverage=true&portfolio_pid=53439607740006446&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UDE/openurl?u.ignore_date_coverage=true&rft.mms_id=99206357762906446",
+    "heldBy" : {
+      "isil" : "DE-465",
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen"
+    },
+    "seeAlso" : [ "https://primo.uni-due.de/discovery/search?query=any,contains,99370687546706441&tab=Everything&search_scope=MyInst_and_CI_custom&vid=49HBZ_UDE:UDE&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-465#!",
+      "label" : "Universitätsbibliothek Duisburg-Essen",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-465:53439607740006446#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&portfolio_pid=53354860110006443&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_DUE/openurl?u.ignore_date_coverage=true&rft.mms_id=9947420427506443",
+    "heldBy" : {
+      "isil" : "DE-61",
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf"
+    },
+    "seeAlso" : [ "https://katalog.ulb.hhu.de/Search/Results?lookfor=id_marc_001_txt:99370687546706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-61#!",
+      "label" : "Universitäts- und Landesbibliothek Düsseldorf",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-61:53354860110006443#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&portfolio_pid=53351364450006476&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UBK/openurl?u.ignore_date_coverage=true&rft.mms_id=991055654856706476",
+    "heldBy" : {
+      "isil" : "DE-38",
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-koeln.de/portal/search.html?num=20&page=1&l=de&srt=year_desc&tab=books&hbzid=99370687546706441&fdb=uni" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-38#!",
+      "label" : "Universitäts- und Stadtbibliothek Köln, Hauptabteilung",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-38:53351364450006476#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&portfolio_pid=53629009990006449&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_ULM/openurl?u.ignore_date_coverage=true&rft.mms_id=991044841304506449",
+    "heldBy" : {
+      "isil" : "DE-6",
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek"
+    },
+    "seeAlso" : [ "https://hbz-ulbms.primo.exlibrisgroup.com/discovery/search?query=any,contains,99370687546706441&tab=Everything&search_scope=MyInst_and_CI&vid=49HBZ_ULM:VU2&offset=0" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-6#!",
+      "label" : "Universitäts- und Landesbibliothek Münster, Zentralbibliothek",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-6:53629009990006449#!"
+  }, {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "enumerationAndChronology" : "Available from 1981 volume: 1 until 1991 volume: 7.",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&portfolio_pid=53173769520006463&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_PAD/openurl?u.ignore_date_coverage=true&rft.mms_id=9925046814106463",
+    "heldBy" : {
+      "isil" : "DE-466",
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn"
+    },
+    "seeAlso" : [ "https://katalog.ub.uni-paderborn.de/local/s?sr[q,any]=99370687546706441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-466#!",
+      "label" : "Universitätsbibliothek Paderborn",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99370687546706441:DE-466:53173769520006463#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99370687546706441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://ld.zdb-services.de/resource/2941183-X",
+    "label" : "ZDB-Ressource"
+  }, {
+    "id" : "https://d-nb.info/1165908344",
+    "label" : "DNB-Ressource"
+  }, {
+    "id" : "https://nbn-resolving.org/urn:nbn:de:bsz:16-diglit-415873",
+    "label" : "URN-Link"
+  } ],
+  "isPartOf" : [ {
+    "hasSuperordinate" : [ {
+      "label" : "Heidelberger historische Bestände - digital"
+    } ],
+    "type" : [ "IsPartOfRelation" ]
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://nbn-resolving.org/urn:nbn:de:bsz:16-diglit-415873",
+    "label" : "URN-Link"
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  }, {
+    "id" : "http://lobid.org/resources/HT014846970#!",
+    "label" : "Zeitschriftendatenbank (ZDB)",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/pol",
+    "label" : "Polnisch"
+  } ],
+  "extent" : "Online-Ressource",
+  "note" : [ "Digitalisierungsprojekt", "Reproduktion" ],
+  "bibliographicLevel" : {
+    "label" : "Serial",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Serial"
+  },
+  "responsibilityStatement" : [ "Oddział Krakowski, Stowarzyszenie Historyków Sztuki ; Muzeum Narodowe w Krakowie" ],
+  "contribution" : [ {
+    "agent" : {
+      "gndIdentifier" : "3022907-8",
+      "id" : "https://d-nb.info/gnd/3022907-8",
+      "label" : "Stowarzyszenie Historyków Sztuki. Oddział (Krakau)",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Oddział Krakowski SHS", "Oddział Krakowski Stowarzyszenia Historyków Sztuki", "SHS Kraków", "Stowarzyszenie Historyków Sztuki. Cracow Division", "Stowarzyszenie Historyków Sztuki. Oddział w Krakowie" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "1021512-8",
+      "id" : "https://d-nb.info/gnd/1021512-8",
+      "label" : "Muzeum Narodowe w Krakowie",
+      "type" : [ "CorporateBody" ],
+      "altLabel" : [ "Nationalmuseum in Krakau", "Nationalmuseum Krakau", "Polnisches Nationalmuseum Krakau", "National Museum in Krakow", "Musée National de Cracovie", "Museum Nationale Cracoviense", "Nationaal Museum Krakow", "Kurakufu Kokuritsu Bijutsukan", "Muzeum Narodowe (Krakau)", "クラクフ国立美術館" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/isb",
+      "label" : "Herausgeber/in"
+    },
+    "type" : [ "Contribution" ]
+  }, {
+    "agent" : {
+      "gndIdentifier" : "1214585-3",
+      "id" : "https://d-nb.info/gnd/1214585-3",
+      "label" : "Niedzica Seminars",
+      "type" : [ "ConferenceOrEvent" ],
+      "altLabel" : [ "Niedzica Seminars" ]
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99370687546706441.json
+++ b/src/test/resources/alma-fix/99370687546706441.json
@@ -26,6 +26,7 @@
       "id" : "http://marc21rdf.info/terms/continuingfre#u",
       "label" : "unbekannte Erscheinungsfrequenz"
     } ],
+    "startDate" : "2018",
     "endDate" : "0000",
     "status" : {
       "id" : "http://id.loc.gov/vocabulary/mstatus/ceased",

--- a/src/test/resources/alma-fix/99370687546706441.json
+++ b/src/test/resources/alma-fix/99370687546706441.json
@@ -27,7 +27,6 @@
       "label" : "unbekannte Erscheinungsfrequenz"
     } ],
     "startDate" : "2018",
-    "endDate" : "0000",
     "status" : {
       "id" : "http://id.loc.gov/vocabulary/mstatus/ceased",
       "label" : "eingestellt"

--- a/src/test/resources/alma-fix/99370687546706441.xml
+++ b/src/test/resources/alma-fix/99370687546706441.xml
@@ -1,0 +1,692 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>02008nas a22004338c 4500</leader>
+  <controlfield tag="001">99370687546706441</controlfield>
+  <controlfield tag="005">20260218111125.0</controlfield>
+  <controlfield tag="007">cr||||||||||||</controlfield>
+  <controlfield tag="008">180831d20180000pl u||p|o ||| 1||||1pol c</controlfield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="2">DE-101</subfield>
+    <subfield code="a">1165908344</subfield>
+  </datafield>
+  <datafield tag="016" ind1="7" ind2=" ">
+    <subfield code="2">DE-600</subfield>
+    <subfield code="a">2941183-X</subfield>
+  </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="2">urn</subfield>
+    <subfield code="a">urn:nbn:de:bsz:16-diglit-415873</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)5280000000204485</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)ZDB2941183-X</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-101)1165908344</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-599)2941183-X</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)995280000000204485</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">0016</subfield>
+    <subfield code="b">ger</subfield>
+    <subfield code="c">DE-101</subfield>
+    <subfield code="d">0016</subfield>
+    <subfield code="e">rda</subfield>
+  </datafield>
+  <datafield tag="041" ind1=" " ind2=" ">
+    <subfield code="a">pol</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="c">XA-PL</subfield>
+  </datafield>
+  <datafield tag="082" ind1="7" ind2="4">
+    <subfield code="a">900</subfield>
+    <subfield code="q">DE-600</subfield>
+    <subfield code="2">23sdnb</subfield>
+  </datafield>
+  <datafield tag="111" ind1="2" ind2=" ">
+    <subfield code="a">Niedzica Seminars</subfield>
+    <subfield code="j">Verfasser</subfield>
+    <subfield code="0">(DE-588)1214585-3</subfield>
+    <subfield code="0">https://d-nb.info/gnd/1214585-3</subfield>
+    <subfield code="0">(DE-101)004497295</subfield>
+    <subfield code="4">aut</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="0">https://d-nb.info/gnd/004497295</subfield>
+    <subfield code="0">http://viaf.org/viaf/172623366</subfield>
+    <subfield code="B">GND-004497295</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Seminaria Niedzickie</subfield>
+    <subfield code="b">zwia̧zki artystyczne polsko-czesko-slowacko-wegierskie = Niedzica Seminars : Polish-Czech-Slovak-Hungarian artistic connections</subfield>
+    <subfield code="c">Oddział Krakowski, Stowarzyszenie Historyków Sztuki ; Muzeum Narodowe w Krakowie</subfield>
+  </datafield>
+  <datafield tag="246" ind1=" " ind2=" ">
+    <subfield code="a">Seminaria Niedzickie</subfield>
+  </datafield>
+  <datafield tag="246" ind1="1" ind2="1">
+    <subfield code="a">Niedzica Seminars</subfield>
+    <subfield code="b">Polish-Czech-Slovak-Hungarian artistic connections</subfield>
+  </datafield>
+  <datafield tag="264" ind1="3" ind2="1">
+    <subfield code="a">Heidelberg</subfield>
+    <subfield code="b">Universitätsbibliothek Heidelberg</subfield>
+    <subfield code="c">0000</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">Online-Ressource</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">Text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">Computermedien</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">Online-Ressource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="362" ind1="0" ind2=" ">
+    <subfield code="a">1.1981 - 7.1991(1992)</subfield>
+  </datafield>
+  <datafield tag="363" ind1="0" ind2="0">
+    <subfield code="8">1.1\x</subfield>
+    <subfield code="a">1</subfield>
+    <subfield code="i">1981</subfield>
+  </datafield>
+  <datafield tag="363" ind1="1" ind2="0">
+    <subfield code="8">1.2\x</subfield>
+    <subfield code="a">7</subfield>
+    <subfield code="i">1991</subfield>
+  </datafield>
+  <datafield tag="490" ind1="0" ind2=" ">
+    <subfield code="a">Heidelberger historische Bestände - digital</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Digitalisierungsprojekt</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" ">
+    <subfield code="a">Reproduktion</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="7">
+    <subfield code="0">(DE-588)4067488-5</subfield>
+    <subfield code="0">https://d-nb.info/gnd/4067488-5</subfield>
+    <subfield code="0">(DE-101)040674886</subfield>
+    <subfield code="a">Zeitschrift</subfield>
+    <subfield code="2">gnd-content</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="0">(DE-588)3022907-8</subfield>
+    <subfield code="0">https://d-nb.info/gnd/3022907-8</subfield>
+    <subfield code="0">(DE-101)942300661</subfield>
+    <subfield code="a">Stowarzyszenie Historyków Sztuki</subfield>
+    <subfield code="b">Oddział</subfield>
+    <subfield code="g">Krakau</subfield>
+    <subfield code="e">Herausgebendes Organ</subfield>
+    <subfield code="4">isb</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="0">https://d-nb.info/gnd/942300661</subfield>
+    <subfield code="0">http://viaf.org/viaf/125132112</subfield>
+    <subfield code="B">GND-942300661</subfield>
+  </datafield>
+  <datafield tag="710" ind1="2" ind2=" ">
+    <subfield code="a">Muzeum Narodowe w Krakowie,</subfield>
+    <subfield code="e">Herausgebendes Organ</subfield>
+    <subfield code="0">(DE-588)1021512-8</subfield>
+    <subfield code="0">https://d-nb.info/gnd/1021512-8</subfield>
+    <subfield code="0">(DE-101)004127323</subfield>
+    <subfield code="4">isb</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="0">https://d-nb.info/gnd/004127323</subfield>
+    <subfield code="0">http://viaf.org/viaf/169063657</subfield>
+    <subfield code="B">GND-004127323</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">JOURNAL</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99370687546706441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ZBS</subfield>
+    <subfield code="i">998475354406478</subfield>
+    <subfield code="n">Deutsche Sporthochschule Köln</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="i">9925046814106463</subfield>
+    <subfield code="n">Universitätsbibliothek Paderborn</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_FUH</subfield>
+    <subfield code="i">99381836020606464</subfield>
+    <subfield code="n">Fernuniversität Hagen</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_RTU</subfield>
+    <subfield code="i">992022037882807476</subfield>
+    <subfield code="n">RPTU Kaiserslautern-Landau</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_TGA</subfield>
+    <subfield code="i">991000714195606469</subfield>
+    <subfield code="n">Technische Fachhochschule - Georg Agricola</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULB</subfield>
+    <subfield code="i">991045253632906467</subfield>
+    <subfield code="n">Universitaet Bonn</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="i">99206357762906446</subfield>
+    <subfield code="n">Universität Duisburg-Essen</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_DUE</subfield>
+    <subfield code="i">9947420427506443</subfield>
+    <subfield code="n">Universität Düsseldorf</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="i">991055654856706476</subfield>
+    <subfield code="n">Universität Köln</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="i">991044841304506449</subfield>
+    <subfield code="n">Universität Münster</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">system</subfield>
+    <subfield code="f">CKB</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">82</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-02-19 01:35:16 Europe/Berlin</subfield>
+    <subfield code="g">995280000000204485</subfield>
+    <subfield code="a">CKB</subfield>
+    <subfield code="b">2021-04-19 21:07:40 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5329464520006478</subfield>
+    <subfield code="M">49HBZ_ZBS</subfield>
+    <subfield code="p">6127036270006478</subfield>
+    <subfield code="q">EZB-FREE-00999 freely available EZB journals</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 18:42:28 Europe/Berlin</subfield>
+    <subfield code="w">2023-08-14 14:21:11 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5329464520006478&amp;Force_direct=true</subfield>
+    <subfield code="v">NON_SFX_CREATOR</subfield>
+    <subfield code="z">2023-08-14 12:21:11</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">6227036260006478</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=998475354406478</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">5329464520006478</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">5329464520006478</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53139658110006464</subfield>
+    <subfield code="h">EZProxy</subfield>
+    <subfield code="M">49HBZ_FUH</subfield>
+    <subfield code="p">61136607210006464</subfield>
+    <subfield code="q">EZB-FREE-00999 freely available EZB journals</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 06:39:45 Europe/Berlin</subfield>
+    <subfield code="w">2022-07-05 10:24:22 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53139658110006464&amp;Force_direct=true</subfield>
+    <subfield code="v">NON_SFX_CREATOR</subfield>
+    <subfield code="z">2022-07-05 08:24:22</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62136607200006464</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=99381836020606464</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53139658110006464</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53139658110006464</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53117704320007476</subfield>
+    <subfield code="M">49HBZ_RTU</subfield>
+    <subfield code="p">61116949210007476</subfield>
+    <subfield code="q">Frei zugängliche E-Journals (Freely available e-journals)</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 23:05:44 Europe/Berlin</subfield>
+    <subfield code="w">2022-09-21 11:46:26 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53117704320007476&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2022-09-21 09:46:26</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62116949200007476</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=992022037882807476</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53117704320007476</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53117704320007476</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5314856200006469</subfield>
+    <subfield code="h">DEFAULT</subfield>
+    <subfield code="M">49HBZ_TGA</subfield>
+    <subfield code="p">6112657420006469</subfield>
+    <subfield code="q">Frei zugängliche EZB-Zeitschriften</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 06:18:16 Europe/Berlin</subfield>
+    <subfield code="w">2023-12-12 12:41:35 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5314856200006469&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2023-12-12 11:41:35</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">true</subfield>
+    <subfield code="S">6212657410006469</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991000714195606469</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">5314856200006469</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">5314856200006469</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53345676760006467</subfield>
+    <subfield code="M">49HBZ_ULB</subfield>
+    <subfield code="p">61320827360006467</subfield>
+    <subfield code="q">EZB-FREE-00999 freely available EZB journals</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 19:38:38 Europe/Berlin</subfield>
+    <subfield code="w">2023-07-25 19:46:34 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53345676760006467&amp;Force_direct=true</subfield>
+    <subfield code="v">NON_SFX_CREATOR</subfield>
+    <subfield code="z">2023-07-25 17:46:34</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62320827350006467</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991045253632906467</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53345676760006467</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53345676760006467</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53439607740006446</subfield>
+    <subfield code="M">49HBZ_UDE</subfield>
+    <subfield code="p">61436539580006446</subfield>
+    <subfield code="q">Zu den frei zugänglichen Zeitschriften aus der EZB</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 18:42:24 Europe/Berlin</subfield>
+    <subfield code="w">2021-04-16 15:47:07 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53439607740006446&amp;Force_direct=true</subfield>
+    <subfield code="v">NON_SFX_CREATOR</subfield>
+    <subfield code="z">2021-04-16 13:47:07</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62436539570006446</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=99206357762906446</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53439607740006446</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53439607740006446</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53354860110006443</subfield>
+    <subfield code="M">49HBZ_DUE</subfield>
+    <subfield code="p">61352426420006443</subfield>
+    <subfield code="q">EZB freely available journals</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 06:19:33 Europe/Berlin</subfield>
+    <subfield code="w">2022-04-22 09:19:03 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53354860110006443&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2022-04-22 07:19:03</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62352426410006443</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=9947420427506443</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53354860110006443</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53354860110006443</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53351364450006476</subfield>
+    <subfield code="M">49HBZ_UBK</subfield>
+    <subfield code="k">freier Zugriff</subfield>
+    <subfield code="p">61351291440006476</subfield>
+    <subfield code="q">EZB-FREE-00999 freely available EZB journals</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="B">grüne Ampeln der EZB aller Fächer</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 08:14:36 Europe/Berlin</subfield>
+    <subfield code="w">2023-10-23 10:52:21 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53351364450006476&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2023-10-23 08:52:21</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62351291430006476</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991055654856706476</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53351364450006476</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53351364450006476</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53629009990006449</subfield>
+    <subfield code="M">49HBZ_ULM</subfield>
+    <subfield code="p">61626439470006449</subfield>
+    <subfield code="q">Frei zugängliche Zeitschriften in der EZB</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 19:52:45 Europe/Berlin</subfield>
+    <subfield code="w">2022-07-19 22:21:30 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53629009990006449&amp;Force_direct=true</subfield>
+    <subfield code="v">NON_SFX_CREATOR</subfield>
+    <subfield code="z">2022-07-19 20:21:30</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62626439460006449</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=991044841304506449</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53629009990006449</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53629009990006449</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">Ezb</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">53173769520006463</subfield>
+    <subfield code="M">49HBZ_PAD</subfield>
+    <subfield code="p">61165839590006463</subfield>
+    <subfield code="q">In der EZB frei verfügbare Zeitschriften</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615280000000001088</subfield>
+    <subfield code="y">2026-03-24 06:34:55 Europe/Berlin</subfield>
+    <subfield code="w">2022-08-03 12:02:34 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=53173769520006463&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2022-08-03 10:02:34</subfield>
+    <subfield code="n"> Available from 1981 volume: 1 until 1991 volume: 7.</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">62165839580006463</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=9925046814106463</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">JOURNAL</subfield>
+    <subfield code="8">53173769520006463</subfield>
+  </datafield>
+  <datafield tag="POC" ind1=" " ind2=" ">
+    <subfield code="a">53173769520006463</subfield>
+    <subfield code="b">1981</subfield>
+    <subfield code="c">1991</subfield>
+    <subfield code="d">1</subfield>
+    <subfield code="e">12</subfield>
+    <subfield code="f">1</subfield>
+    <subfield code="g">31</subfield>
+    <subfield code="h">1</subfield>
+    <subfield code="i">7</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Nationalmuseum in Krakau</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Nationalmuseum Krakau</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Polnisches Nationalmuseum Krakau</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">National Museum in Krakow</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Musée National de Cracovie</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Museum Nationale Cracoviense</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Nationaal Museum Krakow</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Kurakufu Kokuritsu Bijutsukan</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Muzeum Narodowe</subfield>
+    <subfield code="g">Krakau</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="9">U:Jpan</subfield>
+    <subfield code="a">クラクフ国立美術館</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">1021512-8</subfield>
+    <subfield code="0">http://d-nb.info/gnd/1021512-8</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004127323</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Oddział Krakowski SHS</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Oddział Krakowski Stowarzyszenia Historyków Sztuki</subfield>
+    <subfield code="4">nauv</subfield>
+    <subfield code="i">Unveraenderte Form</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">SHS Kraków</subfield>
+    <subfield code="4">nauv</subfield>
+    <subfield code="i">Unveraenderte Form</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Stowarzyszenie Historyków Sztuki</subfield>
+    <subfield code="b">Cracow Division</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GKT" ind1="2" ind2=" ">
+    <subfield code="a">Stowarzyszenie Historyków Sztuki</subfield>
+    <subfield code="b">Oddział w Krakowie</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">410</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">3022907-8</subfield>
+    <subfield code="0">http://d-nb.info/gnd/3022907-8</subfield>
+    <subfield code="2">gnd</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">n83144245</subfield>
+    <subfield code="2">lccn</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-942300661</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+  <datafield tag="GKS" ind1="2" ind2=" ">
+    <subfield code="a">Niedzica Seminars</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004497295</subfield>
+    <subfield code="C">411</subfield>
+  </datafield>
+  <datafield tag="GSI" ind1="7" ind2=" ">
+    <subfield code="a">http://d-nb.info/gnd/1214585-3</subfield>
+    <subfield code="2">uri</subfield>
+    <subfield code="A">GND</subfield>
+    <subfield code="B">GND-004497295</subfield>
+    <subfield code="C">024</subfield>
+  </datafield>
+</record>

--- a/src/test/resources/alma-fix/99376424186306441.json
+++ b/src/test/resources/alma-fix/99376424186306441.json
@@ -1,0 +1,167 @@
+{
+  "@context" : "http://lobid.org/resources/context.jsonld",
+  "id" : "http://lobid.org/resources/99376424186306441#!",
+  "type" : [ "BibliographicResource", "Book" ],
+  "medium" : [ {
+    "label" : "Datenträger",
+    "id" : "http://rdaregistry.info/termList/RDAMediaType/1003"
+  }, {
+    "label" : "Online-Ressource",
+    "id" : "http://rdaregistry.info/termList/RDACarrierType/1018"
+  } ],
+  "title" : "Like a Lake",
+  "almaMmsId" : "99376424186306441",
+  "isbn" : [ "9780823289349", "0823289346" ],
+  "doi" : [ "10.1515/9780823289349" ],
+  "oclcNumber" : [ "1196283329", "1193112254" ],
+  "otherTitleInformation" : [ "A Story of Uneasy Love and Photography" ],
+  "edition" : [ "First edition" ],
+  "publication" : [ {
+    "dateStatement" : "2020",
+    "startDate" : "2020",
+    "type" : [ "PublicationEvent" ],
+    "location" : [ "Baltimore, Maryland" ],
+    "publishedBy" : [ "Project Muse" ]
+  } ],
+  "manufacture" : [ {
+    "dateStatement" : "0000",
+    "startDate" : "0000",
+    "type" : [ "Event" ],
+    "location" : [ "Baltimore, Md." ],
+    "manufacturedBy" : [ "Project MUSE" ]
+  } ],
+  "describedBy" : {
+    "id" : "http://lobid.org/resources/99376424186306441",
+    "label" : "Webseite der hbz-Ressource 99376424186306441",
+    "type" : [ "BibliographicDescription" ],
+    "inDataset" : {
+      "id" : "http://lobid.org/resources/dataset#!",
+      "label" : "lobid-resources – Der hbz-Verbundkatalog als Linked Open Data"
+    },
+    "resultOf" : {
+      "type" : [ "CreateAction" ],
+      "endTime" : "0000-00-00T00:00:00",
+      "instrument" : {
+        "id" : "https://github.com/hbz/lobid-resources",
+        "type" : [ "SoftwareApplication" ],
+        "label" : "Software lobid-resources"
+      },
+      "object" : {
+        "id" : "https://lobid.org/marcxml/99376424186306441",
+        "dateCreated" : "2020-09-18",
+        "dateModified" : "2026-07-21",
+        "type" : [ "DataFeedItem" ],
+        "label" : "hbz-Ressource 99376424186306441 im Exportformat MARC21 XML",
+        "inDataset" : {
+          "id" : "https://datahub.io/dataset/hbz_unioncatalog",
+          "label" : "hbz_unioncatalog"
+        },
+        "sourceOrganization" : {
+          "id" : "http://lobid.org/organisations/XX-MdBmJHUP#!",
+          "label" : "lobid Organisation"
+        },
+        "provider" : {
+          "id" : "http://lobid.org/organisations/XX-MdBmJHUP#!",
+          "label" : "lobid Organisation"
+        }
+      }
+    },
+    "license" : [ {
+      "id" : "http://creativecommons.org/publicdomain/zero/1.0",
+      "label" : "Creative Commons-Lizenz CC0 1.0 Universal"
+    } ]
+  },
+  "subject" : [ {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Photography / 20th century / Fiction."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Library of Congress Subject Headings",
+      "id" : "https://id.loc.gov/authorities/subjects.html"
+    },
+    "label" : "Mothers and sons / Fiction."
+  }, {
+    "type" : [ "Concept" ],
+    "source" : {
+      "label" : "Dewey-Dezimalklassifikation",
+      "id" : "https://d-nb.info/gnd/4149423-4"
+    },
+    "label" : "813/.6",
+    "notation" : "813/.6",
+    "version" : "23"
+  } ],
+  "subjectslabels" : [ "Photography / 20th century / Fiction.", "Mothers and sons / Fiction." ],
+  "hasItem" : [ {
+    "type" : [ "Item", "DigitalDocument" ],
+    "label" : "Electronic Portfolio",
+    "electronicLocator" : "https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_UKO/openurl?u.ignore_date_coverage=true&portfolio_pid=5363159820008057&Force_direct=true",
+    "sublocation" : "https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_UKO/openurl?u.ignore_date_coverage=true&rft.mms_id=9910217893208057",
+    "heldBy" : {
+      "isil" : "DE-Kob7",
+      "id" : "http://lobid.org/organisations/DE-Kob7#!",
+      "label" : "Universitätsbibliothek Koblenz"
+    },
+    "seeAlso" : [ "https://primo.uni-koblenz.de/permalink/49HBZ_UKO/16pslu1/alma99376424186306441" ],
+    "inCollection" : [ {
+      "id" : "http://lobid.org/organisations/DE-Kob7#!",
+      "label" : "Universitätsbibliothek Koblenz",
+      "type" : [ "Collection" ]
+    } ],
+    "id" : "http://lobid.org/items/99376424186306441:DE-Kob7:5363159820008057#!"
+  } ],
+  "sameAs" : [ {
+    "id" : "https://hub.culturegraph.org/resource/(DE-605)99376424186306441",
+    "label" : "Culturegraph-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1196283329",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "http://worldcat.org/oclc/1193112254",
+    "label" : "OCLC-Ressource"
+  }, {
+    "id" : "https://doi.org/10.1515/9780823289349",
+    "label" : "DOI-Link"
+  } ],
+  "fulltextOnline" : [ {
+    "id" : "https://doi.org/10.1515/9780823289349",
+    "label" : "DOI-Link"
+  } ],
+  "related" : [ {
+    "isbn" : [ "9780823289349", "0823289346" ]
+  }, {
+    "isbn" : [ "9780823289325", "082328932X" ]
+  } ],
+  "inCollection" : [ {
+    "id" : "https://nrw.digibib.net/search/hbzvk/",
+    "label" : "DigiBib hbz Verbundkatalog",
+    "type" : [ "Collection" ]
+  } ],
+  "language" : [ {
+    "id" : "http://id.loc.gov/vocabulary/iso639-2/eng",
+    "label" : "Englisch"
+  } ],
+  "extent" : "1 online resource (145 pages) : illustrations",
+  "abstract" : [ "A vivid, imaginative response to the sensual and erotic in postwar American photography, with attention to the beauty of the nude, both male and female. When photographer Coda Gray befriends a family with a special interest in a young boy, the motivation behind his special attention is difficult to grasp, \"like water slipping through our fingers.\" Can a man innocently love a boy who is not his own? Using fiction to reveal the truths about families, communities, art objects, love, and mourning, Like a Lake tells the story of ten-year-old Nico, who lives with his father (an Italian- American architect) and his mother (a Japanese-American sculptor who learned how to draw while interned during World War II). Set in the 1960s, this is a story of aesthetic perfection waiting to be broken. Nico's midcentury modern house, with its Italian pottery jars along the outside and its interior lit by Japanese lanterns. The elephant-hide gray, fiberglass-reinforced plastic 1951 Eames rocking chair, with metal legs and birch runners. Clam consomme with kombu, giant kelp, yuzu rind, and a little fennel--in each bowl, two clams opened like a pair of butterflies, symbols of the happy couple. Nico's boyish delight in developing photographs under the red safety light of Coda's \"Floating Zendo\"-- the darkroom boat that he keeps on Lake Tahoe. The lives of Nico, his parents, and Coda embody northern California's postwar landscape, giving way to fissures of alternative lifestyles and poetic visions. Author Carol Mavor addresses the sensuality and complexity of a son's love for his mother and that mother's own erotic response to it. The relationship between the mother and son is paralleled by what it means for a boy to be a model for a male photographer and to be his muse. Just as water can freeze into snow and ice, melt back into water, and steam, love takes on new forms with shifts of atmosphere. Like a Lake's haunting images and sensations stay with the reader." ],
+  "bibliographicLevel" : {
+    "label" : "Monograph/Item",
+    "id" : "https://www.loc.gov/marc/bibliographic/bdleader.html#Monograph_Item"
+  },
+  "responsibilityStatement" : [ "Carol Mavor." ],
+  "contribution" : [ {
+    "agent" : {
+      "label" : "Mavor, Carol",
+      "type" : [ "Person" ],
+      "dateOfBirth" : "1957"
+    },
+    "role" : {
+      "id" : "http://id.loc.gov/vocabulary/relators/aut",
+      "label" : "Autor/in"
+    },
+    "type" : [ "Contribution" ]
+  } ]
+}

--- a/src/test/resources/alma-fix/99376424186306441.json
+++ b/src/test/resources/alma-fix/99376424186306441.json
@@ -25,7 +25,6 @@
   } ],
   "manufacture" : [ {
     "dateStatement" : "0000",
-    "startDate" : "0000",
     "type" : [ "Event" ],
     "location" : [ "Baltimore, Md." ],
     "manufacturedBy" : [ "Project MUSE" ]

--- a/src/test/resources/alma-fix/99376424186306441.xml
+++ b/src/test/resources/alma-fix/99376424186306441.xml
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record>
+  <leader>06499cam a22008054a 4500</leader>
+  <controlfield tag="001">99376424186306441</controlfield>
+  <controlfield tag="005">20260720134353.0</controlfield>
+  <controlfield tag="006">m     o  d        </controlfield>
+  <controlfield tag="007">cr||||||||nn|n</controlfield>
+  <controlfield tag="008">200918s2020    nyu     o      00 0 eng d</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9780823289349</subfield>
+  </datafield>
+  <datafield tag="024" ind1="7" ind2=" ">
+    <subfield code="a">10.1515/9780823289349</subfield>
+    <subfield code="2">doi</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(CKB)5590000000000219</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1196283329</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MdBmJHUP)muse85857</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-B1597)571327</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(DE-B1597)9780823289349</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(OCoLC)1193112254</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(MiAaPQ)EBC6320636</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(Au-PeEL)EBL6320636</subfield>
+  </datafield>
+  <datafield tag="035" ind1=" " ind2=" ">
+    <subfield code="a">(EXLCZ)995590000000000219</subfield>
+  </datafield>
+  <datafield tag="040" ind1=" " ind2=" ">
+    <subfield code="a">MdBmJHUP</subfield>
+    <subfield code="c">MdBmJHUP</subfield>
+  </datafield>
+  <datafield tag="044" ind1=" " ind2=" ">
+    <subfield code="a">nyu</subfield>
+    <subfield code="c">US-NY</subfield>
+  </datafield>
+  <datafield tag="050" ind1=" " ind2="4">
+    <subfield code="a">PS3613.A886</subfield>
+    <subfield code="b">L555 2020</subfield>
+  </datafield>
+  <datafield tag="072" ind1=" " ind2="7">
+    <subfield code="a">PHO005000</subfield>
+    <subfield code="2">bisacsh</subfield>
+  </datafield>
+  <datafield tag="082" ind1="0" ind2="4">
+    <subfield code="a">813/.6</subfield>
+    <subfield code="2">23</subfield>
+  </datafield>
+  <datafield tag="082" ind1=" " ind2=" ">
+    <subfield code="a">813.6</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Mavor, Carol,</subfield>
+    <subfield code="d">1957-</subfield>
+    <subfield code="e">author.</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Like a Lake</subfield>
+    <subfield code="b">A Story of Uneasy Love and Photography /</subfield>
+    <subfield code="c">Carol Mavor.</subfield>
+  </datafield>
+  <datafield tag="250" ind1=" " ind2=" ">
+    <subfield code="a">First edition.</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">Baltimore, Maryland :</subfield>
+    <subfield code="b">Project Muse,</subfield>
+    <subfield code="c">2020</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="3">
+    <subfield code="a">Baltimore, Md. :</subfield>
+    <subfield code="b">Project MUSE, </subfield>
+    <subfield code="c">0000</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="4">
+    <subfield code="c">©2020</subfield>
+  </datafield>
+  <datafield tag="300" ind1=" " ind2=" ">
+    <subfield code="a">1 online resource (145 pages) : </subfield>
+    <subfield code="b">illustrations</subfield>
+  </datafield>
+  <datafield tag="336" ind1=" " ind2=" ">
+    <subfield code="a">text</subfield>
+    <subfield code="b">txt</subfield>
+    <subfield code="2">rdacontent</subfield>
+  </datafield>
+  <datafield tag="337" ind1=" " ind2=" ">
+    <subfield code="a">computer</subfield>
+    <subfield code="b">c</subfield>
+    <subfield code="2">rdamedia</subfield>
+  </datafield>
+  <datafield tag="338" ind1=" " ind2=" ">
+    <subfield code="a">online resource</subfield>
+    <subfield code="b">cr</subfield>
+    <subfield code="2">rdacarrier</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Epub Accessibility Specification 1.1</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Table of contents navigation</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Index navigation</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Single logical reading order</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Short alternative textual descriptions</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Full alternative textual descriptions</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Visualised data also available as non-graphical data</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Accessible math content as MathML</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Synchronised pre-recorded audio</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Language tagging provided</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Use of high contrast between text and background color</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Next / Previous structural navigation</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">ARIA roles provided</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Landmark navigation</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Appearance of all textual content can be modified</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Use of ultra-high contrast between text foreground and background</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">Link purposes clear</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">All non-decorative content supports reading without sight</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">WCAG v2.2</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">WCAG level A</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="341" ind1="0" ind2=" ">
+    <subfield code="b">WCAG level AA</subfield>
+    <subfield code="2">onix</subfield>
+  </datafield>
+  <datafield tag="504" ind1=" " ind2=" ">
+    <subfield code="a">Includes bibliographical references.</subfield>
+  </datafield>
+  <datafield tag="505" ind1="0" ind2="0">
+    <subfield code="t">Frontmatter -- </subfield>
+    <subfield code="t">Contents -- </subfield>
+    <subfield code="t">Millions of Years Ago -- </subfield>
+    <subfield code="t">My Nico -- </subfield>
+    <subfield code="t">Unfolding a Flood -- </subfield>
+    <subfield code="t">Turning the Key -- </subfield>
+    <subfield code="t">The Memory of Lake Tahoe -- </subfield>
+    <subfield code="t">My Mother’s Eyes -- </subfield>
+    <subfield code="t">My Mother -- </subfield>
+    <subfield code="t">Coda -- </subfield>
+    <subfield code="t">By Chance -- </subfield>
+    <subfield code="t">When Bamboo Shoots Poke Their Heads out of the Earth -- </subfield>
+    <subfield code="t">Blue Rambler -- </subfield>
+    <subfield code="t">Tender Buttons -- </subfield>
+    <subfield code="t">Waiting -- </subfield>
+    <subfield code="t">Refusing to be Plucked -- </subfield>
+    <subfield code="t">We Want Roses -- </subfield>
+    <subfield code="t">She Sleeps with Him Every Night -- </subfield>
+    <subfield code="t">She-Wolf Made of Rock -- </subfield>
+    <subfield code="t">Blue Ticket -- </subfield>
+    <subfield code="t">Learning to Swim -- </subfield>
+    <subfield code="t">Floating Studio, Floating Zendo -- </subfield>
+    <subfield code="t">Fannette Island -- </subfield>
+    <subfield code="t">Floating Zendos and Mentorgartens -- </subfield>
+    <subfield code="t">I Learned about Snowflakes -- </subfield>
+    <subfield code="t">I Learned about the Birds of Lake Tahoe -- </subfield>
+    <subfield code="t">Summer Snow Cake -- </subfield>
+    <subfield code="t">Love or Affection -- </subfield>
+    <subfield code="t">Mary’s Dream -- </subfield>
+    <subfield code="t">Each Other’s Pockets -- </subfield>
+    <subfield code="t">Black Cloth -- </subfield>
+    <subfield code="t">Brown Kimono -- </subfield>
+    <subfield code="t">Something Broke -- </subfield>
+    <subfield code="t">The Voice of the Lake -- </subfield>
+    <subfield code="t">Moon Writing -- </subfield>
+    <subfield code="t">Artichoke -- </subfield>
+    <subfield code="t">No Name for Him -- </subfield>
+    <subfield code="t">What’s in a Name? -- </subfield>
+    <subfield code="t">Like Piles of Laundry? -- </subfield>
+    <subfield code="t">Frozen Pond -- </subfield>
+    <subfield code="t">Coda’s Dream -- </subfield>
+    <subfield code="t">Like Mother and Son -- </subfield>
+    <subfield code="t">Fifteen Good Prints -- </subfield>
+    <subfield code="t">Glass Moon -- </subfield>
+    <subfield code="t">Tsukimi Udon (Moon Noodles) -- </subfield>
+    <subfield code="t">Soaring -- </subfield>
+    <subfield code="t">Walking Underwater -- </subfield>
+    <subfield code="t">Open My Heart -- </subfield>
+    <subfield code="t">Like Rice on Chopsticks -- </subfield>
+    <subfield code="t">Like a Sequence of Poems -- </subfield>
+    <subfield code="t">Waiting, Still -- </subfield>
+    <subfield code="t">Morpheus -- </subfield>
+    <subfield code="t">Blue Marble -- </subfield>
+    <subfield code="t">Something Like Love -- </subfield>
+    <subfield code="t">Afterword (Afterward): Like the Navel of My Dream of N -- </subfield>
+    <subfield code="t">Acknowledgments -- </subfield>
+    <subfield code="t">Illustrations -- </subfield>
+    <subfield code="t">Notes</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">A vivid, imaginative response to the sensual and erotic in postwar American photography, with attention to the beauty of the nude, both male and female. When photographer Coda Gray befriends a family with a special interest in a young boy, the motivation behind his special attention is difficult to grasp, "like water slipping through our fingers." Can a man innocently love a boy who is not his own? Using fiction to reveal the truths about families, communities, art objects, love, and mourning, Like a Lake tells the story of ten-year-old Nico, who lives with his father (an Italian- American architect) and his mother (a Japanese-American sculptor who learned how to draw while interned during World War II). Set in the 1960s, this is a story of aesthetic perfection waiting to be broken. Nico's midcentury modern house, with its Italian pottery jars along the outside and its interior lit by Japanese lanterns. The elephant-hide gray, fiberglass-reinforced plastic 1951 Eames rocking chair, with metal legs and birch runners. Clam consomme with kombu, giant kelp, yuzu rind, and a little fennel--in each bowl, two clams opened like a pair of butterflies, symbols of the happy couple. Nico's boyish delight in developing photographs under the red safety light of Coda's "Floating Zendo"-- the darkroom boat that he keeps on Lake Tahoe. The lives of Nico, his parents, and Coda embody northern California's postwar landscape, giving way to fissures of alternative lifestyles and poetic visions. Author Carol Mavor addresses the sensuality and complexity of a son's love for his mother and that mother's own erotic response to it. The relationship between the mother and son is paralleled by what it means for a boy to be a model for a male photographer and to be his muse. Just as water can freeze into snow and ice, melt back into water, and steam, love takes on new forms with shifts of atmosphere. Like a Lake's haunting images and sensations stay with the reader.</subfield>
+  </datafield>
+  <datafield tag="532" ind1="8" ind2=" ">
+    <subfield code="a">Accessibility summary: This product includes accessibility features including a table of contents, navigable semantic structure, text-to-speech, alt text for images, and adjustable fonts. It satisfies the EPUB Accessibility 1.1 specification and the World Wide Web Consorti</subfield>
+  </datafield>
+  <datafield tag="588" ind1=" " ind2=" ">
+    <subfield code="a">Description based on print version record.</subfield>
+  </datafield>
+  <datafield tag="588" ind1=" " ind2=" ">
+    <subfield code="a">Description based on publisher supplied metadata and other sources.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Photography</subfield>
+    <subfield code="y">20th century</subfield>
+    <subfield code="v">Fiction.</subfield>
+  </datafield>
+  <datafield tag="650" ind1=" " ind2="0">
+    <subfield code="a">Mothers and sons</subfield>
+    <subfield code="v">Fiction.</subfield>
+  </datafield>
+  <datafield tag="655" ind1=" " ind2="4">
+    <subfield code="a">Electronic books. </subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">9780823289349</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">0823289346</subfield>
+  </datafield>
+  <datafield tag="776" ind1="0" ind2="8">
+    <subfield code="z">9780823289325</subfield>
+  </datafield>
+  <datafield tag="906" ind1=" " ind2=" ">
+    <subfield code="a">BOOK</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_NETWORK</subfield>
+    <subfield code="i">99376424186306441</subfield>
+    <subfield code="n">HBZ Network</subfield>
+  </datafield>
+  <datafield tag="MBD" ind1=" " ind2=" ">
+    <subfield code="M">49HBZ_UKO</subfield>
+    <subfield code="i">9910217893208057</subfield>
+    <subfield code="n">Universität Koblenz</subfield>
+  </datafield>
+  <datafield tag="MNG" ind1=" " ind2=" ">
+    <subfield code="c">system</subfield>
+    <subfield code="f">EBC</subfield>
+    <subfield code="i">marc21</subfield>
+    <subfield code="l">94</subfield>
+    <subfield code="e">false</subfield>
+    <subfield code="d">2026-07-21 01:10:05 Europe/Berlin</subfield>
+    <subfield code="g">995590000000000219</subfield>
+    <subfield code="a">CKB</subfield>
+    <subfield code="b">2026-01-05 12:56:36 Europe/Berlin</subfield>
+  </datafield>
+  <datafield tag="POR" ind1=" " ind2=" ">
+    <subfield code="j">JSTOR</subfield>
+    <subfield code="x">System</subfield>
+    <subfield code="a">5363159820008057</subfield>
+    <subfield code="M">49HBZ_UKO</subfield>
+    <subfield code="p">6162930390008057</subfield>
+    <subfield code="q">EBA JSTOR 2026</subfield>
+    <subfield code="c">param</subfield>
+    <subfield code="o">615400000000000569</subfield>
+    <subfield code="y">2026-01-05 12:51:41 Europe/Berlin</subfield>
+    <subfield code="w">2026-01-05 12:51:27 Europe/Berlin</subfield>
+    <subfield code="D">https://eu04.alma.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;portfolio_pid=5363159820008057&amp;Force_direct=true</subfield>
+    <subfield code="v">System</subfield>
+    <subfield code="z">2026-01-05 11:51:27</subfield>
+    <subfield code="i">false</subfield>
+    <subfield code="S">6262930380008057</subfield>
+    <subfield code="d">https://hbz-network.userservices.exlibrisgroup.com/view/uresolver/49HBZ_NETWORK/openurl?u.ignore_date_coverage=true&amp;rft.mms_id=9910217893208057</subfield>
+    <subfield code="b">Available</subfield>
+    <subfield code="f">BOOK</subfield>
+    <subfield code="8">5363159820008057</subfield>
+  </datafield>
+</record>

--- a/web/test/tests/IndexIntegrationTest.java
+++ b/web/test/tests/IndexIntegrationTest.java
@@ -33,7 +33,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 	public static Collection<Object[]> data() {
 		// @formatter:off
 		return queries(new Object[][] {
-			{ "title:der", /*->*/ 26 },
+			{ "title:der", /*->*/ 27 },
 			{ "title:Westfalen", /*->*/ 8 },
 			{ "contribution.agent.label:Westfalen", /*->*/ 5 },
 			{ "contribution.agent.label:Westfälen", /*->*/ 5 },
@@ -63,7 +63,7 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "spatial.label:Westfalen", /*->*/ 10 },
 			{ "spatial.label:Westfälen", /*->*/ 10 },
 			{ "subject.componentList.id:1113670827", /*->*/ 0 },
-			{ "subject.componentList.type:PlaceOrGeographicName", /*->*/ 35 },
+			{ "subject.componentList.type:PlaceOrGeographicName", /*->*/ 36 },
 			{ "publication.location:Berlin", /*->*/ 17 },
 			{ "subject.gndIdentifier:4040795-0", /*->*/ 1 },
 			{ "subject.notation:914.3", /*->*/ 8 },
@@ -73,8 +73,8 @@ public class IndexIntegrationTest extends LocalIndexSetup {
 			{ "publication.location:Koln", /*->*/ 7 },
 			{ "publication.startDate:1993", /*->*/ 4 },
 			{ "publication.location:Berlin AND publication.startDate:1993", /*->*/ 1 },
-			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 212 },
-			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 239 },
+			{ "inCollection.id:\"http\\://lobid.org/organisations/DE-655#\\!\"", /*->*/ 216 },
+			{ "inCollection.id:\"https\\://nrw.digibib.net/search/hbzvk/\"", /*->*/ 245 },
 			{ "inCollection.id:NWBib", /*->*/ 0 },
 			{ "publication.publishedBy:Quedenfeldt", /*->*/ 2 },
 			{ "publication.publishedBy:Quedenfeld", /*->*/ 2 },


### PR DESCRIPTION
The different tests represent different scenarios where 0000 can be mapped to `publication.startDate`, `publication.endDate`, `manufacture.startDate`. The adjustments in the Fix skip all `0000` since they are placeholder or cataloguing errors.

Resolves #2395 