### PR TITLE
Update jsonschema cli version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         mvn clean install
         mvn editorconfig:check
     - name: Install the JSON Schema CLI
-      uses: sourcemeta/jsonschema@v15.11.0
+      uses: sourcemeta/jsonschema@v16.10.0
     - name: Validate Test Json Output with jsonschema
       run: |
         cd src/test/resources/

--- a/src/test/resources/validateJsonTestFiles.sh
+++ b/src/test/resources/validateJsonTestFiles.sh
@@ -11,7 +11,7 @@ DIRECTORY_OF_JSON_TO_VALIDATE="alma-fix/"
 
 for version in "draft"; do
 	echo "Testing version: $version"
-	jsonschema validate "schemas/resource.json" "${DIRECTORY_OF_JSON_TO_VALIDATE}" 2>&1
+	jsonschema validate --verbose "schemas/resource.json" "${DIRECTORY_OF_JSON_TO_VALIDATE}" 2>&1
 done
 
 if [ $? -eq 0 ]


### PR DESCRIPTION
Updated the jsonschema cli validation version and process.
Now states if data is okay as ajv did: https://github.com/hbz/lobid-resources/actions/runs/34198024979/job/101970057350?pr=2402#step:8:13

Related to: https://github.com/sourcemeta/jsonschema/issues/782#issuecomment-5575344939