### PR TITLE
Use Java 21 and bump mf-core dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
       MAVEN_OPTS: "-Xmx768M"
     steps:
     - uses: actions/checkout@v7
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: 17
+        java-version: 21
         distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v6
@@ -24,13 +24,13 @@ jobs:
         cd ..
         git clone https://github.com/metafacture/metafacture-core.git
         cd metafacture-core
-        git checkout -b f2cf79da098258a2bc034da6bf7178f704fb5db4
-        git reset --hard f2cf79da098258a2bc034da6bf7178f704fb5db4
+        git checkout -b ddf031d1a5c792da16fc632354bded3bdcdda611
+        git reset --hard ddf031d1a5c792da16fc632354bded3bdcdda611
         ./gradlew publishToMavenLocal
         cd -
     - name: Build with Maven
       run: |
-        mvn install
+        mvn clean install
         mvn editorconfig:check
     - name: Install the JSON Schema CLI
       uses: sourcemeta/jsonschema@v15.11.0
@@ -52,4 +52,6 @@ jobs:
     - name: Build and Test with play
       run: |
         cd web
-        sbt  --java-home $JAVA_HOME test
+        export JAVA_OPTS="--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
+        sbt -Djava.security.manager=allow clean
+        sbt -Djava.security.manager=allow test

--- a/README.md
+++ b/README.md
@@ -24,13 +24,22 @@ see <http://hbz.github.io/#lobid>.
 
 ### Prerequisites:
 
-- Java 11, Maven 3; verify with `mvn -version`
-- sbt 1.8.2 or higher should work; verify with `sbt --version`
-- A working installation of [metafacture-core standalone application](https://github.com/metafacture/metafacture-core?tab=readme-ov-file#metafacture-as-a-stand-alone-application)
+- Java 21, Maven 3; verify with `mvn -version`
+- sbt 0.13.18 or higher should work; verify with `sbt --version`
 
 Create and change into a folder where you want to store the projects:
 
 - `mkdir ~/git ; cd ~/git`
+
+Create local Metafacture SNAPSHOT of commit ddf031d1a5c792da16fc632354bded3bdcdda611 and publish to local maven:
+
+- `cd ..`
+- `git clone https://github.com/metafacture/metafacture-core.git`
+- `cd metafacture-core`
+- `git checkout -b ddf031d1a5c792da16fc632354bded3bdcdda611`
+- `git reset --hard ddf031d1a5c792da16fc632354bded3bdcdda611`
+- `./gradlew publishToMavenLocal`
+- `cd -`
 
 Build lobid-resources:
 
@@ -41,9 +50,10 @@ Build lobid-resources:
 Build the web application:
 
 - `cd web`
-- `sbt clean`
-- `sbt stage`
-- `./target/universal/stage/bin/lobid-resources-web -no-version-check`
+- `export JAVA_OPTS="--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"`
+- `sbt -Djava.security.manager=allow clean`
+- `sbt -Djava.security.manager=allow stage`
+- `./target/universal/stage/bin/lobid-resources-web -Djava.security.manager=allow -no-version-check`
 
 See the `.github/workflows/build.yml` file for details on the CI config
 used by Github Actions.
@@ -51,7 +61,10 @@ used by Github Actions.
 To run the tests:
 
 - `cd web`
-- `sbt test`
+- `export JAVA_OPTS="--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"`
+- `sbt -Djava.security.manager=allow clean`
+- `sbt -Djava.security.manager=allow stage`
+- `sbt -Djava.security.manager=allow test`
 
 ## Eclipse setup
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lobid</groupId>
     <artifactId>lobid-resources</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <target.jdk>11</target.jdk>
+        <target.jdk>21</target.jdk>
         <junit.version>4.8.2</junit.version>
         <logback.version>1.3.14</logback.version>
     </properties>
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-io</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-files</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-json</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -40,72 +40,72 @@
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-biblio</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formeta</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-monitoring</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-strings</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-formatting</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-elasticsearch</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-csv</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-flowcontrol</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-plumbing</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metamorph-test</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-xml</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafacture-mangling</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.metafacture</groupId>
             <artifactId>metafix</artifactId>
-            <version>f2cf79da098258a2bc034da6bf7178f704fb5db4-SNAPSHOT</version>
+            <version>ddf031d1a5c792da16fc632354bded3bdcdda611-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -1,6 +1,6 @@
 name := "lobid-resources-web"
 
-version := "1.0.2-SNAPSHOT"
+version := "2.0.0-SNAPSHOT"
 
 scalaVersion := "2.11.12"
 
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.google.gdata" % "core" % "1.47.1" exclude ("com.google.guava", "guava"),
   "org.easytesting" % "fest-assert" % "1.4" %Test,
   "org.xbib.elasticsearch.plugin" % "elasticsearch-plugin-bundle" % "5.4.1.0",
-  "org.lobid" % "lobid-resources" % "1.0.2-SNAPSHOT" changing()
+  "org.lobid" % "lobid-resources" % "2.0.0-SNAPSHOT" changing()
 )
 
 dependencyOverrides += "com.google.inject" % "guice" % "6.0.0"
@@ -27,9 +27,9 @@ resolvers += "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-javacOptions ++= Seq("-source", "11", "-target", "11")
-javaOptions in (Test,run) += "--add-opens=java.base/java.lang=ALL-UNNAMED"
-javaOptions in (Test,run) += "--add-opens=java.base/java.util=ALL-UNNAMED"
+javacOptions ++= Seq("-source", "21", "-target", "21")
+javaOptions in (Test,run) += "--add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
+javaOptions in (Test,run) += "--add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
 
 import com.typesafe.sbteclipse.core.EclipsePlugin.EclipseKeys
 

--- a/web/monit_restart.sh
+++ b/web/monit_restart.sh
@@ -26,8 +26,9 @@ HOME="/home/sol"
 
 # it is important to set the proper locale
 . $HOME/.locale
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64/
 JAVA_OPTS=$(echo "$JAVA_OPTS" |sed 's#,#\ #g')
+JAVA_OPTS="$JAVA_OPTS --add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.file=ALL-UNNAMED"
 
 cd $HOME/git/$REPO
 ETL_TOKEN=$(cat scripts/.secrets/ETL_TOKEN)
@@ -45,9 +46,9 @@ case $ACTION in
           rm target/universal/stage/RUNNING_PID
        fi
        export JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError -DpreferIPv4Stack"
-       sbt  -Djava.security.manager=allow clean
-       sbt --java-home $JAVA_HOME stage
-       ./target/universal/stage/bin/lobid-resources-web -Dhttp.port=$PORT -no-version-check > monit_start.log &
+       sbt -Djava.security.manager=allow clean
+       sbt -Djava.security.manager=allow stage
+       ./target/universal/stage/bin/lobid-resources-web -Djava.security.manager=allow -Dhttp.port=$PORT -no-version-check > monit_start.log &
        if [ -n "$DO_ETL_UPDATE" -a $(tail -n100 logs/etl.log  |grep -c "Finishing indexing of ES index 'resources-alma-fix") -eq 0 ]; then
           echo "Automatical updates-ETL triggered and last entries were not ok, thus starting ETL. Sleep 100s before starting ETL ..." >> monit_start.log
           sleep 100


### PR DESCRIPTION
Use Java 21.
Also, use a metafacture-core build based on https://github.com/metafacture/metafacture-core/issues/765 (which uses Java 21).
 Resolves #2397.
Note to self: Don't forget to build the metafacture-core SNAPSHOT on all server. See `.github/workflows/build.yml` to set the proper commit hash (it's ddf031d1a5c792da16fc632354bded3bdcdda611). Deliberately not using a branch name as the branch may be deleted at some point in future while the commit hash is stable (as we don't force push to master).